### PR TITLE
feat: The trace printed by facades.Log().Error uses reverse order

### DIFF
--- a/log/logrus_writer.go
+++ b/log/logrus_writer.go
@@ -194,7 +194,12 @@ func (r *Writer) With(data map[string]any) log.Writer {
 func (r *Writer) withStackTrace(message string) {
 	erisNew := eris.New(message)
 	r.message = erisNew.Error()
-	r.stacktrace = eris.ToJSON(erisNew, true)
+	format := eris.NewDefaultJSONFormat(eris.FormatOptions{
+		InvertOutput: true,
+		WithTrace:    true,
+		InvertTrace:  true,
+	})
+	r.stacktrace = eris.ToCustomJSON(erisNew, format)
 	r.stackEnabled = true
 }
 


### PR DESCRIPTION
Closes https://github.com/goravel/goravel/issues/244

## 📑 Description
Before:
![image](https://github.com/goravel/framework/assets/84431594/50f0982b-190d-458b-9a45-b296e7019de3)

After:
![image](https://github.com/goravel/framework/assets/84431594/62fcdd55-3ab8-433f-851a-bb8e5b498548)


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
