### PR TITLE
feat: remove route.Shutdown

### DIFF
--- a/contracts/route/route.go
+++ b/contracts/route/route.go
@@ -23,8 +23,6 @@ type Route interface {
 	RunTLSWithCert(host, certFile, keyFile string) error
 	// ServeHTTP serves HTTP requests.
 	ServeHTTP(writer http.ResponseWriter, request *http.Request)
-	// DEPRECATED use Stop instead.
-	Shutdown(ctx ...context.Context) error
 	// Stop gracefully stop the serve.
 	Stop(ctx ...context.Context) error
 }

--- a/mocks/route/Route.go
+++ b/mocks/route/Route.go
@@ -719,65 +719,6 @@ func (_c *Route_ServeHTTP_Call) RunAndReturn(run func(nethttp.ResponseWriter, *n
 	return _c
 }
 
-// Shutdown provides a mock function with given fields: ctx
-func (_m *Route) Shutdown(ctx ...context.Context) error {
-	_va := make([]interface{}, len(ctx))
-	for _i := range ctx {
-		_va[_i] = ctx[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Shutdown")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(...context.Context) error); ok {
-		r0 = rf(ctx...)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// Route_Shutdown_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Shutdown'
-type Route_Shutdown_Call struct {
-	*mock.Call
-}
-
-// Shutdown is a helper method to define mock.On call
-//   - ctx ...context.Context
-func (_e *Route_Expecter) Shutdown(ctx ...interface{}) *Route_Shutdown_Call {
-	return &Route_Shutdown_Call{Call: _e.mock.On("Shutdown",
-		append([]interface{}{}, ctx...)...)}
-}
-
-func (_c *Route_Shutdown_Call) Run(run func(ctx ...context.Context)) *Route_Shutdown_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]context.Context, len(args)-0)
-		for i, a := range args[0:] {
-			if a != nil {
-				variadicArgs[i] = a.(context.Context)
-			}
-		}
-		run(variadicArgs...)
-	})
-	return _c
-}
-
-func (_c *Route_Shutdown_Call) Return(_a0 error) *Route_Shutdown_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Route_Shutdown_Call) RunAndReturn(run func(...context.Context) error) *Route_Shutdown_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Static provides a mock function with given fields: relativePath, root
 func (_m *Route) Static(relativePath string, root string) {
 	_m.Called(relativePath, root)


### PR DESCRIPTION
## 📑 Description

Remove `route.Shutdown`, use `route.Stop` directly.

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
