### PR TITLE
feat: Context can be passed to facades.Auth() directly, and other methods of Auth don't need to pass Contect anymore

### DIFF
--- a/auth/service_provider.go
+++ b/auth/service_provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/goravel/framework/auth/console"
 	contractconsole "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
+	"github.com/goravel/framework/contracts/http"
 )
 
 const BindingAuth = "goravel.auth"
@@ -16,10 +17,10 @@ type ServiceProvider struct {
 }
 
 func (database *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(BindingAuth, func(app foundation.Application) (any, error) {
+	app.BindWith(BindingAuth, func(app foundation.Application, parameters map[string]any) (any, error) {
 		config := app.MakeConfig()
 		return NewAuth(config.GetString("auth.defaults.guard"),
-			app.MakeCache(), config, app.MakeOrm()), nil
+			app.MakeCache(), config, parameters["ctx"].(http.Context), app.MakeOrm()), nil
 	})
 	app.Singleton(BindingGate, func(app foundation.Application) (any, error) {
 		return access.NewGate(context.Background()), nil

--- a/contracts/auth/auth.go
+++ b/contracts/auth/auth.go
@@ -2,25 +2,23 @@ package auth
 
 import (
 	"time"
-
-	"github.com/goravel/framework/contracts/http"
 )
 
 type Auth interface {
 	// Guard attempts to get the guard against the local cache.
 	Guard(name string) Auth
 	// Parse the given token.
-	Parse(ctx http.Context, token string) (*Payload, error)
+	Parse(token string) (*Payload, error)
 	// User returns the current authenticated user.
-	User(ctx http.Context, user any) error
+	User(user any) error
 	// Login logs a user into the application.
-	Login(ctx http.Context, user any) (token string, err error)
+	Login(user any) (token string, err error)
 	// LoginUsingID logs the given user ID into the application.
-	LoginUsingID(ctx http.Context, id any) (token string, err error)
+	LoginUsingID(id any) (token string, err error)
 	// Refresh the token for the current user.
-	Refresh(ctx http.Context) (token string, err error)
+	Refresh() (token string, err error)
 	// Logout logs the user out of the application.
-	Logout(ctx http.Context) error
+	Logout() error
 }
 
 type Payload struct {

--- a/contracts/foundation/container.go
+++ b/contracts/foundation/container.go
@@ -38,7 +38,7 @@ type Container interface {
 	// MakeArtisan resolves the artisan console instance.
 	MakeArtisan() console.Artisan
 	// MakeAuth resolves the auth instance.
-	MakeAuth() auth.Auth
+	MakeAuth(ctx http.Context) auth.Auth
 	// MakeCache resolves the cache instance.
 	MakeCache() cache.Cache
 	// MakeConfig resolves the config instance.

--- a/facades/auth.go
+++ b/facades/auth.go
@@ -3,10 +3,11 @@ package facades
 import (
 	"github.com/goravel/framework/contracts/auth"
 	"github.com/goravel/framework/contracts/auth/access"
+	"github.com/goravel/framework/contracts/http"
 )
 
-func Auth() auth.Auth {
-	return App().MakeAuth()
+func Auth(ctx http.Context) auth.Auth {
+	return App().MakeAuth(ctx)
 }
 
 func Gate() access.Gate {

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -142,7 +142,7 @@ func (s *ApplicationTestSuite) TestMakeAuth() {
 	serviceProvider := &auth.ServiceProvider{}
 	serviceProvider.Register(s.app)
 
-	s.NotNil(s.app.MakeAuth())
+	s.NotNil(s.app.MakeAuth(http.Background()))
 	mockConfig.AssertExpectations(s.T())
 }
 

--- a/foundation/container.go
+++ b/foundation/container.go
@@ -90,8 +90,10 @@ func (c *Container) MakeArtisan() consolecontract.Artisan {
 	return instance.(consolecontract.Artisan)
 }
 
-func (c *Container) MakeAuth() authcontract.Auth {
-	instance, err := c.Make(auth.BindingAuth)
+func (c *Container) MakeAuth(ctx httpcontract.Context) authcontract.Auth {
+	instance, err := c.MakeWith(auth.BindingAuth, map[string]any{
+		"ctx": ctx,
+	})
 	if err != nil {
 		color.Redln(err)
 		return nil

--- a/mocks/auth/Auth.go
+++ b/mocks/auth/Auth.go
@@ -4,8 +4,6 @@ package mocks
 
 import (
 	auth "github.com/goravel/framework/contracts/auth"
-	http "github.com/goravel/framework/contracts/http"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -30,23 +28,23 @@ func (_m *Auth) Guard(name string) auth.Auth {
 	return r0
 }
 
-// Login provides a mock function with given fields: ctx, user
-func (_m *Auth) Login(ctx http.Context, user interface{}) (string, error) {
-	ret := _m.Called(ctx, user)
+// Login provides a mock function with given fields: user
+func (_m *Auth) Login(user interface{}) (string, error) {
+	ret := _m.Called(user)
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(http.Context, interface{}) (string, error)); ok {
-		return rf(ctx, user)
+	if rf, ok := ret.Get(0).(func(interface{}) (string, error)); ok {
+		return rf(user)
 	}
-	if rf, ok := ret.Get(0).(func(http.Context, interface{}) string); ok {
-		r0 = rf(ctx, user)
+	if rf, ok := ret.Get(0).(func(interface{}) string); ok {
+		r0 = rf(user)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(http.Context, interface{}) error); ok {
-		r1 = rf(ctx, user)
+	if rf, ok := ret.Get(1).(func(interface{}) error); ok {
+		r1 = rf(user)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -54,23 +52,23 @@ func (_m *Auth) Login(ctx http.Context, user interface{}) (string, error) {
 	return r0, r1
 }
 
-// LoginUsingID provides a mock function with given fields: ctx, id
-func (_m *Auth) LoginUsingID(ctx http.Context, id interface{}) (string, error) {
-	ret := _m.Called(ctx, id)
+// LoginUsingID provides a mock function with given fields: id
+func (_m *Auth) LoginUsingID(id interface{}) (string, error) {
+	ret := _m.Called(id)
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(http.Context, interface{}) (string, error)); ok {
-		return rf(ctx, id)
+	if rf, ok := ret.Get(0).(func(interface{}) (string, error)); ok {
+		return rf(id)
 	}
-	if rf, ok := ret.Get(0).(func(http.Context, interface{}) string); ok {
-		r0 = rf(ctx, id)
+	if rf, ok := ret.Get(0).(func(interface{}) string); ok {
+		r0 = rf(id)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(http.Context, interface{}) error); ok {
-		r1 = rf(ctx, id)
+	if rf, ok := ret.Get(1).(func(interface{}) error); ok {
+		r1 = rf(id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -78,13 +76,13 @@ func (_m *Auth) LoginUsingID(ctx http.Context, id interface{}) (string, error) {
 	return r0, r1
 }
 
-// Logout provides a mock function with given fields: ctx
-func (_m *Auth) Logout(ctx http.Context) error {
-	ret := _m.Called(ctx)
+// Logout provides a mock function with given fields:
+func (_m *Auth) Logout() error {
+	ret := _m.Called()
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(http.Context) error); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -92,25 +90,25 @@ func (_m *Auth) Logout(ctx http.Context) error {
 	return r0
 }
 
-// Parse provides a mock function with given fields: ctx, token
-func (_m *Auth) Parse(ctx http.Context, token string) (*auth.Payload, error) {
-	ret := _m.Called(ctx, token)
+// Parse provides a mock function with given fields: token
+func (_m *Auth) Parse(token string) (*auth.Payload, error) {
+	ret := _m.Called(token)
 
 	var r0 *auth.Payload
 	var r1 error
-	if rf, ok := ret.Get(0).(func(http.Context, string) (*auth.Payload, error)); ok {
-		return rf(ctx, token)
+	if rf, ok := ret.Get(0).(func(string) (*auth.Payload, error)); ok {
+		return rf(token)
 	}
-	if rf, ok := ret.Get(0).(func(http.Context, string) *auth.Payload); ok {
-		r0 = rf(ctx, token)
+	if rf, ok := ret.Get(0).(func(string) *auth.Payload); ok {
+		r0 = rf(token)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*auth.Payload)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(http.Context, string) error); ok {
-		r1 = rf(ctx, token)
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(token)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -118,23 +116,23 @@ func (_m *Auth) Parse(ctx http.Context, token string) (*auth.Payload, error) {
 	return r0, r1
 }
 
-// Refresh provides a mock function with given fields: ctx
-func (_m *Auth) Refresh(ctx http.Context) (string, error) {
-	ret := _m.Called(ctx)
+// Refresh provides a mock function with given fields:
+func (_m *Auth) Refresh() (string, error) {
+	ret := _m.Called()
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(http.Context) (string, error)); ok {
-		return rf(ctx)
+	if rf, ok := ret.Get(0).(func() (string, error)); ok {
+		return rf()
 	}
-	if rf, ok := ret.Get(0).(func(http.Context) string); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(http.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -142,13 +140,13 @@ func (_m *Auth) Refresh(ctx http.Context) (string, error) {
 	return r0, r1
 }
 
-// User provides a mock function with given fields: ctx, user
-func (_m *Auth) User(ctx http.Context, user interface{}) error {
-	ret := _m.Called(ctx, user)
+// User provides a mock function with given fields: user
+func (_m *Auth) User(user interface{}) error {
+	ret := _m.Called(user)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(http.Context, interface{}) error); ok {
-		r0 = rf(ctx, user)
+	if rf, ok := ret.Get(0).(func(interface{}) error); ok {
+		r0 = rf(user)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/foundation/Application.go
+++ b/mocks/foundation/Application.go
@@ -207,13 +207,13 @@ func (_m *Application) MakeArtisan() console.Artisan {
 	return r0
 }
 
-// MakeAuth provides a mock function with given fields:
-func (_m *Application) MakeAuth() auth.Auth {
-	ret := _m.Called()
+// MakeAuth provides a mock function with given fields: ctx
+func (_m *Application) MakeAuth(ctx http.Context) auth.Auth {
+	ret := _m.Called(ctx)
 
 	var r0 auth.Auth
-	if rf, ok := ret.Get(0).(func() auth.Auth); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(http.Context) auth.Auth); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(auth.Auth)

--- a/mocks/foundation/Container.go
+++ b/mocks/foundation/Container.go
@@ -113,13 +113,13 @@ func (_m *Container) MakeArtisan() console.Artisan {
 	return r0
 }
 
-// MakeAuth provides a mock function with given fields:
-func (_m *Container) MakeAuth() auth.Auth {
-	ret := _m.Called()
+// MakeAuth provides a mock function with given fields: ctx
+func (_m *Container) MakeAuth(ctx http.Context) auth.Auth {
+	ret := _m.Called(ctx)
 
 	var r0 auth.Auth
-	if rf, ok := ret.Get(0).(func() auth.Auth); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(http.Context) auth.Auth); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(auth.Auth)


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes https://github.com/goravel/goravel/issues/329

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
