### PR TITLE
feat: optimize the ctx parameter

### DIFF
--- a/contracts/route/route.go
+++ b/contracts/route/route.go
@@ -1,6 +1,7 @@
 package route
 
 import (
+	"context"
 	"net/http"
 
 	contractshttp "github.com/goravel/framework/contracts/http"
@@ -23,7 +24,7 @@ type Route interface {
 	// ServeHTTP serves HTTP requests.
 	ServeHTTP(writer http.ResponseWriter, request *http.Request)
 	// Shutdown gracefully shuts down the serve.
-	Shutdown() error
+	Shutdown(ctx ...context.Context) error
 }
 
 type Router interface {

--- a/contracts/route/route.go
+++ b/contracts/route/route.go
@@ -1,7 +1,6 @@
 package route
 
 import (
-	"context"
 	"net/http"
 
 	contractshttp "github.com/goravel/framework/contracts/http"
@@ -23,8 +22,8 @@ type Route interface {
 	RunTLSWithCert(host, certFile, keyFile string) error
 	// ServeHTTP serves HTTP requests.
 	ServeHTTP(writer http.ResponseWriter, request *http.Request)
-	// Shutdown gracefully shuts down the serve.If the provided context expires before the shutdown is complete, Shutdown returns the context's error.
-	Shutdown(ctx context.Context) error
+	// Shutdown gracefully shuts down the serve.
+	Shutdown() error
 }
 
 type Router interface {

--- a/mocks/route/Route.go
+++ b/mocks/route/Route.go
@@ -3,6 +3,8 @@
 package route
 
 import (
+	context "context"
+
 	http "github.com/goravel/framework/contracts/http"
 	mock "github.com/stretchr/testify/mock"
 
@@ -717,17 +719,23 @@ func (_c *Route_ServeHTTP_Call) RunAndReturn(run func(nethttp.ResponseWriter, *n
 	return _c
 }
 
-// Shutdown provides a mock function with given fields:
-func (_m *Route) Shutdown() error {
-	ret := _m.Called()
+// Shutdown provides a mock function with given fields: ctx
+func (_m *Route) Shutdown(ctx ...context.Context) error {
+	_va := make([]interface{}, len(ctx))
+	for _i := range ctx {
+		_va[_i] = ctx[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Shutdown")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(...context.Context) error); ok {
+		r0 = rf(ctx...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -741,13 +749,21 @@ type Route_Shutdown_Call struct {
 }
 
 // Shutdown is a helper method to define mock.On call
-func (_e *Route_Expecter) Shutdown() *Route_Shutdown_Call {
-	return &Route_Shutdown_Call{Call: _e.mock.On("Shutdown")}
+//   - ctx ...context.Context
+func (_e *Route_Expecter) Shutdown(ctx ...interface{}) *Route_Shutdown_Call {
+	return &Route_Shutdown_Call{Call: _e.mock.On("Shutdown",
+		append([]interface{}{}, ctx...)...)}
 }
 
-func (_c *Route_Shutdown_Call) Run(run func()) *Route_Shutdown_Call {
+func (_c *Route_Shutdown_Call) Run(run func(ctx ...context.Context)) *Route_Shutdown_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		variadicArgs := make([]context.Context, len(args)-0)
+		for i, a := range args[0:] {
+			if a != nil {
+				variadicArgs[i] = a.(context.Context)
+			}
+		}
+		run(variadicArgs...)
 	})
 	return _c
 }
@@ -757,7 +773,7 @@ func (_c *Route_Shutdown_Call) Return(_a0 error) *Route_Shutdown_Call {
 	return _c
 }
 
-func (_c *Route_Shutdown_Call) RunAndReturn(run func() error) *Route_Shutdown_Call {
+func (_c *Route_Shutdown_Call) RunAndReturn(run func(...context.Context) error) *Route_Shutdown_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/route/Route.go
+++ b/mocks/route/Route.go
@@ -3,8 +3,6 @@
 package route
 
 import (
-	context "context"
-
 	http "github.com/goravel/framework/contracts/http"
 	mock "github.com/stretchr/testify/mock"
 
@@ -719,17 +717,17 @@ func (_c *Route_ServeHTTP_Call) RunAndReturn(run func(nethttp.ResponseWriter, *n
 	return _c
 }
 
-// Shutdown provides a mock function with given fields: ctx
-func (_m *Route) Shutdown(ctx context.Context) error {
-	ret := _m.Called(ctx)
+// Shutdown provides a mock function with given fields:
+func (_m *Route) Shutdown() error {
+	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for Shutdown")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -743,14 +741,13 @@ type Route_Shutdown_Call struct {
 }
 
 // Shutdown is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *Route_Expecter) Shutdown(ctx interface{}) *Route_Shutdown_Call {
-	return &Route_Shutdown_Call{Call: _e.mock.On("Shutdown", ctx)}
+func (_e *Route_Expecter) Shutdown() *Route_Shutdown_Call {
+	return &Route_Shutdown_Call{Call: _e.mock.On("Shutdown")}
 }
 
-func (_c *Route_Shutdown_Call) Run(run func(ctx context.Context)) *Route_Shutdown_Call {
+func (_c *Route_Shutdown_Call) Run(run func()) *Route_Shutdown_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		run()
 	})
 	return _c
 }
@@ -760,7 +757,7 @@ func (_c *Route_Shutdown_Call) Return(_a0 error) *Route_Shutdown_Call {
 	return _c
 }
 
-func (_c *Route_Shutdown_Call) RunAndReturn(run func(context.Context) error) *Route_Shutdown_Call {
+func (_c *Route_Shutdown_Call) RunAndReturn(run func() error) *Route_Shutdown_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## 📑 Description

The ctx is unnecessary, change it to `...context.Context`. @zxdstyle

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->
