### PR TITLE
fix: isAir and isDirectlyRun in Windows

### DIFF
--- a/foundation/path.go
+++ b/foundation/path.go
@@ -35,7 +35,7 @@ func isTesting() bool {
 // isAir checks if the application is running using Air.
 func isAir() bool {
 	for _, arg := range os.Args {
-		if strings.Contains(arg, "/storage/temp") {
+		if strings.Contains(filepath.ToSlash(arg), "/storage/temp") {
 			return true
 		}
 	}
@@ -47,5 +47,5 @@ func isAir() bool {
 func isDirectlyRun() bool {
 	executable, _ := os.Executable()
 	return strings.Contains(filepath.Base(executable), os.TempDir()) ||
-		(strings.Contains(executable, "/var/folders") && strings.Contains(executable, "/T/go-build")) // macOS
+		(strings.Contains(filepath.ToSlash(executable), "/var/folders") && strings.Contains(filepath.ToSlash(executable), "/T/go-build")) // macOS
 }


### PR DESCRIPTION
## 📑 Description

有些情况下，在Windows中返回的目录分隔符是`\\`，导致匹配不上，需要统一格式。

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved consistency in file path handling across different operating systems, reducing potential issues with path separators.
  
- **Refactor**
	- Updated functions to ensure uniform path format before performing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->