### PR TITLE
fix: copy nested directories when using app.Publishes

### DIFF
--- a/foundation/console/vendor_publish_command.go
+++ b/foundation/console/vendor_publish_command.go
@@ -155,19 +155,28 @@ func (receiver *VendorPublishCommand) packageDir(packageName string) (string, er
 
 func (receiver *VendorPublishCommand) publish(sourcePath, targetPath string, existing, force bool) (map[string]string, error) {
 	result := make(map[string]string)
+	isTargetPathDir := filepath.Ext(targetPath) == ""
+	isSourcePathDir := filepath.Ext(sourcePath) == ""
+
 	sourceFiles, err := receiver.getSourceFiles(sourcePath)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, sourceFile := range sourceFiles {
-		targetFile := targetPath
-		if filepath.Ext(targetFile) == "" {
-			sourceRelativePath, err := filepath.Rel(sourcePath, sourceFile)
+		relativePath := ""
+		if isSourcePathDir {
+			relativePath, err = filepath.Rel(sourcePath, sourceFile)
 			if err != nil {
 				return nil, err
 			}
-			targetFile = filepath.Join(targetFile, sourceRelativePath)
+		} else {
+			relativePath = filepath.Base(sourcePath)
+		}
+
+		targetFile := targetPath
+		if isTargetPathDir {
+			targetFile = filepath.Join(targetPath, relativePath)
 		}
 
 		success, err := receiver.publishFile(sourceFile, targetFile, existing, force)

--- a/foundation/console/vendor_publish_command.go
+++ b/foundation/console/vendor_publish_command.go
@@ -155,28 +155,19 @@ func (receiver *VendorPublishCommand) packageDir(packageName string) (string, er
 
 func (receiver *VendorPublishCommand) publish(sourcePath, targetPath string, existing, force bool) (map[string]string, error) {
 	result := make(map[string]string)
-	sourcePathStat, err := os.Stat(sourcePath)
+	sourceFiles, err := receiver.getSourceFiles(sourcePath)
 	if err != nil {
 		return nil, err
-	}
-
-	var sourceFiles []string
-	if sourcePathStat.IsDir() {
-		fileInfos, err := os.ReadDir(sourcePath)
-		if err != nil {
-			return nil, err
-		}
-		for _, fileInfo := range fileInfos {
-			sourceFiles = append(sourceFiles, filepath.Join(sourcePath, fileInfo.Name()))
-		}
-	} else {
-		sourceFiles = append(sourceFiles, sourcePath)
 	}
 
 	for _, sourceFile := range sourceFiles {
 		targetFile := targetPath
 		if filepath.Ext(targetFile) == "" {
-			targetFile = filepath.Join(targetFile, filepath.Base(sourceFile))
+			sourceRelativePath, err := filepath.Rel(sourcePath, sourceFile)
+			if err != nil {
+				return nil, err
+			}
+			targetFile = filepath.Join(targetFile, sourceRelativePath)
 		}
 
 		success, err := receiver.publishFile(sourceFile, targetFile, existing, force)
@@ -189,6 +180,42 @@ func (receiver *VendorPublishCommand) publish(sourcePath, targetPath string, exi
 	}
 
 	return result, nil
+}
+
+func (receiver *VendorPublishCommand) getSourceFiles(sourcePath string) ([]string, error) {
+	sourcePathStat, err := os.Stat(sourcePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if sourcePathStat.IsDir() {
+		return receiver.getSourceFilesForDir(sourcePath)
+	} else {
+		return []string{sourcePath}, nil
+	}
+}
+
+func (receiver *VendorPublishCommand) getSourceFilesForDir(sourcePath string) ([]string, error) {
+	dirEntries, err := os.ReadDir(sourcePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var sourceFiles []string
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() {
+			sourcePaths, err := receiver.getSourceFilesForDir(filepath.Join(sourcePath, dirEntry.Name()))
+			if err != nil {
+				return nil, err
+			}
+
+			sourceFiles = append(sourceFiles, sourcePaths...)
+		} else {
+			sourceFiles = append(sourceFiles, filepath.Join(sourcePath, dirEntry.Name()))
+		}
+	}
+
+	return sourceFiles, nil
 }
 
 func (receiver *VendorPublishCommand) publishFile(sourceFile, targetFile string, existing, force bool) (bool, error) {


### PR DESCRIPTION
Closes # [Issue 345](https://github.com/goravel/goravel/issues/345)

## 📑 Description
This will support copy of nested directories when needed with app.Publishes() as used by goravel/gateway [here](https://github.com/goravel/gateway/blob/e5d47620fb9b542eae104333f60eaac6e426014b/service_provider.go#L31)

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
