### PR TITLE
fix: [#280] add wrap for sql

### DIFF
--- a/contracts/database/schema/grammar.go
+++ b/contracts/database/schema/grammar.go
@@ -31,8 +31,6 @@ type Grammar interface {
 	CompileViews() string
 	// GetAttributeCommands Get the commands for the schema build.
 	GetAttributeCommands() []string
-	// GetModifiers Get the column modifiers.
-	GetModifiers() []func(Blueprint, ColumnDefinition) string
 	// TypeBigInteger Create the column definition for a big integer type.
 	TypeBigInteger(column ColumnDefinition) string
 	// TypeInteger Create the column definition for an integer type.

--- a/database/schema/blueprint.go
+++ b/database/schema/blueprint.go
@@ -64,7 +64,7 @@ func (r *Blueprint) DropIfExists() {
 func (r *Blueprint) Foreign(column ...string) schema.ForeignKeyDefinition {
 	command := r.indexCommand(constants.CommandForeign, column)
 
-	return NewForeignKeyDefinition(command, r.prefix)
+	return NewForeignKeyDefinition(command)
 }
 
 func (r *Blueprint) GetAddedColumns() []schema.ColumnDefinition {

--- a/database/schema/blueprint.go
+++ b/database/schema/blueprint.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"fmt"
 	"strings"
 
 	ormcontract "github.com/goravel/framework/contracts/database/orm"
@@ -81,7 +82,7 @@ func (r *Blueprint) GetCommands() []*schema.Command {
 
 func (r *Blueprint) GetTableName() string {
 	// TODO Add schema for Postgres
-	return r.prefix + r.table
+	return r.table
 }
 
 func (r *Blueprint) HasCommand(command string) bool {
@@ -205,11 +206,20 @@ func (r *Blueprint) addImpliedCommands(grammar schema.Grammar) {
 }
 
 func (r *Blueprint) createIndexName(ttype string, columns []string) string {
-	table := r.GetTableName()
-	index := strings.ToLower(table + "_" + strings.Join(columns, "_") + "_" + ttype)
-	index = strings.ReplaceAll(index, "-", "_")
+	var table string
+	if strings.Contains(r.table, ".") {
+		lastDotIndex := strings.LastIndex(r.table, ".")
+		table = r.table[:lastDotIndex+1] + r.prefix + r.table[lastDotIndex+1:]
+	} else {
+		table = r.prefix + r.table
+	}
 
-	return strings.ReplaceAll(index, ".", "_")
+	index := strings.ToLower(fmt.Sprintf("%s_%s_%s", table, strings.Join(columns, "_"), ttype))
+
+	index = strings.ReplaceAll(index, "-", "_")
+	index = strings.ReplaceAll(index, ".", "_")
+
+	return index
 }
 
 func (r *Blueprint) indexCommand(ttype string, columns []string, config ...schema.IndexConfig) *schema.Command {

--- a/database/schema/blueprint_test.go
+++ b/database/schema/blueprint_test.go
@@ -24,7 +24,7 @@ type BlueprintTestSuite struct {
 func TestBlueprintTestSuite(t *testing.T) {
 	suite.Run(t, &BlueprintTestSuite{
 		grammars: map[database.Driver]schema.Grammar{
-			database.DriverPostgres: grammars.NewPostgres(),
+			database.DriverPostgres: grammars.NewPostgres("goravel_"),
 		},
 	})
 }
@@ -139,6 +139,10 @@ func (s *BlueprintTestSuite) TestBuild() {
 func (s *BlueprintTestSuite) TestCreateIndexName() {
 	name := s.blueprint.createIndexName("index", []string{"id", "name-1", "name.2"})
 	s.Equal("goravel_users_id_name_1_name_2_index", name)
+
+	s.blueprint.table = "public.users"
+	name = s.blueprint.createIndexName("index", []string{"id", "name-1", "name.2"})
+	s.Equal("public_goravel_users_id_name_1_name_2_index", name)
 }
 
 func (s *BlueprintTestSuite) TestGetAddedColumns() {
@@ -151,11 +155,6 @@ func (s *BlueprintTestSuite) TestGetAddedColumns() {
 
 	s.Len(s.blueprint.GetAddedColumns(), 1)
 	s.Equal(addedColumn, s.blueprint.GetAddedColumns()[0])
-}
-
-func (s *BlueprintTestSuite) TestGetTableName() {
-	s.blueprint.SetTable("users")
-	s.Equal("goravel_users", s.blueprint.GetTableName())
 }
 
 func (s *BlueprintTestSuite) TestHasCommand() {

--- a/database/schema/grammars/postgres_test.go
+++ b/database/schema/grammars/postgres_test.go
@@ -206,6 +206,31 @@ func (s *PostgresSuite) TestCompilePrimary() {
 	}))
 }
 
+func (s *PostgresSuite) TestGetColumns() {
+	mockColumn1 := mocksschema.NewColumnDefinition(s.T())
+	mockColumn2 := mocksschema.NewColumnDefinition(s.T())
+	mockBlueprint := mocksschema.NewBlueprint(s.T())
+
+	mockBlueprint.EXPECT().GetAddedColumns().Return([]contractsschema.ColumnDefinition{
+		mockColumn1, mockColumn2,
+	}).Once()
+	mockBlueprint.EXPECT().HasCommand("primary").Return(false).Twice()
+
+	mockColumn1.EXPECT().GetName().Return("id").Once()
+	mockColumn1.EXPECT().GetType().Return("integer").Twice()
+	mockColumn1.EXPECT().GetDefault().Return(nil).Once()
+	mockColumn1.EXPECT().GetNullable().Return(false).Once()
+	mockColumn1.EXPECT().GetAutoIncrement().Return(true).Twice()
+
+	mockColumn2.EXPECT().GetName().Return("name").Once()
+	mockColumn2.EXPECT().GetType().Return("string").Twice()
+	mockColumn2.EXPECT().GetDefault().Return("goravel").Twice()
+	mockColumn2.EXPECT().GetNullable().Return(true).Once()
+	mockColumn2.EXPECT().GetLength().Return(10).Once()
+
+	s.Equal([]string{"\"id\" serial primary key not null", "\"name\" varchar(10) default 'goravel' null"}, s.grammar.getColumns(mockBlueprint))
+}
+
 func (s *PostgresSuite) TestEscapeNames() {
 	// SingleName
 	names := []string{"username"}

--- a/database/schema/grammars/utils.go
+++ b/database/schema/grammars/utils.go
@@ -10,29 +10,6 @@ import (
 	"github.com/goravel/framework/contracts/database/schema"
 )
 
-func addModify(modifiers []func(schema.Blueprint, schema.ColumnDefinition) string, sql string, blueprint schema.Blueprint, column schema.ColumnDefinition) string {
-	for _, modifier := range modifiers {
-		sql += modifier(blueprint, column)
-	}
-
-	return sql
-}
-
-func getColumn(grammar schema.Grammar, blueprint schema.Blueprint, column schema.ColumnDefinition) string {
-	sql := fmt.Sprintf("%s %s", column.GetName(), getType(grammar, column))
-
-	return addModify(grammar.GetModifiers(), sql, blueprint, column)
-}
-
-func getColumns(grammar schema.Grammar, blueprint schema.Blueprint) []string {
-	var columns []string
-	for _, column := range blueprint.GetAddedColumns() {
-		columns = append(columns, getColumn(grammar, blueprint, column))
-	}
-
-	return columns
-}
-
 func getCommandByName(commands []*schema.Command, name string) *schema.Command {
 	commands = getCommandsByName(commands, name)
 	if len(commands) == 0 {
@@ -79,20 +56,4 @@ func getType(grammar schema.Grammar, column schema.ColumnDefinition) string {
 	}
 
 	return ""
-}
-
-func prefixArray(prefix string, values []string) []string {
-	for i, value := range values {
-		values[i] = prefix + " " + value
-	}
-
-	return values
-}
-
-func quoteString(value string) string {
-	if value == "" {
-		return value
-	}
-
-	return fmt.Sprintf("'%s'", value)
 }

--- a/database/schema/grammars/utils_test.go
+++ b/database/schema/grammars/utils_test.go
@@ -9,28 +9,6 @@ import (
 	mocksschema "github.com/goravel/framework/mocks/database/schema"
 )
 
-func TestGetColumns(t *testing.T) {
-	mockColumn1 := mocksschema.NewColumnDefinition(t)
-	mockColumn1.EXPECT().GetName().Return("id").Once()
-	mockColumn1.EXPECT().GetType().Return("string").Once()
-
-	mockColumn2 := mocksschema.NewColumnDefinition(t)
-	mockColumn2.EXPECT().GetName().Return("name").Once()
-	mockColumn2.EXPECT().GetType().Return("string").Once()
-
-	mockBlueprint := mocksschema.NewBlueprint(t)
-	mockBlueprint.EXPECT().GetAddedColumns().Return([]schema.ColumnDefinition{
-		mockColumn1, mockColumn2,
-	}).Once()
-
-	mockGrammar := mocksschema.NewGrammar(t)
-	mockGrammar.EXPECT().GetModifiers().Return([]func(schema.Blueprint, schema.ColumnDefinition) string{}).Twice()
-	mockGrammar.EXPECT().TypeString(mockColumn1).Return("varchar(100)").Once()
-	mockGrammar.EXPECT().TypeString(mockColumn2).Return("varchar").Once()
-
-	assert.Equal(t, []string{"id varchar(100)", "name varchar"}, getColumns(mockGrammar, mockBlueprint))
-}
-
 func TestGetCommandByName(t *testing.T) {
 	commands := []*schema.Command{
 		{Name: "create"},
@@ -79,9 +57,4 @@ func TestGetType(t *testing.T) {
 	mockGrammar1 := mocksschema.NewGrammar(t)
 
 	assert.Empty(t, getType(mockGrammar1, mockColumn1))
-}
-
-func TestPrefixArray(t *testing.T) {
-	values := []string{"a", "b", "c"}
-	assert.Equal(t, []string{"prefix a", "prefix b", "prefix c"}, prefixArray("prefix", values))
 }

--- a/database/schema/grammars/wrap.go
+++ b/database/schema/grammars/wrap.go
@@ -57,10 +57,7 @@ func (r *Wrap) Table(table string) string {
 	}
 	if strings.Contains(table, ".") {
 		lastDotIndex := strings.LastIndex(table, ".")
-		newTable := table[:lastDotIndex] + "." + r.tablePrefix
-		if lastDotIndex+1 < len(table) {
-			newTable += table[lastDotIndex+1:]
-		}
+		newTable := table[:lastDotIndex] + "." + r.tablePrefix + table[lastDotIndex+1:]
 
 		return r.Value(newTable)
 	}

--- a/database/schema/grammars/wrap.go
+++ b/database/schema/grammars/wrap.go
@@ -1,0 +1,89 @@
+package grammars
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Wrap struct {
+	tablePrefix string
+}
+
+func NewWrap(tablePrefix string) *Wrap {
+	return &Wrap{
+		tablePrefix: tablePrefix,
+	}
+}
+
+func (r *Wrap) Column(column string) string {
+	if strings.Contains(column, " as ") {
+		return r.aliasedValue(column)
+	}
+
+	return r.Segments(strings.Split(column, "."))
+}
+
+func (r *Wrap) Columns(columns []string) string {
+	for i, column := range columns {
+		columns[i] = r.Column(column)
+	}
+
+	return strings.Join(columns, ", ")
+}
+
+func (r *Wrap) Quote(value string) string {
+	if value == "" {
+		return value
+	}
+
+	return fmt.Sprintf("'%s'", value)
+}
+
+func (r *Wrap) Segments(segments []string) string {
+	for i, segment := range segments {
+		if i == 0 && len(segments) > 1 {
+			segments[i] = r.Table(segment)
+		} else {
+			segments[i] = r.Value(segment)
+		}
+	}
+
+	return strings.Join(segments, ".")
+}
+
+func (r *Wrap) Table(table string) string {
+	if strings.Contains(table, " as ") {
+		return r.aliasedTable(table)
+	}
+	if strings.Contains(table, ".") {
+		lastDotIndex := strings.LastIndex(table, ".")
+		newTable := table[:lastDotIndex] + "." + r.tablePrefix
+		if lastDotIndex+1 < len(table) {
+			newTable += table[lastDotIndex+1:]
+		}
+
+		return r.Value(newTable)
+	}
+
+	return r.Value(r.tablePrefix + table)
+}
+
+func (r *Wrap) Value(value string) string {
+	if value != "*" {
+		return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+	}
+
+	return value
+}
+
+func (r *Wrap) aliasedTable(table string) string {
+	segments := strings.Split(table, " as ")
+
+	return r.Table(segments[0]) + " as " + r.Value(r.tablePrefix+segments[1])
+}
+
+func (r *Wrap) aliasedValue(value string) string {
+	segments := strings.Split(value, " as ")
+
+	return r.Column(segments[0]) + " as " + r.Value(r.tablePrefix+segments[1])
+}

--- a/database/schema/grammars/wrap_test.go
+++ b/database/schema/grammars/wrap_test.go
@@ -1,0 +1,70 @@
+package grammars
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type WrapTestSuite struct {
+	suite.Suite
+	wrap *Wrap
+}
+
+func TestWrapSuite(t *testing.T) {
+	suite.Run(t, new(WrapTestSuite))
+}
+
+func (s *WrapTestSuite) SetupTest() {
+	s.wrap = NewWrap("prefix_")
+}
+
+func (s *WrapTestSuite) ColumnWithAlias() {
+	result := s.wrap.Column("column as alias")
+	s.Equal(`"column" as "prefix_alias"`, result)
+}
+
+func (s *WrapTestSuite) ColumnWithoutAlias() {
+	result := s.wrap.Column("column")
+	s.Equal(`"column"`, result)
+}
+
+func (s *WrapTestSuite) ColumnsWithMultipleColumns() {
+	result := s.wrap.Columns([]string{"column1", "column2 as alias2"})
+	s.Equal(`"column1", "column2" as "prefix_alias2"`, result)
+}
+
+func (s *WrapTestSuite) QuoteWithNonEmptyValue() {
+	result := s.wrap.Quote("value")
+	s.Equal("'value'", result)
+}
+
+func (s *WrapTestSuite) QuoteWithEmptyValue() {
+	result := s.wrap.Quote("")
+	s.Equal("", result)
+}
+
+func (s *WrapTestSuite) SegmentsWithMultipleSegments() {
+	result := s.wrap.Segments([]string{"table", "column"})
+	s.Equal(`"prefix_table"."column"`, result)
+}
+
+func (s *WrapTestSuite) TableWithAlias() {
+	result := s.wrap.Table("table as alias")
+	s.Equal(`"prefix_table" as "prefix_alias"`, result)
+}
+
+func (s *WrapTestSuite) TableWithoutAlias() {
+	result := s.wrap.Table("table")
+	s.Equal(`"prefix_table"`, result)
+}
+
+func (s *WrapTestSuite) ValueWithAsterisk() {
+	result := s.wrap.Value("*")
+	s.Equal("*", result)
+}
+
+func (s *WrapTestSuite) ValueWithNonAsterisk() {
+	result := s.wrap.Value("value")
+	s.Equal(`"value"`, result)
+}

--- a/database/schema/index.go
+++ b/database/schema/index.go
@@ -6,13 +6,11 @@ import (
 
 type ForeignKeyDefinition struct {
 	command *schema.Command
-	prefix  string
 }
 
-func NewForeignKeyDefinition(command *schema.Command, prefix string) schema.ForeignKeyDefinition {
+func NewForeignKeyDefinition(command *schema.Command) schema.ForeignKeyDefinition {
 	return &ForeignKeyDefinition{
 		command: command,
-		prefix:  prefix,
 	}
 }
 
@@ -29,7 +27,7 @@ func (f *ForeignKeyDefinition) CascadeOnUpdate() schema.ForeignKeyDefinition {
 }
 
 func (f *ForeignKeyDefinition) On(table string) schema.ForeignKeyDefinition {
-	f.command.On = f.prefix + table
+	f.command.On = table
 
 	return f
 }

--- a/database/schema/postgres_schema_test.go
+++ b/database/schema/postgres_schema_test.go
@@ -31,7 +31,7 @@ func (s *PostgresSchemaSuite) SetupTest() {
 	postgresDocker := docker.Postgres()
 	s.testQuery = gorm.NewTestQuery(postgresDocker, true)
 	s.mockOrm = mocksorm.NewOrm(s.T())
-	s.postgresSchema = NewPostgresSchema(grammars.NewPostgres(), s.mockOrm, "goravel", "framework")
+	s.postgresSchema = NewPostgresSchema(grammars.NewPostgres("goravel_"), s.mockOrm, "goravel", "goravel_")
 }
 
 // TODO Implement this after implementing create type

--- a/database/schema/schema.go
+++ b/database/schema/schema.go
@@ -49,7 +49,7 @@ func NewSchema(config config.Config, log log.Log, orm contractsorm.Orm, migratio
 	case contractsdatabase.DriverSqlserver:
 		// TODO Optimize here when implementing Sqlserver driver
 	case contractsdatabase.DriverSqlite:
-		sqliteGrammar := grammars.NewSqlite()
+		sqliteGrammar := grammars.NewSqlite(prefix)
 		driverSchema = NewSqliteSchema(sqliteGrammar, orm, prefix)
 		grammar = sqliteGrammar
 	default:

--- a/database/schema/schema.go
+++ b/database/schema/schema.go
@@ -41,7 +41,7 @@ func NewSchema(config config.Config, log log.Log, orm contractsorm.Orm, migratio
 	case contractsdatabase.DriverPostgres:
 		schema := config.GetString(fmt.Sprintf("database.connections.%s.search_path", orm.Name()), "public")
 
-		postgresGrammar := grammars.NewPostgres()
+		postgresGrammar := grammars.NewPostgres(prefix)
 		driverSchema = NewPostgresSchema(postgresGrammar, orm, schema, prefix)
 		grammar = postgresGrammar
 	case contractsdatabase.DriverMysql:
@@ -122,8 +122,7 @@ func (r *Schema) HasIndex(table, index string) bool {
 }
 
 func (r *Schema) HasTable(name string) bool {
-	blueprint := r.createBlueprint(name)
-	tableName := blueprint.GetTableName()
+	tableName := r.prefix + name
 
 	tables, err := r.GetTables()
 	if err != nil {

--- a/mocks/database/schema/Grammar.go
+++ b/mocks/database/schema/Grammar.go
@@ -713,53 +713,6 @@ func (_c *Grammar_GetAttributeCommands_Call) RunAndReturn(run func() []string) *
 	return _c
 }
 
-// GetModifiers provides a mock function with given fields:
-func (_m *Grammar) GetModifiers() []func(schema.Blueprint, schema.ColumnDefinition) string {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetModifiers")
-	}
-
-	var r0 []func(schema.Blueprint, schema.ColumnDefinition) string
-	if rf, ok := ret.Get(0).(func() []func(schema.Blueprint, schema.ColumnDefinition) string); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]func(schema.Blueprint, schema.ColumnDefinition) string)
-		}
-	}
-
-	return r0
-}
-
-// Grammar_GetModifiers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetModifiers'
-type Grammar_GetModifiers_Call struct {
-	*mock.Call
-}
-
-// GetModifiers is a helper method to define mock.On call
-func (_e *Grammar_Expecter) GetModifiers() *Grammar_GetModifiers_Call {
-	return &Grammar_GetModifiers_Call{Call: _e.mock.On("GetModifiers")}
-}
-
-func (_c *Grammar_GetModifiers_Call) Run(run func()) *Grammar_GetModifiers_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *Grammar_GetModifiers_Call) Return(_a0 []func(schema.Blueprint, schema.ColumnDefinition) string) *Grammar_GetModifiers_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Grammar_GetModifiers_Call) RunAndReturn(run func() []func(schema.Blueprint, schema.ColumnDefinition) string) *Grammar_GetModifiers_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // TypeBigInteger provides a mock function with given fields: column
 func (_m *Grammar) TypeBigInteger(column schema.ColumnDefinition) string {
 	ret := _m.Called(column)

--- a/support/docker/docker.go
+++ b/support/docker/docker.go
@@ -15,7 +15,7 @@ const (
 	TestModelNormal
 
 	// Switch this value to control the test model.
-	TestModel = TestModelNormal
+	TestModel = TestModelMinimum
 )
 
 type ContainerType string

--- a/support/docker/docker.go
+++ b/support/docker/docker.go
@@ -15,7 +15,7 @@ const (
 	TestModelNormal
 
 	// Switch this value to control the test model.
-	TestModel = TestModelMinimum
+	TestModel = TestModelNormal
 )
 
 type ContainerType string


### PR DESCRIPTION
## 📑 Description

Add wrap for table, column, index, etc:

```
-- create table goravel_users (id serial primary key not null, name varchar(100) null)
++ create table "goravel_users" ("id" serial primary key not null, "name" varchar(100) null)
```

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `Wrap` struct for managing SQL table and column naming conventions with a specified prefix.
  - Enhanced handling of foreign key definitions and index naming conventions.

- **Bug Fixes**
  - Removed deprecated methods and adjusted related functionalities for better clarity and performance.

- **Tests**
  - Expanded test coverage for PostgreSQL and SQLite grammar operations to validate new naming conventions and functionality.

- **Documentation**
  - Updated initialization methods to include a table prefix, improving consistency across database schema operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
