### PR TITLE
Feat: Add ctx parameter to the methods under request

### DIFF
--- a/contracts/http/request.go
+++ b/contracts/http/request.go
@@ -54,8 +54,8 @@ type Request interface {
 
 type FormRequest interface {
 	Authorize(ctx Context) error
-	Rules() map[string]string
-	Messages() map[string]string
-	Attributes() map[string]string
-	PrepareForValidation(data validation.Data) error
+	Rules(ctx Context) map[string]string
+	Messages(ctx Context) map[string]string
+	Attributes(ctx Context) map[string]string
+	PrepareForValidation(ctx Context, data validation.Data) error
 }

--- a/http/console/stubs.go
+++ b/http/console/stubs.go
@@ -19,19 +19,19 @@ func (r *DummyRequest) Authorize(ctx http.Context) error {
 	return nil
 }
 
-func (r *DummyRequest) Rules() map[string]string {
+func (r *DummyRequest) Rules(ctx http.Context) map[string]string {
 	return map[string]string{}
 }
 
-func (r *DummyRequest) Messages() map[string]string {
+func (r *DummyRequest) Messages(ctx http.Context) map[string]string {
 	return map[string]string{}
 }
 
-func (r *DummyRequest) Attributes() map[string]string {
+func (r *DummyRequest) Attributes(ctx http.Context) map[string]string {
 	return map[string]string{}
 }
 
-func (r *DummyRequest) PrepareForValidation(data validation.Data) error {
+func (r *DummyRequest) PrepareForValidation(ctx http.Context, data validation.Data) error {
 	return nil
 }
 `

--- a/http/gin_request.go
+++ b/http/gin_request.go
@@ -324,7 +324,9 @@ func (r *GinRequest) ValidateRequest(request contractshttp.FormRequest) (contrac
 		return nil, err
 	}
 
-	validator, err := r.Validate(request.Rules(r.ctx), validation.Messages(request.Messages(r.ctx)), validation.Attributes(request.Attributes(r.ctx)), validation.PrepareForValidation(request.PrepareForValidation))
+	validator, err := r.Validate(request.Rules(r.ctx), validation.Messages(request.Messages(r.ctx)), validation.Attributes(request.Attributes(r.ctx)), func(options map[string]any) {
+		options["prepareForValidation"] = request.PrepareForValidation
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/http/gin_request.go
+++ b/http/gin_request.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cast"
 
 	contractsfilesystem "github.com/goravel/framework/contracts/filesystem"
-	httpcontract "github.com/goravel/framework/contracts/http"
-	validatecontract "github.com/goravel/framework/contracts/validation"
+	contractshttp "github.com/goravel/framework/contracts/http"
+	contractsvalidate "github.com/goravel/framework/contracts/validation"
 	"github.com/goravel/framework/facades"
 	"github.com/goravel/framework/filesystem"
 	"github.com/goravel/framework/validation"
@@ -21,7 +21,7 @@ type GinRequest struct {
 	instance *gin.Context
 }
 
-func NewGinRequest(ctx *GinContext) httpcontract.Request {
+func NewGinRequest(ctx *GinContext) contractshttp.Request {
 	return &GinRequest{ctx, ctx.instance}
 }
 
@@ -289,7 +289,7 @@ func (r *GinRequest) Origin() *http.Request {
 	return r.instance.Request
 }
 
-func (r *GinRequest) Validate(rules map[string]string, options ...validatecontract.Option) (validatecontract.Validator, error) {
+func (r *GinRequest) Validate(rules map[string]string, options ...contractsvalidate.Option) (contractsvalidate.Validator, error) {
 	if len(rules) == 0 {
 		return nil, errors.New("rules can't be empty")
 	}
@@ -306,7 +306,7 @@ func (r *GinRequest) Validate(rules map[string]string, options ...validatecontra
 		v = validate.NewValidation(dataFace)
 	} else {
 		if generateOptions["prepareForValidation"] != nil {
-			if err := generateOptions["prepareForValidation"].(func(data validatecontract.Data) error)(validation.NewData(dataFace)); err != nil {
+			if err := generateOptions["prepareForValidation"].(func(ctx contractshttp.Context, data contractsvalidate.Data) error)(r.ctx, validation.NewData(dataFace)); err != nil {
 				return nil, err
 			}
 		}
@@ -319,12 +319,12 @@ func (r *GinRequest) Validate(rules map[string]string, options ...validatecontra
 	return validation.NewValidator(v, dataFace), nil
 }
 
-func (r *GinRequest) ValidateRequest(request httpcontract.FormRequest) (validatecontract.Errors, error) {
+func (r *GinRequest) ValidateRequest(request contractshttp.FormRequest) (contractsvalidate.Errors, error) {
 	if err := request.Authorize(r.ctx); err != nil {
 		return nil, err
 	}
 
-	validator, err := r.Validate(request.Rules(), validation.Messages(request.Messages()), validation.Attributes(request.Attributes()), validation.PrepareForValidation(request.PrepareForValidation))
+	validator, err := r.Validate(request.Rules(r.ctx), validation.Messages(request.Messages(r.ctx)), validation.Attributes(request.Attributes(r.ctx)), validation.PrepareForValidation(request.PrepareForValidation))
 	if err != nil {
 		return nil, err
 	}

--- a/route/gin_test.go
+++ b/route/gin_test.go
@@ -1454,21 +1454,21 @@ func (r *CreateUser) Authorize(ctx httpcontract.Context) error {
 	return nil
 }
 
-func (r *CreateUser) Rules() map[string]string {
+func (r *CreateUser) Rules(ctx httpcontract.Context) map[string]string {
 	return map[string]string{
 		"name": "required",
 	}
 }
 
-func (r *CreateUser) Messages() map[string]string {
+func (r *CreateUser) Messages(ctx httpcontract.Context) map[string]string {
 	return map[string]string{}
 }
 
-func (r *CreateUser) Attributes() map[string]string {
+func (r *CreateUser) Attributes(ctx httpcontract.Context) map[string]string {
 	return map[string]string{}
 }
 
-func (r *CreateUser) PrepareForValidation(data validation.Data) error {
+func (r *CreateUser) PrepareForValidation(ctx httpcontract.Context, data validation.Data) error {
 	if name, exist := data.Get("name"); exist {
 		return data.Set("name", name.(string)+"1")
 	}
@@ -1484,20 +1484,20 @@ func (r *Unauthorize) Authorize(ctx httpcontract.Context) error {
 	return errors.New("error")
 }
 
-func (r *Unauthorize) Rules() map[string]string {
+func (r *Unauthorize) Rules(ctx httpcontract.Context) map[string]string {
 	return map[string]string{
 		"name": "required",
 	}
 }
 
-func (r *Unauthorize) Messages() map[string]string {
+func (r *Unauthorize) Messages(ctx httpcontract.Context) map[string]string {
 	return map[string]string{}
 }
 
-func (r *Unauthorize) Attributes() map[string]string {
+func (r *Unauthorize) Attributes(ctx httpcontract.Context) map[string]string {
 	return map[string]string{}
 }
 
-func (r *Unauthorize) PrepareForValidation(data validation.Data) error {
+func (r *Unauthorize) PrepareForValidation(ctx httpcontract.Context, data validation.Data) error {
 	return nil
 }

--- a/support/str/str.go
+++ b/support/str/str.go
@@ -7,9 +7,6 @@ import (
 	"strings"
 	"time"
 	"unicode"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 func Random(length int) string {
@@ -25,11 +22,23 @@ func Random(length int) string {
 }
 
 func Case2Camel(name string) string {
-	name = strings.Replace(name, "_", " ", -1)
-	caser := cases.Title(language.English)
-	name = caser.String(name)
+	names := strings.Split(name, "_")
 
-	return strings.Replace(name, " ", "", -1)
+	var newName string
+	for _, item := range names {
+		buffer := NewBuffer()
+		for i, r := range item {
+			if i == 0 {
+				buffer.Append(unicode.ToUpper(r))
+			} else {
+				buffer.Append(r)
+			}
+		}
+
+		newName += buffer.String()
+	}
+
+	return newName
 }
 
 func Camel2Case(name string) string {

--- a/support/str/str_test.go
+++ b/support/str/str_test.go
@@ -13,9 +13,11 @@ func TestRandom(t *testing.T) {
 func TestCase2Camel(t *testing.T) {
 	assert.Equal(t, "GoravelFramework", Case2Camel("goravel_framework"))
 	assert.Equal(t, "GoravelFramework1", Case2Camel("goravel_framework1"))
+	assert.Equal(t, "GoravelFramework", Case2Camel("GoravelFramework"))
 }
 
 func TestCamel2Case(t *testing.T) {
 	assert.Equal(t, "goravel_framework", Camel2Case("GoravelFramework"))
 	assert.Equal(t, "goravel_framework1", Camel2Case("GoravelFramework1"))
+	assert.Equal(t, "goravel_framework", Camel2Case("goravel_framework"))
 }

--- a/validation/options.go
+++ b/validation/options.go
@@ -3,10 +3,10 @@ package validation
 import (
 	"strings"
 
+	"github.com/gookit/validate"
+
 	"github.com/goravel/framework/contracts/http"
 	httpvalidate "github.com/goravel/framework/contracts/validation"
-
-	"github.com/gookit/validate"
 )
 
 func Rules(rules map[string]string) httpvalidate.Option {

--- a/validation/options.go
+++ b/validation/options.go
@@ -41,9 +41,11 @@ func Attributes(attributes map[string]string) httpvalidate.Option {
 	}
 }
 
-func PrepareForValidation(prepare func(ctx http.Context, data httpvalidate.Data) error) httpvalidate.Option {
+func PrepareForValidation(prepare func(data httpvalidate.Data) error) httpvalidate.Option {
 	return func(options map[string]any) {
-		options["prepareForValidation"] = prepare
+		options["prepareForValidation"] = func(ctx http.Context, data httpvalidate.Data) error {
+			return prepare(data)
+		}
 	}
 }
 

--- a/validation/options.go
+++ b/validation/options.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"strings"
 
+	"github.com/goravel/framework/contracts/http"
 	httpvalidate "github.com/goravel/framework/contracts/validation"
 
 	"github.com/gookit/validate"
@@ -40,7 +41,7 @@ func Attributes(attributes map[string]string) httpvalidate.Option {
 	}
 }
 
-func PrepareForValidation(prepare func(data httpvalidate.Data) error) httpvalidate.Option {
+func PrepareForValidation(prepare func(ctx http.Context, data httpvalidate.Data) error) httpvalidate.Option {
 	return func(options map[string]any) {
 		options["prepareForValidation"] = prepare
 	}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gookit/validate"
 
+	"github.com/goravel/framework/contracts/http"
 	validatecontract "github.com/goravel/framework/contracts/validation"
 )
 
@@ -61,7 +62,7 @@ func (r *Validation) Make(data any, rules map[string]string, options ...validate
 	options = append(options, Rules(rules), CustomRules(r.rules))
 	generateOptions := GenerateOptions(options)
 	if generateOptions["prepareForValidation"] != nil {
-		if err := generateOptions["prepareForValidation"].(func(data validatecontract.Data) error)(NewData(dataFace)); err != nil {
+		if err := generateOptions["prepareForValidation"].(func(ctx http.Context, data validatecontract.Data) error)(nil, NewData(dataFace)); err != nil {
 			return nil, err
 		}
 	}

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -153,21 +153,23 @@ func TestMake(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		validation := NewValidation()
-		validator, err := validation.Make(test.data, test.rules, test.options...)
-		assert.Equal(t, test.expectValidator, validator != nil, test.description)
-		assert.Equal(t, test.expectErr, err, test.description)
+		t.Run(test.description, func(t *testing.T) {
+			validation := NewValidation()
+			validator, err := validation.Make(test.data, test.rules, test.options...)
+			assert.Equal(t, test.expectValidator, validator != nil, test.description)
+			assert.Equal(t, test.expectErr, err, test.description)
 
-		if validator != nil {
-			var data Data
-			err = validator.Bind(&data)
-			assert.Nil(t, err, test.description)
-			assert.Equal(t, test.expectData, data, test.description)
-			if validator.Fails() {
-				assert.Equal(t, test.expectErrorMessage, validator.Errors().One(), test.description)
+			if validator != nil {
+				var data Data
+				err = validator.Bind(&data)
+				assert.Nil(t, err, test.description)
+				assert.Equal(t, test.expectData, data, test.description)
+				if validator.Fails() {
+					assert.Equal(t, test.expectErrorMessage, validator.Errors().One(), test.description)
+				}
+				assert.Equal(t, test.expectErrors, validator.Fails(), test.description)
 			}
-			assert.Equal(t, test.expectErrors, validator.Fails(), test.description)
-		}
+		})
 	}
 }
 
@@ -258,7 +260,9 @@ func TestRule_Required(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -330,7 +334,9 @@ func TestRule_RequiredIf(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -402,7 +408,9 @@ func TestRule_RequiredUnless(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -477,7 +485,9 @@ func TestRule_RequiredWith(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -570,7 +580,9 @@ func TestRule_RequiredWithAll(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -643,7 +655,9 @@ func TestRule_RequiredWithout(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -711,7 +725,9 @@ func TestRule_RequiredWithoutAll(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -777,7 +793,9 @@ func TestRule_Int(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -815,7 +833,9 @@ func TestRule_Uint(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -875,7 +895,9 @@ func TestRule_Bool(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -941,7 +963,9 @@ func TestRule_String(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -979,7 +1003,9 @@ func TestRule_Float(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1025,7 +1051,9 @@ func TestRule_Slice(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1066,7 +1094,9 @@ func TestRule_In(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1107,7 +1137,9 @@ func TestRule_NotIn(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1143,7 +1175,9 @@ func TestRule_StartsWith(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1179,7 +1213,9 @@ func TestRule_EndsWith(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1215,7 +1251,9 @@ func TestRule_Between(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1251,7 +1289,9 @@ func TestRule_Max(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1287,7 +1327,9 @@ func TestRule_Min(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1323,7 +1365,9 @@ func TestRule_Eq(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1359,7 +1403,9 @@ func TestRule_Ne(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1395,7 +1441,9 @@ func TestRule_Lt(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1431,7 +1479,9 @@ func TestRule_Gt(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1490,7 +1540,9 @@ func TestRule_Len(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1549,7 +1601,9 @@ func TestRule_MinLen(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1608,7 +1662,9 @@ func TestRule_MaxLen(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1644,7 +1700,9 @@ func TestRule_Email(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1688,7 +1746,9 @@ func TestRule_Array(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1733,7 +1793,9 @@ func TestRule_Map(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1773,7 +1835,9 @@ func TestRule_EqField(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1813,7 +1877,9 @@ func TestRule_NeField(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1853,7 +1919,9 @@ func TestRule_GtField(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1895,7 +1963,9 @@ func TestRule_GteField(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1935,7 +2005,9 @@ func TestRule_LtField(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -1977,7 +2049,9 @@ func TestRule_LteField(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2018,7 +2092,9 @@ func TestRule_Date(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2054,7 +2130,9 @@ func TestRule_GtDate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2090,7 +2168,9 @@ func TestRule_LtDate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2128,7 +2208,9 @@ func TestRule_GteDate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2166,7 +2248,9 @@ func TestRule_lteDate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2205,7 +2289,9 @@ func TestRule_Alpha(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2241,7 +2327,9 @@ func TestRule_AlphaNum(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2277,7 +2365,9 @@ func TestRule_AlphaDash(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2313,7 +2403,9 @@ func TestRule_Json(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2349,7 +2441,9 @@ func TestRule_Number(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2387,7 +2481,9 @@ func TestRule_FullUrl(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2428,7 +2524,9 @@ func TestRule_Ip(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2470,7 +2568,9 @@ func TestRule_Ipv4(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2509,7 +2609,9 @@ func TestRule_Ipv6(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 
@@ -2562,7 +2664,9 @@ func TestCustomRule(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.setup(test)
+		t.Run(test.description, func(t *testing.T) {
+			test.setup(test)
+		})
 	}
 }
 


### PR DESCRIPTION
Add `ctx http.Context` parameter to the methods under `request`: `Rules`, `Messages`, `Attributes`, `PrepareForValidation`, allows you to do more custom configurations.