### PR TITLE
feat: extension the Create method of Orm

### DIFF
--- a/database/gorm/event_test.go
+++ b/database/gorm/event_test.go
@@ -83,6 +83,7 @@ func (s *EventTestSuite) SetupTest() {
 }
 
 func (s *EventTestSuite) TestSetAttribute() {
+	// dest is map
 	dest := map[string]any{"avatar": "avatar1"}
 	query := &QueryImpl{
 		instance: &gorm.DB{
@@ -104,6 +105,34 @@ func (s *EventTestSuite) TestSetAttribute() {
 
 	event.SetAttribute("Avatar", "avatar2")
 	avatar := event.GetAttribute("Avatar")
+	s.Equal("avatar2", avatar)
+	avatar = event.GetAttribute("avatar")
+	s.Equal("avatar2", avatar)
+
+	// dest is struct
+	dest1 := &TestEventModel{
+		Avatar: "avatar1",
+	}
+	query1 := &QueryImpl{
+		instance: &gorm.DB{
+			Statement: &gorm.Statement{
+				Selects: []string{},
+				Omits:   []string{},
+				Dest:    dest1,
+			},
+		},
+	}
+
+	event = NewEvent(query1, &testEventModel, dest1)
+
+	event.SetAttribute("Name", "name1")
+	name = event.GetAttribute("Name")
+	s.Equal(name, "name1")
+	name = event.GetAttribute("name")
+	s.Equal(name, "name1")
+
+	event.SetAttribute("Avatar", "avatar2")
+	avatar = event.GetAttribute("Avatar")
 	s.Equal("avatar2", avatar)
 	avatar = event.GetAttribute("avatar")
 	s.Equal("avatar2", avatar)

--- a/database/gorm/query.go
+++ b/database/gorm/query.go
@@ -1206,8 +1206,8 @@ func (r *QueryImpl) event(event ormcontract.EventType, model, dest any) error {
 	}
 	if model != nil {
 		if dispatchesEvents, exist := model.(ormcontract.DispatchesEvents); exist {
-			if e, exists := dispatchesEvents.DispatchesEvents()[event]; exists {
-				return e(instance)
+			if dispatchesEvent, exists := dispatchesEvents.DispatchesEvents()[event]; exists {
+				return dispatchesEvent(instance)
 			}
 
 			return nil
@@ -1215,17 +1215,17 @@ func (r *QueryImpl) event(event ormcontract.EventType, model, dest any) error {
 	}
 
 	if observer := getObserver(dest); observer != nil {
-		if e := observerEvent(event, observer); e != nil {
-			return e(instance)
+		if observerEvent := getObserverEvent(event, observer); observerEvent != nil {
+			return observerEvent(instance)
 		}
 
 		return nil
 	}
 
 	if model != nil {
-		if o := getObserver(model); o != nil {
-			if e := observerEvent(event, o); e != nil {
-				return e(instance)
+		if observer := getObserver(model); observer != nil {
+			if observerEvent := getObserverEvent(event, observer); observerEvent != nil {
+				return observerEvent(instance)
 			}
 
 			return nil
@@ -1519,7 +1519,7 @@ func getObserver(dest any) ormcontract.Observer {
 	return nil
 }
 
-func observerEvent(event ormcontract.EventType, observer ormcontract.Observer) func(ormcontract.Event) error {
+func getObserverEvent(event ormcontract.EventType, observer ormcontract.Observer) func(ormcontract.Event) error {
 	switch event {
 	case ormcontract.EventRetrieved:
 		return observer.Retrieved

--- a/database/gorm/query.go
+++ b/database/gorm/query.go
@@ -1198,8 +1198,8 @@ func (r *QueryImpl) event(event ormcontract.EventType, model, dest any) error {
 	instance := NewEvent(r, model, dest)
 
 	if dispatchesEvents, exist := dest.(ormcontract.DispatchesEvents); exist {
-		if e, exists := dispatchesEvents.DispatchesEvents()[event]; exists {
-			return e(instance)
+		if dispatchesEvent, exists := dispatchesEvents.DispatchesEvents()[event]; exists {
+			return dispatchesEvent(instance)
 		}
 
 		return nil
@@ -1214,8 +1214,8 @@ func (r *QueryImpl) event(event ormcontract.EventType, model, dest any) error {
 		}
 	}
 
-	if o := observer(dest); o != nil {
-		if e := observerEvent(event, o); e != nil {
+	if observer := getObserver(dest); observer != nil {
+		if e := observerEvent(event, observer); e != nil {
 			return e(instance)
 		}
 
@@ -1223,7 +1223,7 @@ func (r *QueryImpl) event(event ormcontract.EventType, model, dest any) error {
 	}
 
 	if model != nil {
-		if o := observer(model); o != nil {
+		if o := getObserver(model); o != nil {
 			if e := observerEvent(event, o); e != nil {
 				return e(instance)
 			}
@@ -1500,7 +1500,7 @@ func getModelConnection(model any) (string, error) {
 	return connectionModel.Connection(), nil
 }
 
-func observer(dest any) ormcontract.Observer {
+func getObserver(dest any) ormcontract.Observer {
 	destType := reflect.TypeOf(dest)
 	if destType.Kind() == reflect.Pointer {
 		destType = destType.Elem()

--- a/database/gorm/query_test.go
+++ b/database/gorm/query_test.go
@@ -3559,8 +3559,8 @@ func TestObserver(t *testing.T) {
 		Observer: &UserObserver{},
 	})
 
-	assert.Nil(t, observer(Product{}))
-	assert.Equal(t, &UserObserver{}, observer(User{}))
+	assert.Nil(t, getObserver(Product{}))
+	assert.Equal(t, &UserObserver{}, getObserver(User{}))
 }
 
 func TestObserverEvent(t *testing.T) {

--- a/database/gorm/query_test.go
+++ b/database/gorm/query_test.go
@@ -3564,18 +3564,18 @@ func TestObserver(t *testing.T) {
 }
 
 func TestObserverEvent(t *testing.T) {
-	assert.EqualError(t, observerEvent(contractsorm.EventRetrieved, &UserObserver{})(nil), "retrieved")
-	assert.EqualError(t, observerEvent(contractsorm.EventCreating, &UserObserver{})(nil), "creating")
-	assert.EqualError(t, observerEvent(contractsorm.EventCreated, &UserObserver{})(nil), "created")
-	assert.EqualError(t, observerEvent(contractsorm.EventUpdating, &UserObserver{})(nil), "updating")
-	assert.EqualError(t, observerEvent(contractsorm.EventUpdated, &UserObserver{})(nil), "updated")
-	assert.EqualError(t, observerEvent(contractsorm.EventSaving, &UserObserver{})(nil), "saving")
-	assert.EqualError(t, observerEvent(contractsorm.EventSaved, &UserObserver{})(nil), "saved")
-	assert.EqualError(t, observerEvent(contractsorm.EventDeleting, &UserObserver{})(nil), "deleting")
-	assert.EqualError(t, observerEvent(contractsorm.EventDeleted, &UserObserver{})(nil), "deleted")
-	assert.EqualError(t, observerEvent(contractsorm.EventForceDeleting, &UserObserver{})(nil), "forceDeleting")
-	assert.EqualError(t, observerEvent(contractsorm.EventForceDeleted, &UserObserver{})(nil), "forceDeleted")
-	assert.Nil(t, observerEvent("error", &UserObserver{}))
+	assert.EqualError(t, getObserverEvent(contractsorm.EventRetrieved, &UserObserver{})(nil), "retrieved")
+	assert.EqualError(t, getObserverEvent(contractsorm.EventCreating, &UserObserver{})(nil), "creating")
+	assert.EqualError(t, getObserverEvent(contractsorm.EventCreated, &UserObserver{})(nil), "created")
+	assert.EqualError(t, getObserverEvent(contractsorm.EventUpdating, &UserObserver{})(nil), "updating")
+	assert.EqualError(t, getObserverEvent(contractsorm.EventUpdated, &UserObserver{})(nil), "updated")
+	assert.EqualError(t, getObserverEvent(contractsorm.EventSaving, &UserObserver{})(nil), "saving")
+	assert.EqualError(t, getObserverEvent(contractsorm.EventSaved, &UserObserver{})(nil), "saved")
+	assert.EqualError(t, getObserverEvent(contractsorm.EventDeleting, &UserObserver{})(nil), "deleting")
+	assert.EqualError(t, getObserverEvent(contractsorm.EventDeleted, &UserObserver{})(nil), "deleted")
+	assert.EqualError(t, getObserverEvent(contractsorm.EventForceDeleting, &UserObserver{})(nil), "forceDeleting")
+	assert.EqualError(t, getObserverEvent(contractsorm.EventForceDeleted, &UserObserver{})(nil), "forceDeleted")
+	assert.Nil(t, getObserverEvent("error", &UserObserver{}))
 }
 
 func TestReadWriteSeparate(t *testing.T) {

--- a/database/gorm/test_models.go
+++ b/database/gorm/test_models.go
@@ -34,8 +34,20 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 				if name.(string) == "event_creating_name" {
 					event.SetAttribute("avatar", "event_creating_avatar")
 				}
+				if name.(string) == "event_creating_by_map_name" {
+					event.SetAttribute("avatar", "event_creating_by_map_avatar1")
+				}
 				if name.(string) == "event_creating_FirstOrCreate_name" {
 					event.SetAttribute("avatar", "event_creating_FirstOrCreate_avatar")
+				}
+				if name.(string) == "event_creating_omit_create_name" {
+					event.SetAttribute("avatar", "event_creating_omit_create_avatar")
+				}
+				if name.(string) == "event_creating_select_create_name" {
+					event.SetAttribute("avatar", "event_creating_select_create_avatar")
+				}
+				if name.(string) == "event_creating_save_name" {
+					event.SetAttribute("avatar", "event_creating_save_avatar")
 				}
 				if name.(string) == "event_creating_IsDirty_name" {
 					if event.IsDirty("name") {
@@ -60,9 +72,24 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 					id := event.GetAttribute("ID")
 					event.SetAttribute("avatar", fmt.Sprintf("event_created_avatar_%d", id))
 				}
+				if name.(string) == "event_created_by_map_name" {
+					event.SetAttribute("avatar", fmt.Sprintf("event_created_by_map_avatar1"))
+				}
 				if name.(string) == "event_created_FirstOrCreate_name" {
 					id := event.GetAttribute("ID")
 					event.SetAttribute("avatar", fmt.Sprintf("event_created_FirstOrCreate_avatar_%d", id))
+				}
+				if name.(string) == "event_created_omit_create_name" {
+					id := event.GetAttribute("ID")
+					event.SetAttribute("avatar", fmt.Sprintf("event_created_omit_create_avatar_%d", id))
+				}
+				if name.(string) == "event_created_select_create_name" {
+					id := event.GetAttribute("ID")
+					event.SetAttribute("avatar", fmt.Sprintf("event_created_select_create_avatar_%d", id))
+				}
+				if name.(string) == "event_created_save_name" {
+					id := event.GetAttribute("ID")
+					event.SetAttribute("avatar", fmt.Sprintf("event_created_save_avatar_%d", id))
 				}
 			}
 
@@ -75,11 +102,20 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 				if name == "event_saving_create_name" {
 					event.SetAttribute("avatar", "event_saving_create_avatar")
 				}
+				if name == "event_saving_create_by_map_name" {
+					event.SetAttribute("avatar", "event_saving_create_by_map_avatar1")
+				}
 				if name == "event_saving_save_name" {
 					event.SetAttribute("avatar", "event_saving_save_avatar")
 				}
 				if name == "event_saving_FirstOrCreate_name" {
 					event.SetAttribute("avatar", "event_saving_FirstOrCreate_avatar")
+				}
+				if name == "event_saving_omit_create_name" {
+					event.SetAttribute("avatar", "event_saving_omit_create_avatar")
+				}
+				if name == "event_saving_select_create_name" {
+					event.SetAttribute("avatar", "event_saving_select_create_avatar")
 				}
 				if name == "event_save_without_name" {
 					event.SetAttribute("avatar", "event_save_without_avatar")
@@ -107,6 +143,15 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 			case string:
 				if name == "event_saved_create_name" {
 					event.SetAttribute("avatar", "event_saved_create_avatar")
+				}
+				if name == "event_saved_create_by_map_name" {
+					event.SetAttribute("avatar", "event_saved_create_by_map_avatar1")
+				}
+				if name == "event_saved_omit_create_name" {
+					event.SetAttribute("avatar", "event_saved_omit_create_avatar")
+				}
+				if name == "event_saved_select_create_name" {
+					event.SetAttribute("avatar", "event_saved_select_create_avatar")
 				}
 				if name == "event_saved_save_name" {
 					event.SetAttribute("avatar", "event_saved_save_avatar")

--- a/database/gorm/test_models.go
+++ b/database/gorm/test_models.go
@@ -73,7 +73,7 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 					event.SetAttribute("avatar", fmt.Sprintf("event_created_avatar_%d", id))
 				}
 				if name.(string) == "event_created_by_map_name" {
-					event.SetAttribute("avatar", fmt.Sprintf("event_created_by_map_avatar1"))
+					event.SetAttribute("avatar", "event_created_by_map_avatar1")
 				}
 				if name.(string) == "event_created_FirstOrCreate_name" {
 					id := event.GetAttribute("ID")


### PR DESCRIPTION
## 📑 Description

The `Create` method of Orm supports map:

```
// Not trigger model events
facades.Orm().Query().Table("users").Create(map[string]any{
  "name": "Goravel",
})

// Trigger model events
facades.Orm().Query().Model(&models.User{}).Create(map[string]any{
  "name": "Goravel",
})
```

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced testing capabilities for attribute setting and retrieval using different data structures (maps and structs).
	- Expanded event handling in the `User` struct to accommodate various event names and set corresponding attributes.

- **Bug Fixes**
	- Improved test coverage for user creation scenarios, ensuring correct handling of IDs and timestamps.

- **Refactor**
	- Simplified method signatures and improved clarity in the `QueryImpl` struct methods.

- **Tests**
	- Added new test cases and modified existing ones to cover more scenarios and ensure expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
