### PR TITLE
fix: The traces don't cleaned when calling Log.Info after Log.Error

### DIFF
--- a/log/logrus_writer.go
+++ b/log/logrus_writer.go
@@ -35,8 +35,7 @@ type Writer struct {
 	stackEnabled bool
 	stacktrace   map[string]any
 
-	tags  []string
-	trace string
+	tags []string
 
 	// user
 	user any
@@ -63,8 +62,7 @@ func NewWriter(instance *logrus.Entry) log.Writer {
 		stackEnabled: false,
 		stacktrace:   nil,
 
-		tags:  []string{},
-		trace: "",
+		tags: []string{},
 
 		// user
 		user: nil,
@@ -203,6 +201,22 @@ func (r *Writer) withStackTrace(message string) {
 	r.stackEnabled = true
 }
 
+// resetAll resets all properties of the log.Writer for a new log entry.
+func (r *Writer) resetAll() {
+	r.code = ""
+	r.context = map[string]any{}
+	r.domain = ""
+	r.hint = ""
+	r.message = ""
+	r.owner = nil
+	r.request = nil
+	r.response = nil
+	r.tags = []string{}
+	r.user = nil
+	r.stacktrace = nil
+	r.stackEnabled = false
+}
+
 // ToMap returns a map representation of the error.
 func (r *Writer) toMap() map[string]any {
 	payload := map[string]any{}
@@ -225,10 +239,6 @@ func (r *Writer) toMap() map[string]any {
 
 	if context := r.context; len(context) > 0 {
 		payload["context"] = context
-	}
-
-	if trace := r.trace; trace != "" {
-		payload["trace"] = trace
 	}
 
 	if hint := r.hint; hint != "" {
@@ -264,6 +274,9 @@ func (r *Writer) toMap() map[string]any {
 	if stacktrace := r.stacktrace; stacktrace != nil || r.stackEnabled {
 		payload["stacktrace"] = stacktrace
 	}
+
+	// reset all properties for a new log entry
+	r.resetAll()
 
 	return payload
 }

--- a/log/logrus_writer_test.go
+++ b/log/logrus_writer_test.go
@@ -342,6 +342,24 @@ func TestLogrus(t *testing.T) {
 				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ncontext: {\"key\":\"value\"}"))
 			},
 		},
+		{
+			name: "No traces when calling Info after Error",
+			setup: func() {
+				mockDriverConfig(mockConfig)
+
+				log = NewApplication(mockConfig)
+				log.Error("test error")
+				log.Info("test info")
+			},
+			assert: func() {
+				assert.True(t, file.Contain(singleLog, "test.error: test error\ntrace:"))
+				assert.True(t, file.Contain(singleLog, "test.info: test info"))
+				assert.False(t, file.Contain(dailyLog, "test.info: test info\ntrace:"))
+				assert.True(t, file.Contain(dailyLog, "test.error: test error"))
+				assert.True(t, file.Contain(dailyLog, "test.info: test info"))
+				assert.False(t, file.Contain(singleLog, "test.info: test info\ntrace:"))
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Closes https://github.com/goravel/goravel/issues/402

## 📑 Description
![image](https://github.com/goravel/framework/assets/84431594/208f3e56-688e-4494-a328-f6aa12b93c4d)
![image](https://github.com/goravel/framework/assets/84431594/9981bb86-3448-4c1b-a181-fcf445d79a05)

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
