### PR TITLE
feat: add resource flag to make:controller

### DIFF
--- a/http/console/controller_make_command.go
+++ b/http/console/controller_make_command.go
@@ -31,6 +31,13 @@ func (receiver *ControllerMakeCommand) Description() string {
 func (receiver *ControllerMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
+		Flags: []command.Flag{
+			&command.BoolFlag{
+				Name:  "resource",
+				Value: false,
+				Usage: "resourceful controller",
+			},
+		},
 	}
 }
 
@@ -41,7 +48,12 @@ func (receiver *ControllerMakeCommand) Handle(ctx console.Context) error {
 		return errors.New("Not enough arguments (missing: name) ")
 	}
 
-	if err := file.Create(receiver.getPath(name), receiver.populateStub(receiver.getStub(), name)); err != nil {
+	stub := receiver.getStub()
+	if ctx.OptionBool("resource") {
+		stub = receiver.getResourceStub()
+	}
+
+	if err := file.Create(receiver.getPath(name), receiver.populateStub(stub, name)); err != nil {
 		return err
 	}
 
@@ -52,6 +64,10 @@ func (receiver *ControllerMakeCommand) Handle(ctx console.Context) error {
 
 func (receiver *ControllerMakeCommand) getStub() string {
 	return Stubs{}.Controller()
+}
+
+func (receiver *ControllerMakeCommand) getResourceStub() string {
+	return Stubs{}.ResourceController()
 }
 
 // populateStub Populate the place-holders in the command stub.

--- a/http/console/controller_make_command_test.go
+++ b/http/console/controller_make_command_test.go
@@ -29,3 +29,21 @@ func TestControllerMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("app/http/controllers/User/auth_controller.go", "type AuthController struct"))
 	assert.Nil(t, file.Remove("app"))
 }
+
+func TestResourceControllerMakeCommand(t *testing.T) {
+	controllerMakeCommand := &ControllerMakeCommand{}
+	mockContext := &consolemocks.Context{}
+	mockContext.On("Argument", 0).Return("User/AuthController").Once()
+	mockContext.On("OptionBool", "resource").Return(true).Once()
+	err := controllerMakeCommand.Handle(mockContext)
+	assert.Nil(t, err)
+	assert.True(t, file.Exists("app/http/controllers/User/auth_controller.go"))
+	assert.True(t, file.Contain("app/http/controllers/User/auth_controller.go", "package User"))
+	assert.True(t, file.Contain("app/http/controllers/User/auth_controller.go", "type AuthController struct"))
+	assert.True(t, file.Contain("app/http/controllers/User/auth_controller.go", "func (r *AuthController) Index(ctx http.Context) {"))
+	assert.True(t, file.Contain("app/http/controllers/User/auth_controller.go", "func (r *AuthController) Show(ctx http.Context) {"))
+	assert.True(t, file.Contain("app/http/controllers/User/auth_controller.go", "func (r *AuthController) Store(ctx http.Context) {"))
+	assert.True(t, file.Contain("app/http/controllers/User/auth_controller.go", "func (r *AuthController) Update(ctx http.Context) {"))
+	assert.True(t, file.Contain("app/http/controllers/User/auth_controller.go", "func (r *AuthController) Destroy(ctx http.Context) {"))
+	assert.Nil(t, file.Remove("app"))
+}

--- a/http/console/controller_make_command_test.go
+++ b/http/console/controller_make_command_test.go
@@ -17,16 +17,19 @@ func TestControllerMakeCommand(t *testing.T) {
 	assert.EqualError(t, err, "Not enough arguments (missing: name) ")
 
 	mockContext.On("Argument", 0).Return("UsersController").Once()
+	mockContext.On("OptionBool", "resource").Return(false).Once()
 	err = controllerMakeCommand.Handle(mockContext)
 	assert.Nil(t, err)
 	assert.True(t, file.Exists("app/http/controllers/users_controller.go"))
 
 	mockContext.On("Argument", 0).Return("User/AuthController").Once()
+	mockContext.On("OptionBool", "resource").Return(false).Once()
 	err = controllerMakeCommand.Handle(mockContext)
 	assert.Nil(t, err)
 	assert.True(t, file.Exists("app/http/controllers/User/auth_controller.go"))
 	assert.True(t, file.Contain("app/http/controllers/User/auth_controller.go", "package User"))
 	assert.True(t, file.Contain("app/http/controllers/User/auth_controller.go", "type AuthController struct"))
+	assert.True(t, file.Contain("app/http/controllers/User/auth_controller.go", "func (r *AuthController) Index(ctx http.Context) {"))
 	assert.Nil(t, file.Remove("app"))
 }
 

--- a/http/console/stubs.go
+++ b/http/console/stubs.go
@@ -59,6 +59,26 @@ func (r *DummyController) Index(ctx http.Context) {
 `
 }
 
+func (r Stubs) ResourceController() string {
+	return r.Controller() + `
+
+func (r *DummyController) Store(ctx http.Context) {
+}
+
+func (r *DummyController) Show(ctx http.Context) {
+}
+
+func (r *DummyController) Store(ctx http.Context) {
+}
+
+func (r *DummyController) Update(ctx http.Context) {
+}
+
+func (r *DummyController) Destroy(ctx http.Context) {
+}
+`
+}
+
 func (r Stubs) Middleware() string {
 	return `package DummyPackage
 


### PR DESCRIPTION
## 📑 Description

This MR adds a `--resource` flag to the make controller command.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
