### PR TITLE
fix: translation issue

### DIFF
--- a/translation/service_provider.go
+++ b/translation/service_provider.go
@@ -25,7 +25,7 @@ func (translation *ServiceProvider) Register(app foundation.Application) {
 		fallback := config.GetString("app.fallback_locale")
 		loader := NewFileLoader([]string{filepath.Join(executable, "lang")}, app.GetJson())
 		trans := NewTranslator(parameters["ctx"].(context.Context), loader, locale, fallback, logger)
-		trans.SetLocale(locale)
+
 		return trans, nil
 	})
 }

--- a/translation/translator_test.go
+++ b/translation/translator_test.go
@@ -240,7 +240,9 @@ func (t *TranslatorTestSuite) TestGetLocale() {
 	t.Equal("en", locale)
 
 	// Case: Set locale using SetLocale and then get it
-	translator.SetLocale("fr")
+	ctx := translator.SetLocale("fr")
+
+	translator = NewTranslator(ctx, t.mockLoader, "en", "en", t.mockLog)
 	locale = translator.CurrentLocale()
 	t.Equal("fr", locale)
 }


### PR DESCRIPTION
## 📑 Description

<!-- Add a brief description of the pr -->
<!-- Please add the Review Ready tag when the PR is good to go -->

There is an issue when calling `facades.Lang().SetLocale` in middle, `facades.Lang().CurrentLocale()` still returns the default locale in controller.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
