### PR TITLE
feat: Added recovery handler

### DIFF
--- a/contracts/support/debug/recovery/handler.go
+++ b/contracts/support/debug/recovery/handler.go
@@ -1,0 +1,6 @@
+package recovery
+
+type Handler interface {
+	ShouldReport(v interface{}) bool
+	Report(v interface{})
+}

--- a/support/debug/recovery/panic_handler.go
+++ b/support/debug/recovery/panic_handler.go
@@ -1,0 +1,17 @@
+package recovery
+
+import (
+	"github.com/goravel/framework/contracts/support/debug/recovery"
+)
+
+type PanicHandler struct{}
+
+var _ recovery.Handler = (*PanicHandler)(nil)
+
+func (h *PanicHandler) ShouldReport(v interface{}) bool {
+	return true
+}
+
+func (h *PanicHandler) Report(v interface{}) {
+	panic(v)
+}

--- a/support/debug/recovery/panic_handler_test.go
+++ b/support/debug/recovery/panic_handler_test.go
@@ -1,0 +1,60 @@
+package recovery
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/goravel/framework/contracts/support/debug/recovery"
+	"github.com/stretchr/testify/assert"
+)
+
+type testPanicHandler struct {
+	*PanicHandler
+}
+
+func (h *testPanicHandler) ShouldReport(v interface{}) bool {
+	if err, ok := v.(error); ok {
+		return !strings.Contains(err.Error(), "no-report")
+	}
+
+	return true
+}
+
+type kernel struct {
+	recovery recovery.Handler
+}
+
+func newKernel(recovery recovery.Handler) *kernel {
+	return &kernel{
+		recovery: recovery,
+	}
+}
+
+func (k *kernel) Handle(fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			if k.recovery.ShouldReport(r) {
+				k.recovery.Report(r)
+			}
+		}
+	}()
+
+	fn()
+}
+
+func TestPanicHandler(t *testing.T) {
+	k := newKernel(&testPanicHandler{})
+
+	assert.NotPanics(t, func() {
+		k.Handle(func() {
+			panic(errors.New("test-no-report"))
+		})
+	})
+
+	assert.Panics(t, func() {
+		k.Handle(func() {
+			panic("test-report")
+		})
+	})
+}


### PR DESCRIPTION
## 📑 Description

I can define a general or global recovery that catches system-level exceptions and identifies those that can be reported.

Example: unit test，

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed

