### PR TITLE
chore(route): add GetInstance method on gin

### DIFF
--- a/route/gin.go
+++ b/route/gin.go
@@ -20,6 +20,10 @@ type Gin struct {
 	instance *gin.Engine
 }
 
+func (r *Gin) GetInstance() *gin.Engine {
+	return r.instance
+}
+
 func NewGin(config config.Config) *Gin {
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()


### PR DESCRIPTION

## 📑 Description
I need to GetInstance method for get the gin.Engine.

Because I want to using goravel in lambda serverless.

Thankyou

https://github.com/awslabs/aws-lambda-go-api-proxy

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
