### PR TITLE
HTTP Throttle middleware

### DIFF
--- a/contracts/http/rate_limiter.go
+++ b/contracts/http/rate_limiter.go
@@ -1,0 +1,12 @@
+package http
+
+type RateLimiter interface {
+	For(name string, callback func(ctx Context) Limit)
+	ForWithLimits(name string, callback func(ctx Context) []Limit)
+	Limiter(name string) func(ctx Context) []Limit
+}
+
+type Limit interface {
+	By(key string) Limit
+	Response(func(ctx Context)) Limit
+}

--- a/facades/http.go
+++ b/facades/http.go
@@ -1,0 +1,7 @@
+package facades
+
+import (
+	"github.com/goravel/framework/contracts/http"
+)
+
+var RateLimiter http.RateLimiter

--- a/http/limit/limit.go
+++ b/http/limit/limit.go
@@ -1,0 +1,64 @@
+package limit
+
+import (
+	"net/http"
+
+	contractshttp "github.com/goravel/framework/contracts/http"
+)
+
+func PerMinute(maxAttempts int) contractshttp.Limit {
+	return NewLimit(maxAttempts, 1)
+}
+
+func PerMinutes(decayMinutes, maxAttempts int) contractshttp.Limit {
+	return NewLimit(maxAttempts, decayMinutes)
+}
+
+func PerHour(maxAttempts int) contractshttp.Limit {
+	return NewLimit(maxAttempts, 60)
+}
+
+func PerHours(decayHours, maxAttempts int) contractshttp.Limit {
+	return NewLimit(maxAttempts, 60*decayHours)
+}
+
+func PerDay(maxAttempts int) contractshttp.Limit {
+	return NewLimit(maxAttempts, 60*24)
+}
+
+func PerDays(decayDays, maxAttempts int) contractshttp.Limit {
+	return NewLimit(maxAttempts, 60*24*decayDays)
+}
+
+type Limit struct {
+	// The rate limit signature key.
+	Key string
+	// The maximum number of attempts allowed within the given number of minutes.
+	MaxAttempts int
+	// The number of minutes until the rate limit is reset.
+	DecayMinutes int
+	// The response generator callback.
+	ResponseCallback func(ctx contractshttp.Context)
+}
+
+func NewLimit(maxAttempts, decayMinutes int) *Limit {
+	return &Limit{
+		MaxAttempts:  maxAttempts,
+		DecayMinutes: decayMinutes,
+		ResponseCallback: func(ctx contractshttp.Context) {
+			ctx.Request().AbortWithStatus(http.StatusTooManyRequests)
+		},
+	}
+}
+
+func (r *Limit) By(key string) contractshttp.Limit {
+	r.Key = key
+
+	return r
+}
+
+func (r *Limit) Response(callable func(ctx contractshttp.Context)) contractshttp.Limit {
+	r.ResponseCallback = callable
+
+	return r
+}

--- a/http/middleware/throttle.go
+++ b/http/middleware/throttle.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"fmt"
+
+	"github.com/goravel/framework/contracts/http"
+	"github.com/goravel/framework/facades"
+	httplimit "github.com/goravel/framework/http/limit"
+)
+
+func Throttle(name string) http.Middleware {
+	return func(ctx http.Context) {
+		if limiter := facades.RateLimiter.Limiter(name); limiter != nil {
+			if limits := limiter(ctx); len(limits) > 0 {
+				for _, limit := range limits {
+					if instance, ok := limit.(*httplimit.Limit); ok {
+						fmt.Println(instance.Key, instance.MaxAttempts, instance.DecayMinutes)
+						if instance.ResponseCallback != nil {
+							instance.ResponseCallback(ctx)
+						}
+						// TODO Determine whether to pass the Limit check
+					}
+				}
+			}
+		}
+
+		ctx.Request().Next()
+
+		// TODO calculate remaining attempts(if needed)
+	}
+}

--- a/http/rate_limiter.go
+++ b/http/rate_limiter.go
@@ -1,0 +1,29 @@
+package http
+
+import (
+	"github.com/goravel/framework/contracts/http"
+)
+
+type RateLimiter struct {
+	limiters map[string]func(ctx http.Context) []http.Limit
+}
+
+func NewRateLimiter() *RateLimiter {
+	return &RateLimiter{
+		limiters: make(map[string]func(ctx http.Context) []http.Limit),
+	}
+}
+
+func (r *RateLimiter) For(name string, callback func(ctx http.Context) http.Limit) {
+	r.limiters[name] = func(ctx http.Context) []http.Limit {
+		return []http.Limit{callback(ctx)}
+	}
+}
+
+func (r *RateLimiter) ForWithLimits(name string, callback func(ctx http.Context) []http.Limit) {
+	r.limiters[name] = callback
+}
+
+func (r *RateLimiter) Limiter(name string) func(ctx http.Context) []http.Limit {
+	return r.limiters[name]
+}

--- a/http/service_provider.go
+++ b/http/service_provider.go
@@ -10,6 +10,7 @@ type ServiceProvider struct {
 }
 
 func (database *ServiceProvider) Register() {
+	facades.RateLimiter = NewRateLimiter()
 }
 
 func (database *ServiceProvider) Boot() {


### PR DESCRIPTION
The expected usage goal in `goravel/goravel` is：

1. Add `configureRateLimiting` method and RateLimiter configurations to `app/providers/route_service_provider.go`；
```
func (receiver *RouteServiceProvider) configureRateLimiting() {
	facades.RateLimiter.For("global", func(ctx contractshttp.Context) contractshttp.Limit {
		return limit.PerMinute(1)
	})
	facades.RateLimiter.ForWithLimits("upload", func(ctx contractshttp.Context) []contractshttp.Limit {
		return []contractshttp.Limit{limit.PerMinute(1), limit.PerDays(2, 3).By("1").Response(func(ctx contractshttp.Context) {
			ctx.Request().AbortWithStatusJson(499, contractshttp.Json{
				"Hi": "Goravel",
			})
		})}
	})
}
```

2. Add middleware to`route/web.go`：
```
facades.Route.Middleware(middleware.Throttle("global"), middleware.Throttle("upload"))
```

