### PR TITLE
feat: Add error return for the Call method of Artisan

### DIFF
--- a/console/application.go
+++ b/console/application.go
@@ -29,7 +29,7 @@ func NewApplication(name, usage, usageText, version string, artisan ...bool) con
 	}
 }
 
-func (c *Application) Register(commands []console.Command) {
+func (r *Application) Register(commands []console.Command) {
 	for _, item := range commands {
 		item := item
 		cliCommand := cli.Command{
@@ -41,44 +41,44 @@ func (c *Application) Register(commands []console.Command) {
 			Category: item.Extend().Category,
 			Flags:    flagsToCliFlags(item.Extend().Flags),
 		}
-		c.instance.Commands = append(c.instance.Commands, &cliCommand)
+		r.instance.Commands = append(r.instance.Commands, &cliCommand)
 	}
 }
 
 // Call Run an Artisan console command by name.
-func (c *Application) Call(command string) error {
+func (r *Application) Call(command string) error {
 	if len(os.Args) == 0 {
 		return nil
 	}
 
 	commands := []string{os.Args[0]}
 
-	if c.isArtisan {
+	if r.isArtisan {
 		commands = append(commands, "artisan")
 	}
 
-	return c.Run(append(commands, strings.Split(command, " ")...), false)
+	return r.Run(append(commands, strings.Split(command, " ")...), false)
 }
 
 // CallAndExit Run an Artisan console command by name and exit.
-func (c *Application) CallAndExit(command string) {
+func (r *Application) CallAndExit(command string) {
 	if len(os.Args) == 0 {
 		return
 	}
 
 	commands := []string{os.Args[0]}
 
-	if c.isArtisan {
+	if r.isArtisan {
 		commands = append(commands, "artisan")
 	}
 
-	c.Run(append(commands, strings.Split(command, " ")...), true)
+	_ = r.Run(append(commands, strings.Split(command, " ")...), true)
 }
 
 // Run a command. Args come from os.Args.
-func (c *Application) Run(args []string, exitIfArtisan bool) error {
+func (r *Application) Run(args []string, exitIfArtisan bool) error {
 	artisanIndex := -1
-	if c.isArtisan {
+	if r.isArtisan {
 		for i, arg := range args {
 			if arg == "artisan" {
 				artisanIndex = i
@@ -96,7 +96,7 @@ func (c *Application) Run(args []string, exitIfArtisan bool) error {
 		}
 
 		cliArgs := append([]string{args[0]}, args[artisanIndex+1:]...)
-		if err := c.instance.Run(cliArgs); err != nil {
+		if err := r.instance.Run(cliArgs); err != nil {
 			if exitIfArtisan {
 				panic(err.Error())
 			}

--- a/console/application.go
+++ b/console/application.go
@@ -46,9 +46,9 @@ func (c *Application) Register(commands []console.Command) {
 }
 
 // Call Run an Artisan console command by name.
-func (c *Application) Call(command string) {
+func (c *Application) Call(command string) error {
 	if len(os.Args) == 0 {
-		return
+		return nil
 	}
 
 	commands := []string{os.Args[0]}
@@ -57,7 +57,7 @@ func (c *Application) Call(command string) {
 		commands = append(commands, "artisan")
 	}
 
-	c.Run(append(commands, strings.Split(command, " ")...), false)
+	return c.Run(append(commands, strings.Split(command, " ")...), false)
 }
 
 // CallAndExit Run an Artisan console command by name and exit.
@@ -76,7 +76,7 @@ func (c *Application) CallAndExit(command string) {
 }
 
 // Run a command. Args come from os.Args.
-func (c *Application) Run(args []string, exitIfArtisan bool) {
+func (c *Application) Run(args []string, exitIfArtisan bool) error {
 	artisanIndex := -1
 	if c.isArtisan {
 		for i, arg := range args {
@@ -97,13 +97,19 @@ func (c *Application) Run(args []string, exitIfArtisan bool) {
 
 		cliArgs := append([]string{args[0]}, args[artisanIndex+1:]...)
 		if err := c.instance.Run(cliArgs); err != nil {
-			panic(err.Error())
+			if exitIfArtisan {
+				panic(err.Error())
+			}
+
+			return err
 		}
 
 		if exitIfArtisan {
-			os.Exit(0)
+			os.Exit(1)
 		}
 	}
+
+	return nil
 }
 
 func flagsToCliFlags(flags []command.Flag) []cli.Flag {

--- a/console/application_test.go
+++ b/console/application_test.go
@@ -18,7 +18,7 @@ func TestRun(t *testing.T) {
 		&TestCommand{},
 	})
 
-	cliApp.Call("test")
+	assert.NoError(t, cliApp.Call("test"))
 	assert.Equal(t, 1, testCommand)
 }
 

--- a/console/console/list_command.go
+++ b/console/console/list_command.go
@@ -16,23 +16,21 @@ func NewListCommand(artisan console.Artisan) *ListCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *ListCommand) Signature() string {
+func (r *ListCommand) Signature() string {
 	return "list"
 }
 
 // Description The console command description.
-func (receiver *ListCommand) Description() string {
+func (r *ListCommand) Description() string {
 	return "List commands"
 }
 
 // Extend The console command extend.
-func (receiver *ListCommand) Extend() command.Extend {
+func (r *ListCommand) Extend() command.Extend {
 	return command.Extend{}
 }
 
 // Handle Execute the console command.
-func (receiver *ListCommand) Handle(ctx console.Context) error {
-	receiver.artisan.Call("--help")
-
-	return nil
+func (r *ListCommand) Handle(ctx console.Context) error {
+	return r.artisan.Call("--help")
 }

--- a/contracts/console/artisan.go
+++ b/contracts/console/artisan.go
@@ -5,11 +5,11 @@ type Artisan interface {
 	Register(commands []Command)
 
 	// Call run an Artisan console command by name.
-	Call(command string)
+	Call(command string) error
 
 	// CallAndExit run an Artisan console command by name and exit.
 	CallAndExit(command string)
 
 	// Run a command. args include: ["./main", "artisan", "command"]
-	Run(args []string, exitIfArtisan bool)
+	Run(args []string, exitIfArtisan bool) error
 }

--- a/contracts/testing/testing.go
+++ b/contracts/testing/testing.go
@@ -18,7 +18,7 @@ type Docker interface {
 type Database interface {
 	DatabaseDriver
 	// Seed runs the database seeds.
-	Seed(seeds ...seeder.Seeder)
+	Seed(seeders ...seeder.Seeder) error
 }
 
 type DatabaseDriver interface {

--- a/database/console/migration/migrate_command_test.go
+++ b/database/console/migration/migrate_command_test.go
@@ -1,0 +1,55 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goravel/framework/errors"
+	mocksconsole "github.com/goravel/framework/mocks/console"
+	mocksmigration "github.com/goravel/framework/mocks/database/migration"
+)
+
+func TestMigrateCommand(t *testing.T) {
+	var (
+		mockContext  *mocksconsole.Context
+		mockMigrator *mocksmigration.Migrator
+	)
+
+	beforeEach := func() {
+		mockContext = mocksconsole.NewContext(t)
+		mockMigrator = mocksmigration.NewMigrator(t)
+	}
+
+	tests := []struct {
+		name  string
+		setup func()
+	}{
+		{
+			name: "Happy path",
+			setup: func() {
+				mockMigrator.EXPECT().Run().Return(nil).Once()
+				mockContext.EXPECT().Info("Migration success").Once()
+			},
+		},
+		{
+			name: "Sad path - run failed",
+			setup: func() {
+				mockMigrator.EXPECT().Run().Return(assert.AnError).Once()
+				mockContext.EXPECT().Error(errors.MigrationMigrateFailed.Args(assert.AnError).Error()).Once()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			beforeEach()
+			test.setup()
+
+			command := NewMigrateCommand(mockMigrator)
+			err := command.Handle(mockContext)
+
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/database/console/migration/migrate_fresh_command.go
+++ b/database/console/migration/migrate_fresh_command.go
@@ -62,7 +62,11 @@ func (r *MigrateFreshCommand) Handle(ctx console.Context) error {
 		if len(seeders) > 0 {
 			seederFlag = " --seeder " + strings.Join(seeders, ",")
 		}
-		r.artisan.Call("db:seed" + seederFlag)
+
+		if err := r.artisan.Call("db:seed" + seederFlag); err != nil {
+			ctx.Error(errors.MigrationFreshFailed.Args(err).Error())
+			return nil
+		}
 	}
 
 	ctx.Info("Migration fresh success")

--- a/database/console/migration/migrate_fresh_command_test.go
+++ b/database/console/migration/migrate_fresh_command_test.go
@@ -33,7 +33,7 @@ func TestMigrateFreshCommand(t *testing.T) {
 				mockMigrator.EXPECT().Fresh().Return(nil).Once()
 				mockContext.EXPECT().OptionBool("seed").Return(true).Once()
 				mockContext.EXPECT().OptionSlice("seeder").Return([]string{"UserSeeder", "AgentSeeder"}).Once()
-				mockArtisan.EXPECT().Call("db:seed --seeder UserSeeder,AgentSeeder").Once()
+				mockArtisan.EXPECT().Call("db:seed --seeder UserSeeder,AgentSeeder").Return(nil).Once()
 				mockContext.EXPECT().Info("Migration fresh success").Once()
 			},
 		},
@@ -41,6 +41,16 @@ func TestMigrateFreshCommand(t *testing.T) {
 			name: "Sad path - fresh failed",
 			setup: func() {
 				mockMigrator.EXPECT().Fresh().Return(assert.AnError).Once()
+				mockContext.EXPECT().Error(errors.MigrationFreshFailed.Args(assert.AnError).Error()).Once()
+			},
+		},
+		{
+			name: "Sad path - call db:seed failed",
+			setup: func() {
+				mockMigrator.EXPECT().Fresh().Return(nil).Once()
+				mockContext.EXPECT().OptionBool("seed").Return(true).Once()
+				mockContext.EXPECT().OptionSlice("seeder").Return([]string{"UserSeeder", "AgentSeeder"}).Once()
+				mockArtisan.EXPECT().Call("db:seed --seeder UserSeeder,AgentSeeder").Return(assert.AnError).Once()
 				mockContext.EXPECT().Error(errors.MigrationFreshFailed.Args(assert.AnError).Error()).Once()
 			},
 		},

--- a/database/console/migration/migrate_refresh_command.go
+++ b/database/console/migration/migrate_refresh_command.go
@@ -25,17 +25,17 @@ func NewMigrateRefreshCommand(config config.Config, artisan console.Artisan) *Mi
 }
 
 // Signature The name and signature of the console command.
-func (receiver *MigrateRefreshCommand) Signature() string {
+func (r *MigrateRefreshCommand) Signature() string {
 	return "migrate:refresh"
 }
 
 // Description The console command description.
-func (receiver *MigrateRefreshCommand) Description() string {
+func (r *MigrateRefreshCommand) Description() string {
 	return "Reset and re-run all migrations"
 }
 
 // Extend The console command extend.
-func (receiver *MigrateRefreshCommand) Extend() command.Extend {
+func (r *MigrateRefreshCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "migrate",
 		Flags: []command.Flag{
@@ -57,8 +57,8 @@ func (receiver *MigrateRefreshCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *MigrateRefreshCommand) Handle(ctx console.Context) error {
-	m, err := getMigrate(receiver.config)
+func (r *MigrateRefreshCommand) Handle(ctx console.Context) error {
+	m, err := getMigrate(r.config)
 	if err != nil {
 		return err
 	}
@@ -90,14 +90,12 @@ func (receiver *MigrateRefreshCommand) Handle(ctx console.Context) error {
 	} else {
 		if err = m.Down(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 			ctx.Error(errors.MigrationRefreshFailed.Args(err).Error())
-
 			return nil
 		}
 	}
 
 	if err = m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 		ctx.Error(errors.MigrationRefreshFailed.Args(err).Error())
-
 		return nil
 	}
 
@@ -108,7 +106,11 @@ func (receiver *MigrateRefreshCommand) Handle(ctx console.Context) error {
 		if len(seeders) > 0 {
 			seederFlag = " --seeder " + strings.Join(seeders, ",")
 		}
-		receiver.artisan.Call("db:seed" + seederFlag)
+
+		if err := r.artisan.Call("db:seed" + seederFlag); err != nil {
+			ctx.Error(errors.MigrationRefreshFailed.Args(err).Error())
+			return nil
+		}
 	}
 	ctx.Info("Migration refresh success")
 

--- a/database/console/migration/migrate_refresh_command_test.go
+++ b/database/console/migration/migrate_refresh_command_test.go
@@ -68,7 +68,7 @@ func TestMigrateRefreshCommand(t *testing.T) {
 		mockContext.EXPECT().OptionBool("seed").Return(true).Once()
 		mockContext.EXPECT().OptionSlice("seeder").Return([]string{"UserSeeder"}).Once()
 		mockContext.EXPECT().Info("Migration refresh success").Once()
-		mockArtisan.EXPECT().Call("db:seed --seeder UserSeeder").Once()
+		mockArtisan.EXPECT().Call("db:seed --seeder UserSeeder").Return(nil).Once()
 
 		migrateRefreshCommand = NewMigrateRefreshCommand(mockConfig, mockArtisan)
 		assert.Nil(t, migrateRefreshCommand.Handle(mockContext))
@@ -81,7 +81,7 @@ func TestMigrateRefreshCommand(t *testing.T) {
 		mockContext.EXPECT().OptionBool("seed").Return(true).Once()
 		mockContext.EXPECT().OptionSlice("seeder").Return([]string{}).Once()
 		mockContext.EXPECT().Info("Migration refresh success").Once()
-		mockArtisan.EXPECT().Call("db:seed").Once()
+		mockArtisan.EXPECT().Call("db:seed").Return(nil).Once()
 
 		migrateRefreshCommand = NewMigrateRefreshCommand(mockConfig, mockArtisan)
 		assert.Nil(t, migrateRefreshCommand.Handle(mockContext))

--- a/database/migration/default_migrator.go
+++ b/database/migration/default_migrator.go
@@ -44,8 +44,12 @@ func (r *DefaultMigrator) Create(name string) error {
 
 // TODO Remove this function and move the logic to the migrate:fresh command when the sql migrator is removed.
 func (r *DefaultMigrator) Fresh() error {
-	r.artisan.Call("db:wipe --force")
-	r.artisan.Call("migrate")
+	if err := r.artisan.Call("db:wipe --force"); err != nil {
+		return err
+	}
+	if err := r.artisan.Call("migrate"); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/database/migration/default_migrator_test.go
+++ b/database/migration/default_migrator_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goravel/framework/contracts/database/schema"
@@ -65,10 +66,22 @@ func (s *DefaultMigratorSuite) TestCreate() {
 }
 
 func (s *DefaultMigratorSuite) TestFresh() {
-	s.mockArtisan.EXPECT().Call("db:wipe --force").Once()
-	s.mockArtisan.EXPECT().Call("migrate").Once()
+	// Success
+	s.mockArtisan.EXPECT().Call("db:wipe --force").Return(nil).Once()
+	s.mockArtisan.EXPECT().Call("migrate").Return(nil).Once()
 
 	s.NoError(s.driver.Fresh())
+
+	// db:wipe returns error
+	s.mockArtisan.EXPECT().Call("db:wipe --force").Return(assert.AnError).Once()
+
+	s.EqualError(s.driver.Fresh(), assert.AnError.Error())
+
+	// migrate returns error
+	s.mockArtisan.EXPECT().Call("db:wipe --force").Return(nil).Once()
+	s.mockArtisan.EXPECT().Call("migrate").Return(assert.AnError).Once()
+
+	s.EqualError(s.driver.Fresh(), assert.AnError.Error())
 }
 
 func (s *DefaultMigratorSuite) TestRun() {

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -178,7 +178,7 @@ func (app *Application) bootArtisan() {
 		return
 	}
 
-	artisanFacade.Run(os.Args, true)
+	_ = artisanFacade.Run(os.Args, true)
 }
 
 // getBaseServiceProviders Get base service providers.

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.12.3 // indirect
 	github.com/gookit/color v1.5.4 // indirect
 	github.com/gookit/filter v1.2.1 // indirect
-	github.com/gookit/goutil v0.6.15 // indirect
+	github.com/gookit/goutil v0.6.15
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/mocks/console/Artisan.go
+++ b/mocks/console/Artisan.go
@@ -21,8 +21,21 @@ func (_m *Artisan) EXPECT() *Artisan_Expecter {
 }
 
 // Call provides a mock function with given fields: command
-func (_m *Artisan) Call(command string) {
-	_m.Called(command)
+func (_m *Artisan) Call(command string) error {
+	ret := _m.Called(command)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Call")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(command)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Artisan_Call_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Call'
@@ -43,12 +56,12 @@ func (_c *Artisan_Call_Call) Run(run func(command string)) *Artisan_Call_Call {
 	return _c
 }
 
-func (_c *Artisan_Call_Call) Return() *Artisan_Call_Call {
-	_c.Call.Return()
+func (_c *Artisan_Call_Call) Return(_a0 error) *Artisan_Call_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Artisan_Call_Call) RunAndReturn(run func(string)) *Artisan_Call_Call {
+func (_c *Artisan_Call_Call) RunAndReturn(run func(string) error) *Artisan_Call_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -120,8 +133,21 @@ func (_c *Artisan_Register_Call) RunAndReturn(run func([]console.Command)) *Arti
 }
 
 // Run provides a mock function with given fields: args, exitIfArtisan
-func (_m *Artisan) Run(args []string, exitIfArtisan bool) {
-	_m.Called(args, exitIfArtisan)
+func (_m *Artisan) Run(args []string, exitIfArtisan bool) error {
+	ret := _m.Called(args, exitIfArtisan)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Run")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]string, bool) error); ok {
+		r0 = rf(args, exitIfArtisan)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Artisan_Run_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Run'
@@ -143,12 +169,12 @@ func (_c *Artisan_Run_Call) Run(run func(args []string, exitIfArtisan bool)) *Ar
 	return _c
 }
 
-func (_c *Artisan_Run_Call) Return() *Artisan_Run_Call {
-	_c.Call.Return()
+func (_c *Artisan_Run_Call) Return(_a0 error) *Artisan_Run_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Artisan_Run_Call) RunAndReturn(run func([]string, bool)) *Artisan_Run_Call {
+func (_c *Artisan_Run_Call) RunAndReturn(run func([]string, bool) error) *Artisan_Run_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/testing/Database.go
+++ b/mocks/testing/Database.go
@@ -237,15 +237,28 @@ func (_c *Database_Image_Call) RunAndReturn(run func(testing.Image)) *Database_I
 	return _c
 }
 
-// Seed provides a mock function with given fields: seeds
-func (_m *Database) Seed(seeds ...seeder.Seeder) {
-	_va := make([]interface{}, len(seeds))
-	for _i := range seeds {
-		_va[_i] = seeds[_i]
+// Seed provides a mock function with given fields: seeders
+func (_m *Database) Seed(seeders ...seeder.Seeder) error {
+	_va := make([]interface{}, len(seeders))
+	for _i := range seeders {
+		_va[_i] = seeders[_i]
 	}
 	var _ca []interface{}
 	_ca = append(_ca, _va...)
-	_m.Called(_ca...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Seed")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(...seeder.Seeder) error); ok {
+		r0 = rf(seeders...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Database_Seed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Seed'
@@ -254,13 +267,13 @@ type Database_Seed_Call struct {
 }
 
 // Seed is a helper method to define mock.On call
-//   - seeds ...seeder.Seeder
-func (_e *Database_Expecter) Seed(seeds ...interface{}) *Database_Seed_Call {
+//   - seeders ...seeder.Seeder
+func (_e *Database_Expecter) Seed(seeders ...interface{}) *Database_Seed_Call {
 	return &Database_Seed_Call{Call: _e.mock.On("Seed",
-		append([]interface{}{}, seeds...)...)}
+		append([]interface{}{}, seeders...)...)}
 }
 
-func (_c *Database_Seed_Call) Run(run func(seeds ...seeder.Seeder)) *Database_Seed_Call {
+func (_c *Database_Seed_Call) Run(run func(seeders ...seeder.Seeder)) *Database_Seed_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		variadicArgs := make([]seeder.Seeder, len(args)-0)
 		for i, a := range args[0:] {
@@ -273,12 +286,12 @@ func (_c *Database_Seed_Call) Run(run func(seeds ...seeder.Seeder)) *Database_Se
 	return _c
 }
 
-func (_c *Database_Seed_Call) Return() *Database_Seed_Call {
-	_c.Call.Return()
+func (_c *Database_Seed_Call) Return(_a0 error) *Database_Seed_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Database_Seed_Call) RunAndReturn(run func(...seeder.Seeder)) *Database_Seed_Call {
+func (_c *Database_Seed_Call) RunAndReturn(run func(...seeder.Seeder) error) *Database_Seed_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/schedule/application.go
+++ b/schedule/application.go
@@ -96,7 +96,9 @@ func (app *Application) getJob(event schedule.Event) cron.Job {
 
 func (app *Application) runJob(event schedule.Event) {
 	if event.GetCommand() != "" {
-		app.artisan.Call(event.GetCommand())
+		if err := app.artisan.Call(event.GetCommand()); err != nil {
+			app.log.Errorf("run %s command error: %v", event.GetCommand(), err)
+		}
 	} else {
 		event.GetCallback()()
 	}

--- a/schedule/application_test.go
+++ b/schedule/application_test.go
@@ -27,7 +27,7 @@ func (s *ApplicationTestSuite) SetupTest() {
 
 func (s *ApplicationTestSuite) TestCallAndCommand() {
 	mockArtisan := mocksconsole.NewArtisan(s.T())
-	mockArtisan.EXPECT().Call("test --name Goravel argument0 argument1").Return().Once()
+	mockArtisan.EXPECT().Call("test --name Goravel argument0 argument1").Return(nil).Once()
 
 	mockLog := mockslog.NewLog(s.T())
 	mockLog.EXPECT().Error("panic", mock.Anything).Return().Once()

--- a/support/docker/docker.go
+++ b/support/docker/docker.go
@@ -15,7 +15,7 @@ const (
 	TestModelNormal
 
 	// Switch this value to control the test model.
-	TestModel = TestModelNormal
+	TestModel = TestModelMinimum
 )
 
 type ContainerType string

--- a/support/docker/docker.go
+++ b/support/docker/docker.go
@@ -15,7 +15,7 @@ const (
 	TestModelNormal
 
 	// Switch this value to control the test model.
-	TestModel = TestModelMinimum
+	TestModel = TestModelNormal
 )
 
 type ContainerType string

--- a/testing/docker/database.go
+++ b/testing/docker/database.go
@@ -57,20 +57,24 @@ func (r *Database) Build() error {
 	}
 
 	r.config.Add(fmt.Sprintf("database.connections.%s.port", r.connection), r.DatabaseDriver.Config().Port)
-	r.artisan.Call("migrate")
+
+	if err := r.artisan.Call("migrate"); err != nil {
+		return err
+	}
+
 	r.orm.Refresh()
 
 	return nil
 }
 
-func (r *Database) Seed(seeds ...seeder.Seeder) {
+func (r *Database) Seed(seeders ...seeder.Seeder) error {
 	command := "db:seed"
-	if len(seeds) > 0 {
+	if len(seeders) > 0 {
 		command += " --seeder"
-		for _, seed := range seeds {
+		for _, seed := range seeders {
 			command += fmt.Sprintf(" %s", seed.Signature())
 		}
 	}
 
-	r.artisan.Call(command)
+	return r.artisan.Call(command)
 }

--- a/testing/docker/database_test.go
+++ b/testing/docker/database_test.go
@@ -213,10 +213,13 @@ func (s *DatabaseTestSuite) TestConfig() {
 
 func (s *DatabaseTestSuite) TestSeed() {
 	s.mockArtisan.EXPECT().Call("db:seed").Return(nil).Once()
-	s.database.Seed()
+	s.NoError(s.database.Seed())
 
 	s.mockArtisan.EXPECT().Call("db:seed --seeder mock").Return(nil).Once()
-	s.database.Seed(&MockSeeder{})
+	s.NoError(s.database.Seed(&MockSeeder{}))
+
+	s.mockArtisan.EXPECT().Call("db:seed").Return(assert.AnError).Once()
+	s.EqualError(s.database.Seed(), assert.AnError.Error())
 }
 
 type MockSeeder struct{}

--- a/testing/docker/database_test.go
+++ b/testing/docker/database_test.go
@@ -188,13 +188,19 @@ func (s *DatabaseTestSuite) TestBuild() {
 		s.T().Skip("Skipping tests that use Docker")
 	}
 
+	// Call success
 	s.mockConfig.EXPECT().Add("database.connections.postgres.port", mock.Anything).Once()
-	s.mockArtisan.EXPECT().Call("migrate").Once()
+	s.mockArtisan.EXPECT().Call("migrate").Return(nil).Once()
 	s.mockOrm.EXPECT().Refresh().Once()
 
 	s.Nil(s.database.Build())
 	s.True(s.database.Config().Port > 0)
 	s.Nil(s.database.Stop())
+
+	// Call error
+	s.mockConfig.EXPECT().Add("database.connections.postgres.port", mock.Anything).Once()
+	s.mockArtisan.EXPECT().Call("migrate").Return(assert.AnError).Once()
+	s.EqualError(s.database.Build(), assert.AnError.Error())
 }
 
 func (s *DatabaseTestSuite) TestConfig() {
@@ -206,10 +212,10 @@ func (s *DatabaseTestSuite) TestConfig() {
 }
 
 func (s *DatabaseTestSuite) TestSeed() {
-	s.mockArtisan.EXPECT().Call("db:seed").Once()
+	s.mockArtisan.EXPECT().Call("db:seed").Return(nil).Once()
 	s.database.Seed()
 
-	s.mockArtisan.EXPECT().Call("db:seed --seeder mock").Once()
+	s.mockArtisan.EXPECT().Call("db:seed --seeder mock").Return(nil).Once()
 	s.database.Seed(&MockSeeder{})
 }
 

--- a/testing/test_case.go
+++ b/testing/test_case.go
@@ -3,33 +3,42 @@ package testing
 import (
 	"fmt"
 
-	"github.com/goravel/framework/contracts/database/seeder"
+	contractsseeder "github.com/goravel/framework/contracts/database/seeder"
 	"github.com/goravel/framework/errors"
 )
 
 type TestCase struct {
 }
 
-func (receiver *TestCase) Seed(seeds ...seeder.Seeder) {
-	command := "db:seed"
-	if len(seeds) > 0 {
-		command += " --seeder"
-		for _, seed := range seeds {
-			command += fmt.Sprintf(" %s", seed.Signature())
-		}
-	}
-
+func (r *TestCase) Seed(seeders ...contractsseeder.Seeder) {
 	if artisanFacade == nil {
 		panic(errors.ArtisanFacadeNotSet.SetModule(errors.ModuleTesting))
 	}
 
-	artisanFacade.Call(command)
+	if err := artisanFacade.Call("db:seed" + getCommandOptionOfSeeders(seeders)); err != nil {
+		panic(err)
+	}
 }
 
-func (receiver *TestCase) RefreshDatabase(seeds ...seeder.Seeder) {
+func (r *TestCase) RefreshDatabase(seeders ...contractsseeder.Seeder) {
 	if artisanFacade == nil {
 		panic(errors.ArtisanFacadeNotSet.SetModule(errors.ModuleTesting))
 	}
 
-	artisanFacade.Call("migrate:refresh")
+	if err := artisanFacade.Call("migrate:refresh" + getCommandOptionOfSeeders(seeders)); err != nil {
+		panic(err)
+	}
+}
+
+func getCommandOptionOfSeeders(seeders []contractsseeder.Seeder) string {
+	if len(seeders) == 0 {
+		return ""
+	}
+
+	command := " --seeder"
+	for _, seed := range seeders {
+		command += fmt.Sprintf(" %s", seed.Signature())
+	}
+
+	return command
 }

--- a/testing/test_case_test.go
+++ b/testing/test_case_test.go
@@ -3,14 +3,15 @@ package testing
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	consolemocks "github.com/goravel/framework/mocks/console"
+	mocksconsole "github.com/goravel/framework/mocks/console"
 )
 
 type TestCaseSuite struct {
 	suite.Suite
-	mockArtisan *consolemocks.Artisan
+	mockArtisan *mocksconsole.Artisan
 	testCase    *TestCase
 }
 
@@ -20,26 +21,32 @@ func TestTestCaseSuite(t *testing.T) {
 
 // SetupTest will run before each test in the suite.
 func (s *TestCaseSuite) SetupTest() {
-	s.mockArtisan = &consolemocks.Artisan{}
+	s.mockArtisan = mocksconsole.NewArtisan(s.T())
 	s.testCase = &TestCase{}
 	artisanFacade = s.mockArtisan
 }
 
 func (s *TestCaseSuite) TestSeed() {
-	s.mockArtisan.On("Call", "db:seed").Once()
+	s.mockArtisan.On("Call", "db:seed").Return(nil).Once()
 	s.testCase.Seed()
 
-	s.mockArtisan.On("Call", "db:seed --seeder mock").Once()
+	s.mockArtisan.On("Call", "db:seed --seeder mock").Return(nil).Once()
 	s.testCase.Seed(&MockSeeder{})
 
-	s.mockArtisan.AssertExpectations(s.T())
+	s.Panics(func() {
+		s.mockArtisan.On("Call", "db:seed").Return(assert.AnError).Once()
+		s.testCase.Seed()
+	})
 }
 
 func (s *TestCaseSuite) TestRefreshDatabase() {
-	s.mockArtisan.On("Call", "migrate:refresh").Once()
+	s.mockArtisan.On("Call", "migrate:refresh").Return(nil).Once()
 	s.testCase.RefreshDatabase()
 
-	s.mockArtisan.AssertExpectations(s.T())
+	s.Panics(func() {
+		s.mockArtisan.On("Call", "migrate:refresh").Return(assert.AnError).Once()
+		s.testCase.RefreshDatabase()
+	})
 }
 
 type MockSeeder struct{}


### PR DESCRIPTION
## 📑 Description

Some commands will be called internally, but the `facades.Artisann().Call()` method panic directly when encountering an error, we want to return the error. 

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced error handling in various commands and methods, allowing for better reporting of failures.
	- Introduced new test cases to cover both successful and erroneous scenarios for migration commands.

- **Bug Fixes**
	- Improved error propagation in the `Seed`, `Build`, and migration methods to ensure that errors are properly handled and reported.

- **Tests**
	- Updated test cases to include assertions for error scenarios, ensuring robust testing of command executions.
	- Added a new test file for `MigrateCommand` functionality, covering multiple scenarios.

- **Chores**
	- Updated Go version in `go.mod` for improved dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
