### PR TITLE
feat: Optimize the Delete and ForceDelete methods of Orm

### DIFF
--- a/contracts/database/orm/events.go
+++ b/contracts/database/orm/events.go
@@ -25,10 +25,10 @@ type Event interface {
 	GetAttribute(key string) any
 	// GetOriginal returns the original attribute value for the given key.
 	GetOriginal(key string, def ...any) any
-	// IsDirty returns true if the given column is dirty.
-	IsDirty(columns ...string) bool
 	// IsClean returns true if the given column is clean.
 	IsClean(columns ...string) bool
+	// IsDirty returns true if the given column is dirty.
+	IsDirty(columns ...string) bool
 	// Query returns the query instance.
 	Query() Query
 	// SetAttribute sets the attribute value for the given key.

--- a/contracts/database/orm/orm.go
+++ b/contracts/database/orm/orm.go
@@ -36,7 +36,7 @@ type Query interface {
 	// Cursor returns a cursor, use scan to iterate over the returned rows.
 	Cursor() (chan Cursor, error)
 	// Delete deletes records matching given conditions, if the conditions are empty will delete all records.
-	Delete(value any, conds ...any) (*Result, error)
+	Delete(value ...any) (*Result, error)
 	// Distinct specifies distinct fields to query.
 	Distinct(args ...any) Query
 	// Driver gets the driver for the query.
@@ -63,7 +63,7 @@ type Query interface {
 	// return a new instance of the model initialized with those attributes.
 	FirstOrNew(dest any, attributes any, values ...any) error
 	// ForceDelete forces delete records matching given conditions.
-	ForceDelete(value any, conds ...any) (*Result, error)
+	ForceDelete(value ...any) (*Result, error)
 	// Get retrieves all rows from the database.
 	Get(dest any) error
 	// Group specifies the group method on the query.

--- a/contracts/database/orm/orm.go
+++ b/contracts/database/orm/orm.go
@@ -193,9 +193,10 @@ type Result struct {
 type ToSql interface {
 	Count() string
 	Create(value any) string
-	Delete(value any, conds ...any) string
+	Delete(value ...any) string
 	Find(dest any, conds ...any) string
 	First(dest any) string
+	ForceDelete(value ...any) string
 	Get(dest any) string
 	Pluck(column string, dest any) string
 	Save(value any) string

--- a/database/gorm/event.go
+++ b/database/gorm/event.go
@@ -45,6 +45,9 @@ func (e *Event) Context() context.Context {
 }
 
 func (e *Event) DestOfMap() map[string]any {
+	if e.dest == nil {
+		return nil
+	}
 	if e.destOfMap != nil {
 		return e.destOfMap
 	}
@@ -148,6 +151,10 @@ func (e *Event) Query() orm.Query {
 }
 
 func (e *Event) SetAttribute(key string, value any) {
+	if e.dest == nil {
+		return
+	}
+
 	destOfMap := e.DestOfMap()
 	destOfMap[e.toDBColumnName(key)] = value
 	e.destOfMap = destOfMap

--- a/database/gorm/event_test.go
+++ b/database/gorm/event_test.go
@@ -333,7 +333,7 @@ func (s *EventTestSuite) TestColumnNames() {
 			"admin_at":   "admin_at",
 			"ManageAt":   "manage_at",
 			"manage_at":  "manage_at",
-		}, event.ColumnNames())
+		}, event.getColumnNames())
 	}
 }
 

--- a/database/gorm/query.go
+++ b/database/gorm/query.go
@@ -362,7 +362,7 @@ func (r *QueryImpl) ForceDelete(dest ...any) (*ormcontract.Result, error) {
 
 	if len(dest) > 0 {
 		realDest = dest[0]
-		query, err = r.refreshConnection(realDest)
+		query, err = query.refreshConnection(realDest)
 		if err != nil {
 			return nil, err
 		}

--- a/database/gorm/query_test.go
+++ b/database/gorm/query_test.go
@@ -681,6 +681,38 @@ func (s *QueryTestSuite) TestDelete() {
 				},
 			},
 			{
+				name: "success by table",
+				setup: func() {
+					user := User{Name: "delete_user_by_table", Avatar: "delete_avatar_by_table"}
+					s.Nil(query.Create(&user))
+					s.True(user.ID > 0)
+
+					res, err := query.Table("users").Where("name", "delete_user_by_table").Delete()
+					s.Equal(int64(1), res.RowsAffected)
+					s.Nil(err)
+
+					var user1 User
+					s.Nil(query.Find(&user1, user.ID))
+					s.Equal(uint(0), user1.ID)
+				},
+			},
+			{
+				name: "success by model",
+				setup: func() {
+					user := User{Name: "delete_user_by_model", Avatar: "delete_avatar_by_model"}
+					s.Nil(query.Create(&user))
+					s.True(user.ID > 0)
+
+					res, err := query.Model(&User{}).Where("name", "delete_user_by_model").Delete()
+					s.Equal(int64(1), res.RowsAffected)
+					s.Nil(err)
+
+					var user1 User
+					s.Nil(query.Find(&user1, user.ID))
+					s.Equal(uint(0), user1.ID)
+				},
+			},
+			{
 				name: "success when refresh connection",
 				setup: func() {
 					user := User{Name: "delete_user", Avatar: "delete_avatar"}
@@ -1936,6 +1968,42 @@ func (s *QueryTestSuite) TestForceDelete() {
 					s.Equal(int64(1), res.RowsAffected)
 					s.Nil(err)
 					s.Equal("force_delete_name", user.Name)
+
+					var user1 User
+					s.Nil(query.WithTrashed().Find(&user1, user.ID))
+					s.Equal(uint(0), user1.ID)
+				},
+			},
+			{
+				name: "success by table",
+				setup: func() {
+					user := User{Name: "force_delete_name_by_table"}
+					s.Nil(query.Create(&user))
+					s.True(user.ID > 0)
+					s.Equal("force_delete_name_by_table", user.Name)
+
+					res, err := query.Table("users").Where("name = ?", "force_delete_name_by_table").ForceDelete()
+					s.Equal(int64(1), res.RowsAffected)
+					s.Nil(err)
+					s.Equal("force_delete_name_by_table", user.Name)
+
+					var user1 User
+					s.Nil(query.WithTrashed().Find(&user1, user.ID))
+					s.Equal(uint(0), user1.ID)
+				},
+			},
+			{
+				name: "success by model",
+				setup: func() {
+					user := User{Name: "force_delete_name_by_model"}
+					s.Nil(query.Create(&user))
+					s.True(user.ID > 0)
+					s.Equal("force_delete_name_by_model", user.Name)
+
+					res, err := query.Model(&User{}).Where("name = ?", "force_delete_name_by_model").ForceDelete()
+					s.Equal(int64(1), res.RowsAffected)
+					s.Nil(err)
+					s.Equal("force_delete_name_by_model", user.Name)
 
 					var user1 User
 					s.Nil(query.WithTrashed().Find(&user1, user.ID))

--- a/database/gorm/query_test.go
+++ b/database/gorm/query_test.go
@@ -42,19 +42,19 @@ func TestQueryTestSuite(t *testing.T) {
 	testContext = context.Background()
 	testContext = context.WithValue(testContext, testContextKey, "goravel")
 
-	mysqls := supportdocker.Mysqls(2)
-
-	mysqlDocker := NewMysqlDocker(mysqls[0])
-	mysqlQuery, err := mysqlDocker.New()
-	if err != nil {
-		log.Fatalf("Init mysql error: %s", err)
-	}
-
-	mysql1Docker := NewMysqlDocker(mysqls[1])
-	_, err = mysql1Docker.New()
-	if err != nil {
-		log.Fatalf("Init mysql error: %s", err)
-	}
+	//mysqls := supportdocker.Mysqls(2)
+	//
+	//mysqlDocker := NewMysqlDocker(mysqls[0])
+	//mysqlQuery, err := mysqlDocker.New()
+	//if err != nil {
+	//	log.Fatalf("Init mysql error: %s", err)
+	//}
+	//
+	//mysql1Docker := NewMysqlDocker(mysqls[1])
+	//_, err = mysql1Docker.New()
+	//if err != nil {
+	//	log.Fatalf("Init mysql error: %s", err)
+	//}
 
 	postgres := supportdocker.Postgres()
 	postgresDocker := NewPostgresDocker(postgres)
@@ -63,31 +63,31 @@ func TestQueryTestSuite(t *testing.T) {
 		log.Fatalf("Init postgres error: %s", err)
 	}
 
-	sqliteDocker := NewSqliteDocker(supportdocker.Sqlite())
-	sqliteQuery, err := sqliteDocker.New()
-	if err != nil {
-		log.Fatalf("Init sqlite error: %s", err)
-	}
-
-	sqlserverDocker := NewSqlserverDocker(supportdocker.Sqlserver())
-	sqlserverQuery, err := sqlserverDocker.New()
-	if err != nil {
-		log.Fatalf("Init sqlserver error: %s", err)
-	}
+	//sqliteDocker := NewSqliteDocker(supportdocker.Sqlite())
+	//sqliteQuery, err := sqliteDocker.New()
+	//if err != nil {
+	//	log.Fatalf("Init sqlite error: %s", err)
+	//}
+	//
+	//sqlserverDocker := NewSqlserverDocker(supportdocker.Sqlserver())
+	//sqlserverQuery, err := sqlserverDocker.New()
+	//if err != nil {
+	//	log.Fatalf("Init sqlserver error: %s", err)
+	//}
 
 	suite.Run(t, &QueryTestSuite{
 		queries: map[contractsorm.Driver]contractsorm.Query{
-			contractsorm.DriverMysql:     mysqlQuery,
-			contractsorm.DriverPostgres:  postgresQuery,
-			contractsorm.DriverSqlite:    sqliteQuery,
-			contractsorm.DriverSqlserver: sqlserverQuery,
+			//contractsorm.DriverMysql:     mysqlQuery,
+			contractsorm.DriverPostgres: postgresQuery,
+			//contractsorm.DriverSqlite:    sqliteQuery,
+			//contractsorm.DriverSqlserver: sqlserverQuery,
 		},
-		mysqlDocker:     mysqlDocker,
-		mysql1:          mysqls[1],
-		postgres:        postgres,
-		postgresDocker:  postgresDocker,
-		sqliteDocker:    sqliteDocker,
-		sqlserverDocker: sqlserverDocker,
+		//mysqlDocker:     mysqlDocker,
+		//mysql1:          mysqls[1],
+		postgres:       postgres,
+		postgresDocker: postgresDocker,
+		//sqliteDocker:    sqliteDocker,
+		//sqlserverDocker: sqlserverDocker,
 	})
 }
 
@@ -659,7 +659,7 @@ func (s *QueryTestSuite) TestDBRaw() {
 }
 
 func (s *QueryTestSuite) TestDelete() {
-	for driver, query := range s.queries {
+	for _, query := range s.queries {
 		tests := []struct {
 			name  string
 			setup func()
@@ -750,7 +750,7 @@ func (s *QueryTestSuite) TestDelete() {
 					s.Nil(query.Create(&user))
 					s.True(user.ID > 0)
 
-					res, err := query.Delete(&User{}, user.ID)
+					res, err := query.Where("id", user.ID).Delete(&User{})
 					s.Equal(int64(1), res.RowsAffected)
 					s.Nil(err)
 
@@ -767,7 +767,7 @@ func (s *QueryTestSuite) TestDelete() {
 					s.True(users[0].ID > 0)
 					s.True(users[1].ID > 0)
 
-					res, err := query.Delete(&User{}, []uint{users[0].ID, users[1].ID})
+					res, err := query.WhereIn("id", []any{users[0].ID, users[1].ID}).Delete(&User{})
 					s.Equal(int64(2), res.RowsAffected)
 					s.Nil(err)
 

--- a/database/gorm/query_test.go
+++ b/database/gorm/query_test.go
@@ -42,19 +42,19 @@ func TestQueryTestSuite(t *testing.T) {
 	testContext = context.Background()
 	testContext = context.WithValue(testContext, testContextKey, "goravel")
 
-	//mysqls := supportdocker.Mysqls(2)
-	//
-	//mysqlDocker := NewMysqlDocker(mysqls[0])
-	//mysqlQuery, err := mysqlDocker.New()
-	//if err != nil {
-	//	log.Fatalf("Init mysql error: %s", err)
-	//}
-	//
-	//mysql1Docker := NewMysqlDocker(mysqls[1])
-	//_, err = mysql1Docker.New()
-	//if err != nil {
-	//	log.Fatalf("Init mysql error: %s", err)
-	//}
+	mysqls := supportdocker.Mysqls(2)
+
+	mysqlDocker := NewMysqlDocker(mysqls[0])
+	mysqlQuery, err := mysqlDocker.New()
+	if err != nil {
+		log.Fatalf("Init mysql error: %s", err)
+	}
+
+	mysql1Docker := NewMysqlDocker(mysqls[1])
+	_, err = mysql1Docker.New()
+	if err != nil {
+		log.Fatalf("Init mysql error: %s", err)
+	}
 
 	postgres := supportdocker.Postgres()
 	postgresDocker := NewPostgresDocker(postgres)
@@ -63,31 +63,31 @@ func TestQueryTestSuite(t *testing.T) {
 		log.Fatalf("Init postgres error: %s", err)
 	}
 
-	//sqliteDocker := NewSqliteDocker(supportdocker.Sqlite())
-	//sqliteQuery, err := sqliteDocker.New()
-	//if err != nil {
-	//	log.Fatalf("Init sqlite error: %s", err)
-	//}
-	//
-	//sqlserverDocker := NewSqlserverDocker(supportdocker.Sqlserver())
-	//sqlserverQuery, err := sqlserverDocker.New()
-	//if err != nil {
-	//	log.Fatalf("Init sqlserver error: %s", err)
-	//}
+	sqliteDocker := NewSqliteDocker(supportdocker.Sqlite())
+	sqliteQuery, err := sqliteDocker.New()
+	if err != nil {
+		log.Fatalf("Init sqlite error: %s", err)
+	}
+
+	sqlserverDocker := NewSqlserverDocker(supportdocker.Sqlserver())
+	sqlserverQuery, err := sqlserverDocker.New()
+	if err != nil {
+		log.Fatalf("Init sqlserver error: %s", err)
+	}
 
 	suite.Run(t, &QueryTestSuite{
 		queries: map[contractsorm.Driver]contractsorm.Query{
-			//contractsorm.DriverMysql:     mysqlQuery,
-			contractsorm.DriverPostgres: postgresQuery,
-			//contractsorm.DriverSqlite:    sqliteQuery,
-			//contractsorm.DriverSqlserver: sqlserverQuery,
+			contractsorm.DriverMysql:     mysqlQuery,
+			contractsorm.DriverPostgres:  postgresQuery,
+			contractsorm.DriverSqlite:    sqliteQuery,
+			contractsorm.DriverSqlserver: sqlserverQuery,
 		},
-		//mysqlDocker:     mysqlDocker,
-		//mysql1:          mysqls[1],
-		postgres:       postgres,
-		postgresDocker: postgresDocker,
-		//sqliteDocker:    sqliteDocker,
-		//sqlserverDocker: sqlserverDocker,
+		mysqlDocker:     mysqlDocker,
+		mysql1:          mysqls[1],
+		postgres:        postgres,
+		postgresDocker:  postgresDocker,
+		sqliteDocker:    sqliteDocker,
+		sqlserverDocker: sqlserverDocker,
 	})
 }
 
@@ -659,7 +659,7 @@ func (s *QueryTestSuite) TestDBRaw() {
 }
 
 func (s *QueryTestSuite) TestDelete() {
-	for _, query := range s.queries {
+	for driver, query := range s.queries {
 		tests := []struct {
 			name  string
 			setup func()
@@ -1964,7 +1964,7 @@ func (s *QueryTestSuite) TestForceDelete() {
 					s.True(user.ID > 0)
 					s.Equal("force_delete_name", user.Name)
 
-					res, err := query.Where("name = ?", "force_delete_name").ForceDelete(&User{})
+					res, err := query.Where("name", "force_delete_name").ForceDelete(&User{})
 					s.Equal(int64(1), res.RowsAffected)
 					s.Nil(err)
 					s.Equal("force_delete_name", user.Name)
@@ -1982,7 +1982,7 @@ func (s *QueryTestSuite) TestForceDelete() {
 					s.True(user.ID > 0)
 					s.Equal("force_delete_name_by_table", user.Name)
 
-					res, err := query.Table("users").Where("name = ?", "force_delete_name_by_table").ForceDelete()
+					res, err := query.Table("users").Where("name", "force_delete_name_by_table").ForceDelete()
 					s.Equal(int64(1), res.RowsAffected)
 					s.Nil(err)
 					s.Equal("force_delete_name_by_table", user.Name)
@@ -2000,7 +2000,7 @@ func (s *QueryTestSuite) TestForceDelete() {
 					s.True(user.ID > 0)
 					s.Equal("force_delete_name_by_model", user.Name)
 
-					res, err := query.Model(&User{}).Where("name = ?", "force_delete_name_by_model").ForceDelete()
+					res, err := query.Model(&User{}).Where("name", "force_delete_name_by_model").ForceDelete()
 					s.Equal(int64(1), res.RowsAffected)
 					s.Nil(err)
 					s.Equal("force_delete_name_by_model", user.Name)

--- a/database/gorm/to_sql.go
+++ b/database/gorm/to_sql.go
@@ -29,10 +29,15 @@ func (r *ToSql) Create(value any) string {
 	return r.sql(query.instance.Session(&gorm.Session{DryRun: true}).Create(value))
 }
 
-func (r *ToSql) Delete(value any, conds ...any) string {
+func (r *ToSql) Delete(value ...any) string {
 	query := r.query.buildConditions()
 
-	return r.sql(query.instance.Session(&gorm.Session{DryRun: true}).Delete(value, conds...))
+	var dest any
+	if len(value) > 0 {
+		dest = value[0]
+	}
+
+	return r.sql(query.instance.Session(&gorm.Session{DryRun: true}).Delete(dest))
 }
 
 func (r *ToSql) Find(dest any, conds ...any) string {
@@ -45,6 +50,17 @@ func (r *ToSql) First(dest any) string {
 	query := r.query.buildConditions()
 
 	return r.sql(query.instance.Session(&gorm.Session{DryRun: true}).First(dest))
+}
+
+func (r *ToSql) ForceDelete(value ...any) string {
+	query := r.query.buildConditions()
+
+	var dest any
+	if len(value) > 0 {
+		dest = value[0]
+	}
+
+	return r.sql(query.instance.Session(&gorm.Session{DryRun: true}).Unscoped().Delete(dest))
 }
 
 func (r *ToSql) Get(dest any) string {

--- a/database/gorm/to_sql_test.go
+++ b/database/gorm/to_sql_test.go
@@ -60,30 +60,16 @@ func (s *ToSqlTestSuite) TestDelete() {
 	toSql := NewToSql(s.query.Where("id", 1).(*QueryImpl), false)
 	s.Equal("UPDATE `users` SET `deleted_at`=? WHERE `id` = ? AND `users`.`deleted_at` IS NULL", toSql.Delete(&User{}))
 
-	toSql = NewToSql(s.query.(*QueryImpl), false)
-	s.Equal("UPDATE `users` SET `deleted_at`=? WHERE `users`.`id` = ? AND `users`.`deleted_at` IS NULL", toSql.Delete(&User{}, 1))
-
 	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), false)
 	s.Equal("DELETE FROM `roles` WHERE `id` = ?", toSql.Delete(&Role{}))
-
-	toSql = NewToSql(s.query.(*QueryImpl), false)
-	s.Equal("DELETE FROM `roles` WHERE `roles`.`id` = ?", toSql.Delete(&Role{}, 1))
 
 	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), true)
 	sql := toSql.Delete(&User{})
 	s.Contains(sql, "UPDATE `users` SET `deleted_at`=")
 	s.Contains(sql, "WHERE `id` = 1 AND `users`.`deleted_at` IS NULL")
 
-	toSql = NewToSql(s.query.(*QueryImpl), true)
-	sql = toSql.Delete(&User{}, 1)
-	s.Contains(sql, "UPDATE `users` SET `deleted_at`=")
-	s.Contains(sql, "WHERE `users`.`id` = 1 AND `users`.`deleted_at` IS NULL")
-
 	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), true)
 	s.Equal("DELETE FROM `roles` WHERE `id` = 1", toSql.Delete(&Role{}))
-
-	toSql = NewToSql(s.query.(*QueryImpl), true)
-	s.Equal("DELETE FROM `roles` WHERE `roles`.`id` = 1", toSql.Delete(&Role{}, 1))
 }
 
 func (s *ToSqlTestSuite) TestFind() {
@@ -106,6 +92,20 @@ func (s *ToSqlTestSuite) TestFirst() {
 
 	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), true)
 	s.Equal("SELECT * FROM `users` WHERE `id` = 1 AND `users`.`deleted_at` IS NULL ORDER BY `users`.`id` LIMIT 1", toSql.First(&User{}))
+}
+
+func (s *ToSqlTestSuite) TestForceDelete() {
+	toSql := NewToSql(s.query.Where("id", 1).(*QueryImpl), false)
+	s.Equal("DELETE FROM `users` WHERE `id` = ?", toSql.ForceDelete(&User{}))
+
+	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), false)
+	s.Equal("DELETE FROM `roles` WHERE `id` = ?", toSql.ForceDelete(&Role{}))
+
+	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), true)
+	s.Equal("DELETE FROM `users` WHERE `id` = 1", toSql.ForceDelete(&User{}))
+
+	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), true)
+	s.Equal("DELETE FROM `roles` WHERE `id` = 1", toSql.ForceDelete(&Role{}))
 }
 
 func (s *ToSqlTestSuite) TestGet() {

--- a/database/gorm/to_sql_test.go
+++ b/database/gorm/to_sql_test.go
@@ -35,10 +35,10 @@ func TestToSqlTestSuite(t *testing.T) {
 func (s *ToSqlTestSuite) SetupTest() {}
 
 func (s *ToSqlTestSuite) TestCount() {
-	toSql := NewToSql(s.query.Model(User{}).Where("id", 1).(*QueryImpl), false)
+	toSql := NewToSql(s.query.Model(&User{}).Where("id", 1).(*QueryImpl), false)
 	s.Equal("SELECT count(*) FROM `users` WHERE `id` = ? AND `users`.`deleted_at` IS NULL", toSql.Count())
 
-	toSql = NewToSql(s.query.Model(User{}).Where("id", 1).(*QueryImpl), true)
+	toSql = NewToSql(s.query.Model(&User{}).Where("id", 1).(*QueryImpl), true)
 	s.Equal("SELECT count(*) FROM `users` WHERE `id` = 1 AND `users`.`deleted_at` IS NULL", toSql.Count())
 }
 
@@ -47,7 +47,7 @@ func (s *ToSqlTestSuite) TestCreate() {
 	toSql := NewToSql(s.query.(*QueryImpl), false)
 	s.Equal("INSERT INTO `users` (`created_at`,`updated_at`,`deleted_at`,`name`,`bio`,`avatar`) VALUES (?,?,?,?,?,?)", toSql.Create(&user))
 
-	toSql = NewToSql(s.query.Model(User{}).Where("id", 1).(*QueryImpl), true)
+	toSql = NewToSql(s.query.Model(&User{}).Where("id", 1).(*QueryImpl), true)
 	s.Contains(toSql.Create(&user), "INSERT INTO `users` (`created_at`,`updated_at`,`deleted_at`,`name`,`bio`,`avatar`) VALUES (")
 	s.Contains(toSql.Create(&user), ",NULL,'to_sql_create',NULL,'')")
 
@@ -58,54 +58,54 @@ func (s *ToSqlTestSuite) TestCreate() {
 
 func (s *ToSqlTestSuite) TestDelete() {
 	toSql := NewToSql(s.query.Where("id", 1).(*QueryImpl), false)
-	s.Equal("UPDATE `users` SET `deleted_at`=? WHERE `id` = ? AND `users`.`deleted_at` IS NULL", toSql.Delete(User{}))
+	s.Equal("UPDATE `users` SET `deleted_at`=? WHERE `id` = ? AND `users`.`deleted_at` IS NULL", toSql.Delete(&User{}))
 
 	toSql = NewToSql(s.query.(*QueryImpl), false)
-	s.Equal("UPDATE `users` SET `deleted_at`=? WHERE `users`.`id` = ? AND `users`.`deleted_at` IS NULL", toSql.Delete(User{}, 1))
+	s.Equal("UPDATE `users` SET `deleted_at`=? WHERE `users`.`id` = ? AND `users`.`deleted_at` IS NULL", toSql.Delete(&User{}, 1))
 
 	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), false)
-	s.Equal("DELETE FROM `roles` WHERE `id` = ?", toSql.Delete(Role{}))
+	s.Equal("DELETE FROM `roles` WHERE `id` = ?", toSql.Delete(&Role{}))
 
 	toSql = NewToSql(s.query.(*QueryImpl), false)
-	s.Equal("DELETE FROM `roles` WHERE `roles`.`id` = ?", toSql.Delete(Role{}, 1))
+	s.Equal("DELETE FROM `roles` WHERE `roles`.`id` = ?", toSql.Delete(&Role{}, 1))
 
 	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), true)
-	sql := toSql.Delete(User{})
+	sql := toSql.Delete(&User{})
 	s.Contains(sql, "UPDATE `users` SET `deleted_at`=")
 	s.Contains(sql, "WHERE `id` = 1 AND `users`.`deleted_at` IS NULL")
 
 	toSql = NewToSql(s.query.(*QueryImpl), true)
-	sql = toSql.Delete(User{}, 1)
+	sql = toSql.Delete(&User{}, 1)
 	s.Contains(sql, "UPDATE `users` SET `deleted_at`=")
 	s.Contains(sql, "WHERE `users`.`id` = 1 AND `users`.`deleted_at` IS NULL")
 
 	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), true)
-	s.Equal("DELETE FROM `roles` WHERE `id` = 1", toSql.Delete(Role{}))
+	s.Equal("DELETE FROM `roles` WHERE `id` = 1", toSql.Delete(&Role{}))
 
 	toSql = NewToSql(s.query.(*QueryImpl), true)
-	s.Equal("DELETE FROM `roles` WHERE `roles`.`id` = 1", toSql.Delete(Role{}, 1))
+	s.Equal("DELETE FROM `roles` WHERE `roles`.`id` = 1", toSql.Delete(&Role{}, 1))
 }
 
 func (s *ToSqlTestSuite) TestFind() {
 	toSql := NewToSql(s.query.Where("id", 1).(*QueryImpl), false)
-	s.Equal("SELECT * FROM `users` WHERE `id` = ? AND `users`.`deleted_at` IS NULL", toSql.Find(User{}))
+	s.Equal("SELECT * FROM `users` WHERE `id` = ? AND `users`.`deleted_at` IS NULL", toSql.Find(&User{}))
 
 	toSql = NewToSql(s.query.(*QueryImpl), false)
-	s.Equal("SELECT * FROM `users` WHERE `users`.`id` = ? AND `users`.`deleted_at` IS NULL", toSql.Find(User{}, 1))
+	s.Equal("SELECT * FROM `users` WHERE `users`.`id` = ? AND `users`.`deleted_at` IS NULL", toSql.Find(&User{}, 1))
 
 	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), true)
-	s.Equal("SELECT * FROM `users` WHERE `id` = 1 AND `users`.`deleted_at` IS NULL", toSql.Find(User{}))
+	s.Equal("SELECT * FROM `users` WHERE `id` = 1 AND `users`.`deleted_at` IS NULL", toSql.Find(&User{}))
 
 	toSql = NewToSql(s.query.(*QueryImpl), true)
-	s.Equal("SELECT * FROM `users` WHERE `users`.`id` = 1 AND `users`.`deleted_at` IS NULL", toSql.Find(User{}, 1))
+	s.Equal("SELECT * FROM `users` WHERE `users`.`id` = 1 AND `users`.`deleted_at` IS NULL", toSql.Find(&User{}, 1))
 }
 
 func (s *ToSqlTestSuite) TestFirst() {
 	toSql := NewToSql(s.query.Where("id", 1).(*QueryImpl), false)
-	s.Equal("SELECT * FROM `users` WHERE `id` = ? AND `users`.`deleted_at` IS NULL ORDER BY `users`.`id` LIMIT ?", toSql.First(User{}))
+	s.Equal("SELECT * FROM `users` WHERE `id` = ? AND `users`.`deleted_at` IS NULL ORDER BY `users`.`id` LIMIT ?", toSql.First(&User{}))
 
 	toSql = NewToSql(s.query.Where("id", 1).(*QueryImpl), true)
-	s.Equal("SELECT * FROM `users` WHERE `id` = 1 AND `users`.`deleted_at` IS NULL ORDER BY `users`.`id` LIMIT 1", toSql.First(User{}))
+	s.Equal("SELECT * FROM `users` WHERE `id` = 1 AND `users`.`deleted_at` IS NULL ORDER BY `users`.`id` LIMIT 1", toSql.First(&User{}))
 }
 
 func (s *ToSqlTestSuite) TestGet() {
@@ -143,38 +143,38 @@ func (s *ToSqlTestSuite) TestSum() {
 }
 
 func (s *ToSqlTestSuite) TestUpdate() {
-	toSql := NewToSql(s.query.Model(User{}).Where("id", 1).(*QueryImpl), false)
+	toSql := NewToSql(s.query.Model(&User{}).Where("id", 1).(*QueryImpl), false)
 	s.Equal("UPDATE `users` SET `name`=?,`updated_at`=? WHERE `id` = ? AND `users`.`deleted_at` IS NULL", toSql.Update("name", "goravel"))
 
-	toSql = NewToSql(s.query.Model(User{}).Where("id", 1).(*QueryImpl), true)
+	toSql = NewToSql(s.query.Model(&User{}).Where("id", 1).(*QueryImpl), true)
 	sql := toSql.Update("name", "goravel")
 	s.Contains(sql, "UPDATE `users` SET `name`='goravel',`updated_at`=")
 	s.Contains(sql, "WHERE `id` = 1 AND `users`.`deleted_at` IS NULL")
 
-	toSql = NewToSql(s.query.Model(User{}).Where("id", 1).(*QueryImpl), false)
+	toSql = NewToSql(s.query.Model(&User{}).Where("id", 1).(*QueryImpl), false)
 	s.Empty(toSql.Update(0, "goravel"))
 
-	toSql = NewToSql(s.query.Model(User{}).Where("id", 1).(*QueryImpl), true)
+	toSql = NewToSql(s.query.Model(&User{}).Where("id", 1).(*QueryImpl), true)
 	s.Empty(toSql.Update(0, "goravel"))
 
-	toSql = NewToSql(s.query.Model(User{}).Where("id", 1).(*QueryImpl), false)
+	toSql = NewToSql(s.query.Model(&User{}).Where("id", 1).(*QueryImpl), false)
 	s.Equal("UPDATE `users` SET `name`=?,`updated_at`=? WHERE `id` = ? AND `users`.`deleted_at` IS NULL", toSql.Update(map[string]any{
 		"name": "goravel",
 	}))
 
-	toSql = NewToSql(s.query.Model(User{}).Where("id", 1).(*QueryImpl), true)
+	toSql = NewToSql(s.query.Model(&User{}).Where("id", 1).(*QueryImpl), true)
 	sql = toSql.Update(map[string]any{
 		"name": "goravel",
 	})
 	s.Contains(sql, "UPDATE `users` SET `name`='goravel',`updated_at`=")
 	s.Contains(sql, "WHERE `id` = 1 AND `users`.`deleted_at` IS NULL")
 
-	toSql = NewToSql(s.query.Model(User{}).Where("id", 1).(*QueryImpl), false)
+	toSql = NewToSql(s.query.Model(&User{}).Where("id", 1).(*QueryImpl), false)
 	s.Equal("UPDATE `users` SET `updated_at`=?,`name`=? WHERE `id` = ? AND `users`.`deleted_at` IS NULL", toSql.Update(User{
 		Name: "goravel",
 	}))
 
-	toSql = NewToSql(s.query.Model(User{}).Where("id", 1).(*QueryImpl), true)
+	toSql = NewToSql(s.query.Model(&User{}).Where("id", 1).(*QueryImpl), true)
 	sql = toSql.Update(User{
 		Name: "goravel",
 	})

--- a/mocks/database/orm/Query.go
+++ b/mocks/database/orm/Query.go
@@ -319,11 +319,10 @@ func (_c *Query_Cursor_Call) RunAndReturn(run func() (chan orm.Cursor, error)) *
 	return _c
 }
 
-// Delete provides a mock function with given fields: value, conds
-func (_m *Query) Delete(value interface{}, conds ...interface{}) (*orm.Result, error) {
+// Delete provides a mock function with given fields: value
+func (_m *Query) Delete(value ...interface{}) (*orm.Result, error) {
 	var _ca []interface{}
-	_ca = append(_ca, value)
-	_ca = append(_ca, conds...)
+	_ca = append(_ca, value...)
 	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
@@ -332,19 +331,19 @@ func (_m *Query) Delete(value interface{}, conds ...interface{}) (*orm.Result, e
 
 	var r0 *orm.Result
 	var r1 error
-	if rf, ok := ret.Get(0).(func(interface{}, ...interface{}) (*orm.Result, error)); ok {
-		return rf(value, conds...)
+	if rf, ok := ret.Get(0).(func(...interface{}) (*orm.Result, error)); ok {
+		return rf(value...)
 	}
-	if rf, ok := ret.Get(0).(func(interface{}, ...interface{}) *orm.Result); ok {
-		r0 = rf(value, conds...)
+	if rf, ok := ret.Get(0).(func(...interface{}) *orm.Result); ok {
+		r0 = rf(value...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*orm.Result)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(interface{}, ...interface{}) error); ok {
-		r1 = rf(value, conds...)
+	if rf, ok := ret.Get(1).(func(...interface{}) error); ok {
+		r1 = rf(value...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -358,22 +357,21 @@ type Query_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-//   - value interface{}
-//   - conds ...interface{}
-func (_e *Query_Expecter) Delete(value interface{}, conds ...interface{}) *Query_Delete_Call {
+//   - value ...interface{}
+func (_e *Query_Expecter) Delete(value ...interface{}) *Query_Delete_Call {
 	return &Query_Delete_Call{Call: _e.mock.On("Delete",
-		append([]interface{}{value}, conds...)...)}
+		append([]interface{}{}, value...)...)}
 }
 
-func (_c *Query_Delete_Call) Run(run func(value interface{}, conds ...interface{})) *Query_Delete_Call {
+func (_c *Query_Delete_Call) Run(run func(value ...interface{})) *Query_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-1)
-		for i, a := range args[1:] {
+		variadicArgs := make([]interface{}, len(args)-0)
+		for i, a := range args[0:] {
 			if a != nil {
 				variadicArgs[i] = a.(interface{})
 			}
 		}
-		run(args[0].(interface{}), variadicArgs...)
+		run(variadicArgs...)
 	})
 	return _c
 }
@@ -383,7 +381,7 @@ func (_c *Query_Delete_Call) Return(_a0 *orm.Result, _a1 error) *Query_Delete_Ca
 	return _c
 }
 
-func (_c *Query_Delete_Call) RunAndReturn(run func(interface{}, ...interface{}) (*orm.Result, error)) *Query_Delete_Call {
+func (_c *Query_Delete_Call) RunAndReturn(run func(...interface{}) (*orm.Result, error)) *Query_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -973,11 +971,10 @@ func (_c *Query_FirstOrNew_Call) RunAndReturn(run func(interface{}, interface{},
 	return _c
 }
 
-// ForceDelete provides a mock function with given fields: value, conds
-func (_m *Query) ForceDelete(value interface{}, conds ...interface{}) (*orm.Result, error) {
+// ForceDelete provides a mock function with given fields: value
+func (_m *Query) ForceDelete(value ...interface{}) (*orm.Result, error) {
 	var _ca []interface{}
-	_ca = append(_ca, value)
-	_ca = append(_ca, conds...)
+	_ca = append(_ca, value...)
 	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
@@ -986,19 +983,19 @@ func (_m *Query) ForceDelete(value interface{}, conds ...interface{}) (*orm.Resu
 
 	var r0 *orm.Result
 	var r1 error
-	if rf, ok := ret.Get(0).(func(interface{}, ...interface{}) (*orm.Result, error)); ok {
-		return rf(value, conds...)
+	if rf, ok := ret.Get(0).(func(...interface{}) (*orm.Result, error)); ok {
+		return rf(value...)
 	}
-	if rf, ok := ret.Get(0).(func(interface{}, ...interface{}) *orm.Result); ok {
-		r0 = rf(value, conds...)
+	if rf, ok := ret.Get(0).(func(...interface{}) *orm.Result); ok {
+		r0 = rf(value...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*orm.Result)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(interface{}, ...interface{}) error); ok {
-		r1 = rf(value, conds...)
+	if rf, ok := ret.Get(1).(func(...interface{}) error); ok {
+		r1 = rf(value...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1012,22 +1009,21 @@ type Query_ForceDelete_Call struct {
 }
 
 // ForceDelete is a helper method to define mock.On call
-//   - value interface{}
-//   - conds ...interface{}
-func (_e *Query_Expecter) ForceDelete(value interface{}, conds ...interface{}) *Query_ForceDelete_Call {
+//   - value ...interface{}
+func (_e *Query_Expecter) ForceDelete(value ...interface{}) *Query_ForceDelete_Call {
 	return &Query_ForceDelete_Call{Call: _e.mock.On("ForceDelete",
-		append([]interface{}{value}, conds...)...)}
+		append([]interface{}{}, value...)...)}
 }
 
-func (_c *Query_ForceDelete_Call) Run(run func(value interface{}, conds ...interface{})) *Query_ForceDelete_Call {
+func (_c *Query_ForceDelete_Call) Run(run func(value ...interface{})) *Query_ForceDelete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-1)
-		for i, a := range args[1:] {
+		variadicArgs := make([]interface{}, len(args)-0)
+		for i, a := range args[0:] {
 			if a != nil {
 				variadicArgs[i] = a.(interface{})
 			}
 		}
-		run(args[0].(interface{}), variadicArgs...)
+		run(variadicArgs...)
 	})
 	return _c
 }
@@ -1037,7 +1033,7 @@ func (_c *Query_ForceDelete_Call) Return(_a0 *orm.Result, _a1 error) *Query_Forc
 	return _c
 }
 
-func (_c *Query_ForceDelete_Call) RunAndReturn(run func(interface{}, ...interface{}) (*orm.Result, error)) *Query_ForceDelete_Call {
+func (_c *Query_ForceDelete_Call) RunAndReturn(run func(...interface{}) (*orm.Result, error)) *Query_ForceDelete_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/database/orm/ToSql.go
+++ b/mocks/database/orm/ToSql.go
@@ -108,11 +108,10 @@ func (_c *ToSql_Create_Call) RunAndReturn(run func(interface{}) string) *ToSql_C
 	return _c
 }
 
-// Delete provides a mock function with given fields: value, conds
-func (_m *ToSql) Delete(value interface{}, conds ...interface{}) string {
+// Delete provides a mock function with given fields: value
+func (_m *ToSql) Delete(value ...interface{}) string {
 	var _ca []interface{}
-	_ca = append(_ca, value)
-	_ca = append(_ca, conds...)
+	_ca = append(_ca, value...)
 	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
@@ -120,8 +119,8 @@ func (_m *ToSql) Delete(value interface{}, conds ...interface{}) string {
 	}
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(interface{}, ...interface{}) string); ok {
-		r0 = rf(value, conds...)
+	if rf, ok := ret.Get(0).(func(...interface{}) string); ok {
+		r0 = rf(value...)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
@@ -135,22 +134,21 @@ type ToSql_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-//   - value interface{}
-//   - conds ...interface{}
-func (_e *ToSql_Expecter) Delete(value interface{}, conds ...interface{}) *ToSql_Delete_Call {
+//   - value ...interface{}
+func (_e *ToSql_Expecter) Delete(value ...interface{}) *ToSql_Delete_Call {
 	return &ToSql_Delete_Call{Call: _e.mock.On("Delete",
-		append([]interface{}{value}, conds...)...)}
+		append([]interface{}{}, value...)...)}
 }
 
-func (_c *ToSql_Delete_Call) Run(run func(value interface{}, conds ...interface{})) *ToSql_Delete_Call {
+func (_c *ToSql_Delete_Call) Run(run func(value ...interface{})) *ToSql_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]interface{}, len(args)-1)
-		for i, a := range args[1:] {
+		variadicArgs := make([]interface{}, len(args)-0)
+		for i, a := range args[0:] {
 			if a != nil {
 				variadicArgs[i] = a.(interface{})
 			}
 		}
-		run(args[0].(interface{}), variadicArgs...)
+		run(variadicArgs...)
 	})
 	return _c
 }
@@ -160,7 +158,7 @@ func (_c *ToSql_Delete_Call) Return(_a0 string) *ToSql_Delete_Call {
 	return _c
 }
 
-func (_c *ToSql_Delete_Call) RunAndReturn(run func(interface{}, ...interface{}) string) *ToSql_Delete_Call {
+func (_c *ToSql_Delete_Call) RunAndReturn(run func(...interface{}) string) *ToSql_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -264,6 +262,61 @@ func (_c *ToSql_First_Call) Return(_a0 string) *ToSql_First_Call {
 }
 
 func (_c *ToSql_First_Call) RunAndReturn(run func(interface{}) string) *ToSql_First_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ForceDelete provides a mock function with given fields: value
+func (_m *ToSql) ForceDelete(value ...interface{}) string {
+	var _ca []interface{}
+	_ca = append(_ca, value...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ForceDelete")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(...interface{}) string); ok {
+		r0 = rf(value...)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// ToSql_ForceDelete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ForceDelete'
+type ToSql_ForceDelete_Call struct {
+	*mock.Call
+}
+
+// ForceDelete is a helper method to define mock.On call
+//   - value ...interface{}
+func (_e *ToSql_Expecter) ForceDelete(value ...interface{}) *ToSql_ForceDelete_Call {
+	return &ToSql_ForceDelete_Call{Call: _e.mock.On("ForceDelete",
+		append([]interface{}{}, value...)...)}
+}
+
+func (_c *ToSql_ForceDelete_Call) Run(run func(value ...interface{})) *ToSql_ForceDelete_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-0)
+		for i, a := range args[0:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *ToSql_ForceDelete_Call) Return(_a0 string) *ToSql_ForceDelete_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ToSql_ForceDelete_Call) RunAndReturn(run func(...interface{}) string) *ToSql_ForceDelete_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## 📑 Description

Currently, we have to set a model using the `Delete` and `ForceDelete` methods. After this PR, we can use them  like below:

```
# Before
facades.Orm().Query()Where(**).Delete(&User{})
facades.Orm().Query().Where(**).ForceDelete(&User{})

# After
facades.Orm().Query().Table("users").Where(**).Delete()
facades.Orm().Query().Model(&models.User{}).Where(**).Delete()

facades.Orm().Query().Table("users").Where(**).ForceDelete()
facades.Orm().Query().Model(&models.User{}).Where(**).ForceDelete()
```

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced deletion methods to accept a variable number of arguments, simplifying usage.
	- Added a new `ForceDelete` method for unscoped deletions.
- **Bug Fixes**
	- Added nil checks in event handling methods to prevent potential errors.
- **Tests**
	- Introduced new test cases for deletion methods, improving coverage and ensuring robust functionality.
	- Updated test functions to use pointer receivers for better memory management in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
