### PR TITLE
Adding Artisan Commands for Generating Controllers, Middlewares, and Models

### DIFF
--- a/database/console/model_make_command.go
+++ b/database/console/model_make_command.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/gookit/color"
+
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/console/command"
 	"github.com/goravel/framework/support/file"
 	"github.com/goravel/framework/support/str"
-
-	"github.com/gookit/color"
 )
 
 type ModelMakeCommand struct {

--- a/database/console/model_make_command.go
+++ b/database/console/model_make_command.go
@@ -1,0 +1,65 @@
+package console
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/goravel/framework/contracts/console"
+	"github.com/goravel/framework/contracts/console/command"
+	"github.com/goravel/framework/support/file"
+	"github.com/goravel/framework/support/str"
+
+	"github.com/gookit/color"
+)
+
+type ModelMakeCommand struct {
+}
+
+// Signature The name and signature of the console command.
+func (receiver *ModelMakeCommand) Signature() string {
+	return "make:model"
+}
+
+// Description The console command description.
+func (receiver *ModelMakeCommand) Description() string {
+	return "Create a new model class"
+}
+
+// Extend The console command extend.
+func (receiver *ModelMakeCommand) Extend() command.Extend {
+	return command.Extend{
+		Category: "make",
+	}
+}
+
+// Handle Execute the console command.
+func (receiver *ModelMakeCommand) Handle(ctx console.Context) error {
+	name := ctx.Argument(0)
+	if name == "" {
+		return errors.New("Not enough arguments (missing: name) ")
+	}
+
+	file.Create(receiver.getPath(name), receiver.populateStub(receiver.getStub(), name))
+	color.Greenln("Model created successfully")
+
+	return nil
+}
+
+func (receiver *ModelMakeCommand) getStub() string {
+	return Stubs{}.Model()
+}
+
+// populateStub Populate the place-holders in the command stub.
+func (receiver *ModelMakeCommand) populateStub(stub string, name string) string {
+	stub = strings.ReplaceAll(stub, "DummyModel", str.Case2Camel(name))
+
+	return stub
+}
+
+// getPath Get the full path to the command.
+func (receiver *ModelMakeCommand) getPath(name string) string {
+	pwd, _ := os.Getwd()
+
+	return pwd + "/app/models/" + str.Camel2Case(name) + ".go"
+}

