### PR TITLE
feat: Alias `spew.Dump` and so on

### DIFF
--- a/support/debug/dump.go
+++ b/support/debug/dump.go
@@ -1,0 +1,21 @@
+package debug
+
+import (
+	"github.com/davecgh/go-spew/spew"
+	"io"
+)
+
+// Dump is a wrapper around spew.Dump.
+func Dump(v ...interface{}) {
+	spew.Dump(v...)
+}
+
+// FDump is a wrapper around spew.Fdump.
+func FDump(w io.Writer, v ...interface{}) {
+	spew.Fdump(w, v...)
+}
+
+// SDump is a wrapper around spew.Sdump.
+func SDump(v ...interface{}) string {
+	return spew.Sdump(v...)
+}

--- a/support/debug/dump.go
+++ b/support/debug/dump.go
@@ -1,21 +1,25 @@
 package debug
 
 import (
-	"github.com/davecgh/go-spew/spew"
 	"io"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
-// Dump is a wrapper around spew.Dump.
+// Dump is used to display detailed information about variables
+// And this is a wrapper around spew.Dump.
 func Dump(v ...interface{}) {
 	spew.Dump(v...)
 }
 
-// FDump is a wrapper around spew.Fdump.
+// FDump is used to display detailed information about variables to the specified io.Writer
+// And this is a wrapper around spew.Fdump.
 func FDump(w io.Writer, v ...interface{}) {
 	spew.Fdump(w, v...)
 }
 
-// SDump is a wrapper around spew.Sdump.
+// SDump is used to display detailed information about variables as a string,
+// And this is a wrapper around spew.Sdump.
 func SDump(v ...interface{}) string {
 	return spew.Sdump(v...)
 }

--- a/support/debug/dump_test.go
+++ b/support/debug/dump_test.go
@@ -1,20 +1,46 @@
 package debug
 
 import (
-	"fmt"
-	"github.com/stretchr/testify/assert"
+	"bytes"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
+func redirectStdout(fn func()) ([]byte, error) {
+	f, err := os.CreateTemp("", "stdout")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(f.Name())
+	defer f.Close()
+
+	orig := os.Stdout
+	os.Stdout = f
+	fn()
+	os.Stdout = orig
+
+	return os.ReadFile(f.Name())
+}
+
 func TestDump(t *testing.T) {
-	Dump("foo")
+	buf, err := redirectStdout(func() {
+		Dump("foo")
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, `(string) (len=3) "foo"
+`, string(buf))
 }
 
 func TestFDump(t *testing.T) {
-	FDump(os.Stdout, "foo")
+	var buf bytes.Buffer
+	w := &buf
 
-	fmt.Sprintf("%s", SDump("foo"))
+	FDump(w, "foo")
+
+	assert.Equal(t, `(string) (len=3) "foo"
+`, buf.String())
 }
 
 func TestSDump(t *testing.T) {

--- a/support/debug/dump_test.go
+++ b/support/debug/dump_test.go
@@ -1,0 +1,23 @@
+package debug
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestDump(t *testing.T) {
+	Dump("foo")
+}
+
+func TestFDump(t *testing.T) {
+	FDump(os.Stdout, "foo")
+
+	fmt.Sprintf("%s", SDump("foo"))
+}
+
+func TestSDump(t *testing.T) {
+	assert.Equal(t, `(string) (len=3) "foo"
+`, SDump("foo"))
+}


### PR DESCRIPTION
## 📑 Description

Alias `spew.Dump` and so on.

- `debug.Dump()`
- `debug.SDump()`
- `debug.FDump()`

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed