### PR TITLE
feat: Add a predefined ServiceProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .idea
 .DS_Store
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .env
 .idea
 .DS_Store
-vendor
+/vendor

--- a/contracts/foundation/service_provider.go
+++ b/contracts/foundation/service_provider.go
@@ -1,8 +1,15 @@
 package foundation
 
 type ServiceProvider interface {
-	//Register any application services.
+	// Register any application services.
 	Register(app Application)
-	//Boot any application services after register.
+	// Boot any application services after register.
 	Boot(app Application)
 }
+
+// UnimplementedServiceProvider is a default implementation of the Provider interface.
+type UnimplementedServiceProvider struct{}
+
+func (u *UnimplementedServiceProvider) Register(app Application) {}
+
+func (u *UnimplementedServiceProvider) Boot(app Application) {}

--- a/contracts/foundation/service_provider.go
+++ b/contracts/foundation/service_provider.go
@@ -7,9 +7,9 @@ type ServiceProvider interface {
 	Boot(app Application)
 }
 
-// UnimplementedServiceProvider is a default implementation of the Provider interface.
-type UnimplementedServiceProvider struct{}
+// BaseServiceProvider is a default implementation of the Provider interface.
+type BaseServiceProvider struct{}
 
-func (u *UnimplementedServiceProvider) Register(app Application) {}
+func (u *BaseServiceProvider) Register(Application) {}
 
-func (u *UnimplementedServiceProvider) Boot(app Application) {}
+func (u *BaseServiceProvider) Boot(Application) {}

--- a/contracts/foundation/service_provider.go
+++ b/contracts/foundation/service_provider.go
@@ -10,6 +10,6 @@ type ServiceProvider interface {
 // BaseServiceProvider is a default implementation of the Provider interface.
 type BaseServiceProvider struct{}
 
-func (u *BaseServiceProvider) Register(Application) {}
+func (s *BaseServiceProvider) Register(Application) {}
 
-func (u *BaseServiceProvider) Boot(Application) {}
+func (s *BaseServiceProvider) Boot(Application) {}

--- a/contracts/foundation/service_provider_test.go
+++ b/contracts/foundation/service_provider_test.go
@@ -1,0 +1,26 @@
+package foundation
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type test1ServiceProvider struct {
+}
+
+type test2ServiceProvider struct {
+	*UnimplementedServiceProvider
+}
+
+func TestUnimplementedServiceProvider(t *testing.T) {
+	var (
+		sp1 = &test1ServiceProvider{}
+		sp2 = &test2ServiceProvider{}
+	)
+
+	_, ok1 := interface{}(sp1).(ServiceProvider)
+	_, ok2 := interface{}(sp2).(ServiceProvider)
+
+	assert.False(t, ok1)
+	assert.True(t, ok2)
+}

--- a/contracts/foundation/service_provider_test.go
+++ b/contracts/foundation/service_provider_test.go
@@ -8,30 +8,23 @@ import (
 
 var testRegister = 0
 
-type test1ServiceProvider struct {
-}
-
-type test2ServiceProvider struct {
+type testServiceProvider struct {
 	*BaseServiceProvider
 }
 
-func (t *test2ServiceProvider) Register(Application) {
+func (t *testServiceProvider) Register(Application) {
 	testRegister++
 }
 
 func TestBaseServiceProvider(t *testing.T) {
-	var (
-		sp1 = &test1ServiceProvider{}
-		sp2 = &test2ServiceProvider{}
-	)
+	var sp = &testServiceProvider{}
 
-	_, ok1 := interface{}(sp1).(ServiceProvider)
-	_, ok2 := interface{}(sp2).(ServiceProvider)
+	_, ok := interface{}(sp).(ServiceProvider)
 
-	assert.False(t, ok1)
-	assert.True(t, ok2)
+	assert.True(t, ok)
 
-	sp2.Register(nil)
+	sp.Register(nil)
+	sp.Boot(nil)
+
 	assert.Equal(t, 1, testRegister)
-	sp2.Boot(nil)
 }

--- a/contracts/foundation/service_provider_test.go
+++ b/contracts/foundation/service_provider_test.go
@@ -1,18 +1,25 @@
 package foundation
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+var testRegister = 0
 
 type test1ServiceProvider struct {
 }
 
 type test2ServiceProvider struct {
-	*UnimplementedServiceProvider
+	*BaseServiceProvider
 }
 
-func TestUnimplementedServiceProvider(t *testing.T) {
+func (t *test2ServiceProvider) Register(Application) {
+	testRegister++
+}
+
+func TestBaseServiceProvider(t *testing.T) {
 	var (
 		sp1 = &test1ServiceProvider{}
 		sp2 = &test2ServiceProvider{}
@@ -25,5 +32,6 @@ func TestUnimplementedServiceProvider(t *testing.T) {
 	assert.True(t, ok2)
 
 	sp2.Register(nil)
+	assert.Equal(t, 1, testRegister)
 	sp2.Boot(nil)
 }

--- a/contracts/foundation/service_provider_test.go
+++ b/contracts/foundation/service_provider_test.go
@@ -23,4 +23,7 @@ func TestUnimplementedServiceProvider(t *testing.T) {
 
 	assert.False(t, ok1)
 	assert.True(t, ok2)
+
+	sp2.Register(nil)
+	sp2.Boot(nil)
 }


### PR DESCRIPTION
## 📑 Description

Adding a predefined ServiceProvider allows you to omit some implementations when defining a ServiceProvider.

The idea came from GRPC `UnimplementedTestServiceServer`.

See: https://github.com/goravel/framework/blob/master/grpc/test.pb.go#L191

**Before:**

```go
package hash

import (
	"github.com/goravel/framework/contracts/foundation"
)

const Binding = "goravel.hash"

type ServiceProvider struct {
}

func (hash *ServiceProvider) Register(app foundation.Application) {
	app.Singleton(Binding, func(app foundation.Application) (any, error) {
		return NewApplication(app.MakeConfig()), nil
	})
}

func (hash *ServiceProvider) Boot(app foundation.Application) {

}
```

**But now:**

```go
package hash

import (
	"github.com/goravel/framework/contracts/foundation"
)

const Binding = "goravel.hash"

type ServiceProvider struct {
	*foundation.UnimplementedServiceProvider // <------- look it
}

func (hash *ServiceProvider) Register(app foundation.Application) {
	app.Singleton(Binding, func(app foundation.Application) (any, error) {
		return NewApplication(app.MakeConfig()), nil
	})
}
```

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed

## ℹ Additional Information

None