--- a/database/console/model_make_command_test.go
+++ b/database/console/model_make_command_test.go
@@ -3,10 +3,10 @@ package console
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	consolemocks "github.com/goravel/framework/contracts/console/mocks"
 	"github.com/goravel/framework/support/file"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestModelMakeCommand(t *testing.T) {

--- a/database/console/model_make_command_test.go
+++ b/database/console/model_make_command_test.go
@@ -1,0 +1,24 @@
+package console
+
+import (
+	"testing"
+
+	consolemocks "github.com/goravel/framework/contracts/console/mocks"
+	"github.com/goravel/framework/support/file"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModelMakeCommand(t *testing.T) {
+	modelMakeCommand := &ModelMakeCommand{}
+	mockContext := &consolemocks.Context{}
+	mockContext.On("Argument", 0).Return("").Once()
+	err := modelMakeCommand.Handle(mockContext)
+	assert.EqualError(t, err, "Not enough arguments (missing: name) ")
+
+	mockContext.On("Argument", 0).Return("User").Once()
+	err = modelMakeCommand.Handle(mockContext)
+	assert.Nil(t, err)
+	assert.True(t, file.Exists("app/models/user.go"))
+	assert.True(t, file.Remove("app"))
+}

--- a/database/console/stubs.go
+++ b/database/console/stubs.go
@@ -6,13 +6,12 @@ type Stubs struct {
 func (r Stubs) Model() string {
 	return `package models
 
-	import (
-		"github.com/goravel/framework/database/orm"
-	)
-	
-	type DummyModel struct {
-		orm.Model
-		Id   string
-	}
+import (
+	"github.com/goravel/framework/database/orm"
+)
+
+type DummyModel struct {
+	orm.Model
+}
 `
 }

--- a/database/console/stubs.go
+++ b/database/console/stubs.go
@@ -1,0 +1,18 @@
+package console
+
+type Stubs struct {
+}
+
+func (r Stubs) Model() string {
+	return `package models
+
+	import (
+		"github.com/goravel/framework/database/orm"
+	)
+	
+	type DummyModel struct {
+		orm.Model
+		Id   string
+	}
+`
+}

--- a/database/service_provider.go
+++ b/database/service_provider.go
@@ -24,5 +24,6 @@ func (database *ServiceProvider) registerCommands() {
 		&console.MigrateMakeCommand{},
 		&console.MigrateCommand{},
 		&console.MigrateRollbackCommand{},
+		&console.ModelMakeCommand{},
 	})
 }

--- a/http/console/controller_make_command.go
+++ b/http/console/controller_make_command.go
@@ -1,0 +1,65 @@
+package console
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/goravel/framework/contracts/console"
+	"github.com/goravel/framework/contracts/console/command"
+	"github.com/goravel/framework/support/file"
+	"github.com/goravel/framework/support/str"
+
+	"github.com/gookit/color"
+)
+
+type ControllerMakeCommand struct {
+}
+
+// Signature The name and signature of the console command.
+func (receiver *ControllerMakeCommand) Signature() string {
+	return "make:controller"
+}
+
+// Description The console command description.
+func (receiver *ControllerMakeCommand) Description() string {
+	return "Create a new controller class"
+}
+
+// Extend The console command extend.
+func (receiver *ControllerMakeCommand) Extend() command.Extend {
+	return command.Extend{
+		Category: "make",
+	}
+}
+
+// Handle Execute the console command.
+func (receiver *ControllerMakeCommand) Handle(ctx console.Context) error {
+	name := ctx.Argument(0)
+	if name == "" {
+		return errors.New("Not enough arguments (missing: name) ")
+	}
+
+	file.Create(receiver.getPath(name), receiver.populateStub(receiver.getStub(), name))
+	color.Greenln("Controller created successfully")
+
+	return nil
+}
+
+func (receiver *ControllerMakeCommand) getStub() string {
+	return Stubs{}.Controller()
+}
+
+// populateStub Populate the place-holders in the command stub.
+func (receiver *ControllerMakeCommand) populateStub(stub string, name string) string {
+	stub = strings.ReplaceAll(stub, "DummyController", str.Case2Camel(name))
+
+	return stub
+}
+
+// getPath Get the full path to the command.
+func (receiver *ControllerMakeCommand) getPath(name string) string {
+	pwd, _ := os.Getwd()
+
+	return pwd + "/app/http/controllers/" + str.Camel2Case(name) + ".go"
+}

--- a/http/console/controller_make_command.go
+++ b/http/console/controller_make_command.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/gookit/color"
+
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/console/command"
 	"github.com/goravel/framework/support/file"
 	"github.com/goravel/framework/support/str"
