### PR TITLE
fix: [#388] [Bug] data error when calling facades.Auth().Parse() multiple times with different guard

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -229,9 +229,15 @@ func (a *Auth) Logout(ctx http.Context) error {
 }
 
 func (a *Auth) makeAuthContext(ctx http.Context, claims *Claims, token string) {
-	ctx.WithValue(ctxKey, Guards{
-		a.guard: {claims, token},
-	})
+	guards := ctx.Value(ctxKey)
+	if g, ok := guards.(Guards); ok {
+		g[a.guard] = &Guard{claims, token}
+		ctx.WithValue(ctxKey, g)
+	} else {
+		ctx.WithValue(ctxKey, Guards{
+			a.guard: {claims, token},
+		})
+	}
 }
 
 func (a *Auth) tokenIsDisabled(token string) bool {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -229,15 +229,12 @@ func (a *Auth) Logout(ctx http.Context) error {
 }
 
 func (a *Auth) makeAuthContext(ctx http.Context, claims *Claims, token string) {
-	guards := ctx.Value(ctxKey)
-	if g, ok := guards.(Guards); ok {
-		g[a.guard] = &Guard{claims, token}
-		ctx.WithValue(ctxKey, g)
-	} else {
-		ctx.WithValue(ctxKey, Guards{
-			a.guard: {claims, token},
-		})
+	guards, ok := ctx.Value(ctxKey).(Guards)
+	if !ok {
+		guards = make(Guards)
 	}
+	guards[a.guard] = &Guard{claims, token}
+	ctx.WithValue(ctxKey, guards)
 }
 
 func (a *Auth) tokenIsDisabled(token string) bool {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes https://github.com/goravel/goravel/issues/388

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