-
-	"github.com/gookit/color"
 )
 
 type ControllerMakeCommand struct {

--- a/http/console/controller_make_command_test.go
+++ b/http/console/controller_make_command_test.go
@@ -3,10 +3,10 @@ package console
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	consolemocks "github.com/goravel/framework/contracts/console/mocks"
 	"github.com/goravel/framework/support/file"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestControllerMakeCommand(t *testing.T) {

--- a/http/console/controller_make_command_test.go
+++ b/http/console/controller_make_command_test.go
@@ -1,0 +1,24 @@
+package console
+
+import (
+	"testing"
+
+	consolemocks "github.com/goravel/framework/contracts/console/mocks"
+	"github.com/goravel/framework/support/file"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestControllerMakeCommand(t *testing.T) {
+	controllerMakeCommand := &ControllerMakeCommand{}
+	mockContext := &consolemocks.Context{}
+	mockContext.On("Argument", 0).Return("").Once()
+	err := controllerMakeCommand.Handle(mockContext)
+	assert.EqualError(t, err, "Not enough arguments (missing: name) ")
+
+	mockContext.On("Argument", 0).Return("UsersController").Once()
+	err = controllerMakeCommand.Handle(mockContext)
+	assert.Nil(t, err)
+	assert.True(t, file.Exists("app/http/controllers/users_controller.go"))
+	assert.True(t, file.Remove("app"))
+}

--- a/http/console/middleware_make_command.go
+++ b/http/console/middleware_make_command.go
@@ -1,0 +1,65 @@
+package console
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/goravel/framework/contracts/console"
+	"github.com/goravel/framework/contracts/console/command"
+	"github.com/goravel/framework/support/file"
+	"github.com/goravel/framework/support/str"
+
+	"github.com/gookit/color"
+)
+
+type MiddlewareMakeCommand struct {
+}
+
+// Signature The name and signature of the console command.
+func (receiver *MiddlewareMakeCommand) Signature() string {
+	return "make:middleware"
+}
+
+// Description The console command description.
+func (receiver *MiddlewareMakeCommand) Description() string {
+	return "Create a new middleware class"
+}
+
+// Extend The console command extend.
+func (receiver *MiddlewareMakeCommand) Extend() command.Extend {
+	return command.Extend{
+		Category: "make",
+	}
+}
+
+// Handle Execute the console command.
+func (receiver *MiddlewareMakeCommand) Handle(ctx console.Context) error {
+	name := ctx.Argument(0)
+	if name == "" {
+		return errors.New("Not enough arguments (missing: name) ")
+	}
+
+	file.Create(receiver.getPath(name), receiver.populateStub(receiver.getStub(), name))
+	color.Greenln("Middleware created successfully")
+
+	return nil
+}
+
+func (receiver *MiddlewareMakeCommand) getStub() string {
+	return Stubs{}.Middleware()
+}
+
+// populateStub Populate the place-holders in the command stub.
+func (receiver *MiddlewareMakeCommand) populateStub(stub string, name string) string {
+	stub = strings.ReplaceAll(stub, "DummyMiddleware", str.Case2Camel(name))
+
+	return stub
+}
+
+// getPath Get the full path to the command.
+func (receiver *MiddlewareMakeCommand) getPath(name string) string {
+	pwd, _ := os.Getwd()
+
+	return pwd + "/app/http/middlewares/" + str.Camel2Case(name) + ".go"
+}

--- a/http/console/middleware_make_command.go
+++ b/http/console/middleware_make_command.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/gookit/color"
+
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/console/command"
 	"github.com/goravel/framework/support/file"
 	"github.com/goravel/framework/support/str"
-
-	"github.com/gookit/color"
 )
 
 type MiddlewareMakeCommand struct {
@@ -61,5 +61,5 @@ func (receiver *MiddlewareMakeCommand) populateStub(stub string, name string) st
 func (receiver *MiddlewareMakeCommand) getPath(name string) string {
 	pwd, _ := os.Getwd()
 
-	return pwd + "/app/http/middlewares/" + str.Camel2Case(name) + ".go"
+	return pwd + "/app/http/middleware/" + str.Camel2Case(name) + ".go"
 }

--- a/http/console/middleware_make_command_test.go
+++ b/http/console/middleware_make_command_test.go
@@ -1,0 +1,24 @@
+package console
+
+import (
+	"testing"
+
+	consolemocks "github.com/goravel/framework/contracts/console/mocks"
+	"github.com/goravel/framework/support/file"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiddlewareMakeCommand(t *testing.T) {
+	middlewareMakeCommand := &MiddlewareMakeCommand{}
+	mockContext := &consolemocks.Context{}
+	mockContext.On("Argument", 0).Return("").Once()
+	err := middlewareMakeCommand.Handle(mockContext)
+	assert.EqualError(t, err, "Not enough arguments (missing: name) ")
+
+	mockContext.On("Argument", 0).Return("VerifyCsrfToken").Once()
+	err = middlewareMakeCommand.Handle(mockContext)
+	assert.Nil(t, err)
+	assert.True(t, file.Exists("app/http/middlewares/verify_csrf_token.go"))
+	assert.True(t, file.Remove("app"))
+}

--- a/http/console/middleware_make_command_test.go
+++ b/http/console/middleware_make_command_test.go
@@ -3,10 +3,10 @@ package console
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	consolemocks "github.com/goravel/framework/contracts/console/mocks"
 	"github.com/goravel/framework/support/file"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMiddlewareMakeCommand(t *testing.T) {
@@ -19,6 +19,6 @@ func TestMiddlewareMakeCommand(t *testing.T) {
 	mockContext.On("Argument", 0).Return("VerifyCsrfToken").Once()
 	err = middlewareMakeCommand.Handle(mockContext)
 	assert.Nil(t, err)
-	assert.True(t, file.Exists("app/http/middlewares/verify_csrf_token.go"))
+	assert.True(t, file.Exists("app/http/middleware/verify_csrf_token.go"))
 	assert.True(t, file.Remove("app"))
 }

--- a/http/console/stubs.go
+++ b/http/console/stubs.go
@@ -40,36 +40,36 @@ func (r *DummyRequest) PrepareForValidation(data validation.Data) {
 func (r Stubs) Controller() string {
 	return `package controllers
 
-	import (
-		"github.com/goravel/framework/contracts/http"
-	)
-	
-	type DummyController struct {
-		//Dependent services
+import (
+	"github.com/goravel/framework/contracts/http"
+)
+
+type DummyController struct {
+	//Dependent services
+}
+
+func NewDummyController() *DummyController {
+	return &DummyController{
+		//Inject services
 	}
-	
-	func NewDummyController() *DummyController {
-		return &DummyController{
-			//Inject services
-		}
-	}
-	
-	func (r *DummyController) Index(ctx http.Context) {
-	}	
+}
+
+func (r *DummyController) Index(ctx http.Context) {
+}	
 `
 }
 
 func (r Stubs) Middleware() string {
 	return `package middleware
 
-	import (
-		contractshttp "github.com/goravel/framework/contracts/http"
-	)
-	
-	func DummyMiddleware() contractshttp.Middleware {
-		return func(ctx contractshttp.Context) {
-			ctx.Request().Next()
-		}
+import (
+	contractshttp "github.com/goravel/framework/contracts/http"
+)
+
+func DummyMiddleware() contractshttp.Middleware {
+	return func(ctx contractshttp.Context) {
+		ctx.Request().Next()
 	}
+}
 `
 }

--- a/http/console/stubs.go
+++ b/http/console/stubs.go
@@ -36,3 +36,40 @@ func (r *DummyRequest) PrepareForValidation(data validation.Data) {
 }
 `
 }
+
+func (r Stubs) Controller() string {
+	return `package controllers
+
+	import (
+		"github.com/goravel/framework/contracts/http"
+	)
+	
+	type DummyController struct {
+		//Dependent services
+	}
+	
+	func NewDummyController() *DummyController {
+		return &DummyController{
+			//Inject services
+		}
+	}
+	
+	func (r *DummyController) Index(ctx http.Context) {
+	}	
+`
+}
+
+func (r Stubs) Middleware() string {
+	return `package middleware
+
+	import (
+		contractshttp "github.com/goravel/framework/contracts/http"
+	)
+	
+	func DummyMiddleware() contractshttp.Middleware {
+		return func(ctx contractshttp.Context) {
+			ctx.Request().Next()
+		}
+	}
+`
+}

--- a/http/service_provider.go
+++ b/http/service_provider.go
@@ -19,5 +19,7 @@ func (database *ServiceProvider) Boot() {
 func (database *ServiceProvider) registerCommands() {
 	facades.Artisan.Register([]consolecontract.Command{
 		&console.RequestMakeCommand{},
+		&console.ControllerMakeCommand{},
+		&console.MiddlewareMakeCommand{},
 	})
 }


### PR DESCRIPTION
I have implemented the following Artisan commands to simplify the development process:
- make:controller: generates a new controller with the specified name.
- make:middleware: generates a new middleware with the specified name.
- make:model: generates a new model with the specified name.