### PR TITLE
feat: [#282] Print the values in ctx when calling facades.Log().WithContext(ctx).Info()

### DIFF
--- a/contracts/log/log.go
+++ b/contracts/log/log.go
@@ -104,6 +104,10 @@ type Entry interface {
 	Context() context.Context
 	// Data returns the data of the entry.
 	Data() Data
+	// Domain returns the domain of the entry.
+	Domain() string
+	// Hint returns the hint of the entry.
+	Hint() string
 	// Level returns the level of the entry.
 	Level() Level
 	// Message returns the message of the entry.

--- a/log/application.go
+++ b/log/application.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/foundation"
+	"github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/contracts/log"
 	"github.com/goravel/framework/support/color"
 )
@@ -37,6 +38,10 @@ func NewApplication(config config.Config, json foundation.Json) (*Application, e
 }
 
 func (r *Application) WithContext(ctx context.Context) log.Writer {
+	if httpCtx, ok := ctx.(http.Context); ok {
+		return NewWriter(r.instance.WithContext(httpCtx.Context()))
+	}
+
 	return NewWriter(r.instance.WithContext(ctx))
 }
 

--- a/log/entry.go
+++ b/log/entry.go
@@ -8,19 +8,21 @@ import (
 )
 
 type Entry struct {
+	code       string
 	ctx        context.Context
 	data       log.Data
+	domain     string
+	hint       string
 	level      log.Level
-	time       time.Time
 	message    string
-	code       string
-	user       any
-	tags       []string
 	owner      any
 	request    map[string]any
 	response   map[string]any
-	with       map[string]any
 	stacktrace map[string]any
+	tags       []string
+	time       time.Time
+	user       any
+	with       map[string]any
 }
 
 func (r *Entry) Code() string {
@@ -33,6 +35,14 @@ func (r *Entry) Context() context.Context {
 
 func (r *Entry) Data() log.Data {
 	return r.data
+}
+
+func (r *Entry) Domain() string {
+	return r.domain
+}
+
+func (r *Entry) Hint() string {
+	return r.hint
 }
 
 func (r *Entry) Level() log.Level {

--- a/log/formatter/general.go
+++ b/log/formatter/general.go
@@ -82,14 +82,9 @@ func (general *General) formatData(data logrus.Fields) (string, error) {
 			return "", err
 		}
 
-		for _, key := range []string{"code", "context", "domain", "hint", "owner", "request", "response", "tags", "user"} {
+		for _, key := range []string{"code", "context", "with", "domain", "hint", "owner", "request", "response", "tags", "user"} {
 			if value, exists := root[key]; exists && value != nil {
-				v, err := general.json.Marshal(value)
-				if err != nil {
-					return "", err
-				}
-
-				builder.WriteString(fmt.Sprintf("%s: %v\n", key, string(v)))
+				builder.WriteString(fmt.Sprintf("%s: %+v\n", key, value))
 			}
 		}
 

--- a/log/formatter/general.go
+++ b/log/formatter/general.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/foundation"
+	"github.com/goravel/framework/support/str"
 )
 
 type General struct {
@@ -82,9 +83,9 @@ func (general *General) formatData(data logrus.Fields) (string, error) {
 			return "", err
 		}
 
-		for _, key := range []string{"code", "context", "with", "domain", "hint", "owner", "request", "response", "tags", "user"} {
+		for _, key := range []string{"hint", "tags", "owner", "context", "with", "domain", "code", "request", "response", "user"} {
 			if value, exists := root[key]; exists && value != nil {
-				builder.WriteString(fmt.Sprintf("%s: %+v\n", key, value))
+				builder.WriteString(fmt.Sprintf("%s: %+v\n", str.Of(key).UcFirst().String(), value))
 			}
 		}
 
@@ -113,7 +114,7 @@ func (general *General) formatStackTraces(stackTraces any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	formattedTraces.WriteString("trace:\n")
+	formattedTraces.WriteString("Trace:\n")
 	root := traces.Root
 	if len(root.Stack) > 0 {
 		for _, stackStr := range root.Stack {

--- a/log/formatter/general_test.go
+++ b/log/formatter/general_test.go
@@ -71,10 +71,10 @@ func (s *GeneralTestSuite) TestFormat() {
 			assert: func() {
 				formatLog, err := general.Format(s.entry)
 				s.Nil(err)
-				s.Contains(string(formatLog), "code: \"200\"")
-				s.Contains(string(formatLog), "domain: \"example.com\"")
-				s.Contains(string(formatLog), "owner: \"owner\"")
-				s.Contains(string(formatLog), "user: \"user1\"")
+				s.Contains(string(formatLog), "code: 200")
+				s.Contains(string(formatLog), "domain: example.com")
+				s.Contains(string(formatLog), "owner: owner")
+				s.Contains(string(formatLog), "user: user1")
 			},
 		},
 	}
@@ -121,29 +121,6 @@ func (s *GeneralTestSuite) TestFormatData() {
 			},
 		},
 		{
-			name: "Invalid data type",
-			setup: func() {
-				data = logrus.Fields{
-					"root": map[string]any{
-						"code":     "123",
-						"context":  "sample",
-						"domain":   "example.com",
-						"hint":     make(chan int), // Invalid data type that will cause an error during value extraction
-						"owner":    "owner",
-						"request":  map[string]any{"method": "GET", "uri": "http://localhost"},
-						"response": map[string]any{"status": 200},
-						"tags":     []string{"tag1", "tag2"},
-						"user":     "user1",
-					},
-				}
-			},
-			assert: func() {
-				formattedData, err := general.formatData(data)
-				s.NotNil(err)
-				s.Empty(formattedData)
-			},
-		},
-		{
 			name: "Data is not empty",
 			setup: func() {
 				data = logrus.Fields{
@@ -158,10 +135,10 @@ func (s *GeneralTestSuite) TestFormatData() {
 			assert: func() {
 				formattedData, err := general.formatData(data)
 				s.Nil(err)
-				s.Contains(formattedData, "code: \"200\"")
-				s.Contains(formattedData, "domain: \"example.com\"")
-				s.Contains(formattedData, "owner: \"owner\"")
-				s.Contains(formattedData, "user: \"user1\"")
+				s.Contains(formattedData, "code: 200")
+				s.Contains(formattedData, "domain: example.com")
+				s.Contains(formattedData, "owner: owner")
+				s.Contains(formattedData, "user: user1")
 			},
 		},
 	}

--- a/log/formatter/general_test.go
+++ b/log/formatter/general_test.go
@@ -71,10 +71,10 @@ func (s *GeneralTestSuite) TestFormat() {
 			assert: func() {
 				formatLog, err := general.Format(s.entry)
 				s.Nil(err)
-				s.Contains(string(formatLog), "code: 200")
-				s.Contains(string(formatLog), "domain: example.com")
-				s.Contains(string(formatLog), "owner: owner")
-				s.Contains(string(formatLog), "user: user1")
+				s.Contains(string(formatLog), "Code: 200")
+				s.Contains(string(formatLog), "Domain: example.com")
+				s.Contains(string(formatLog), "Owner: owner")
+				s.Contains(string(formatLog), "User: user1")
 			},
 		},
 	}
@@ -135,10 +135,10 @@ func (s *GeneralTestSuite) TestFormatData() {
 			assert: func() {
 				formattedData, err := general.formatData(data)
 				s.Nil(err)
-				s.Contains(formattedData, "code: 200")
-				s.Contains(formattedData, "domain: example.com")
-				s.Contains(formattedData, "owner: owner")
-				s.Contains(formattedData, "user: user1")
+				s.Contains(formattedData, "Code: 200")
+				s.Contains(formattedData, "Domain: example.com")
+				s.Contains(formattedData, "Owner: owner")
+				s.Contains(formattedData, "User: user1")
 			},
 		},
 	}
@@ -167,7 +167,7 @@ func (s *GeneralTestSuite) TestFormatStackTraces() {
 			assert: func() {
 				traces, err := general.formatStackTraces(stackTraces)
 				s.Nil(err)
-				s.Equal("trace:\n", traces)
+				s.Equal("Trace:\n", traces)
 			},
 		},
 		{
@@ -200,7 +200,7 @@ func (s *GeneralTestSuite) TestFormatStackTraces() {
 					"/dummy/examples/logging/example.go:29 [main.(*Request).Validate]",
 					"/dummy/examples/logging/example.go:28 [main.(*Request).Validate]",
 				}
-				formattedStackTraces := "trace:\n" + strings.Join(stackTraces, "\n") + "\n"
+				formattedStackTraces := "Trace:\n" + strings.Join(stackTraces, "\n") + "\n"
 
 				s.Equal(formattedStackTraces, traces)
 			},

--- a/log/hook.go
+++ b/log/hook.go
@@ -55,7 +55,7 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 		if response, err := cast.ToStringMapE(root["response"]); err == nil {
 			e.response = response
 		}
-		if stacktrace, ok := cast.ToStringMapE(root["stacktrace"]); ok == nil {
+		if stacktrace, err := cast.ToStringMapE(root["stacktrace"]); err == nil {
 			e.stacktrace = stacktrace
 		}
 		if tags, err := cast.ToStringSliceE(root["tags"]); err == nil {
@@ -64,7 +64,7 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 
 		e.user = root["user"]
 
-		if with, ok := cast.ToStringMapE(root["with"]); ok == nil {
+		if with, err := cast.ToStringMapE(root["with"]); err == nil {
 			e.with = with
 		}
 	}

--- a/log/hook.go
+++ b/log/hook.go
@@ -26,8 +26,8 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 		ctx:     entry.Context,
 		data:    map[string]any(entry.Data),
 		level:   log.Level(entry.Level),
-		time:    entry.Time,
 		message: entry.Message,
+		time:    entry.Time,
 	}
 
 	data := entry.Data

--- a/log/hook.go
+++ b/log/hook.go
@@ -1,0 +1,73 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cast"
+
+	"github.com/goravel/framework/contracts/log"
+)
+
+type Hook struct {
+	instance log.Hook
+}
+
+func (h *Hook) Levels() []logrus.Level {
+	levels := h.instance.Levels()
+	var logrusLevels []logrus.Level
+	for _, item := range levels {
+		logrusLevels = append(logrusLevels, logrus.Level(item))
+	}
+
+	return logrusLevels
+}
+
+func (h *Hook) Fire(entry *logrus.Entry) error {
+	e := &Entry{
+		ctx:     entry.Context,
+		data:    map[string]any(entry.Data),
+		level:   log.Level(entry.Level),
+		time:    entry.Time,
+		message: entry.Message,
+	}
+
+	data := entry.Data
+	if len(data) > 0 {
+		root, err := cast.ToStringMapE(data["root"])
+		if err != nil {
+			return err
+		}
+
+		if code, err := cast.ToStringE(root["code"]); err == nil {
+			e.code = code
+		}
+		if domain, err := cast.ToStringE(root["domain"]); err == nil {
+			e.domain = domain
+		}
+		if hint, err := cast.ToStringE(root["hint"]); err == nil {
+			e.hint = hint
+		}
+
+		e.owner = root["owner"]
+
+		if request, err := cast.ToStringMapE(root["request"]); err == nil {
+			e.request = request
+		}
+		if response, err := cast.ToStringMapE(root["response"]); err == nil {
+			e.response = response
+		}
+		if stacktrace, ok := cast.ToStringMapE(root["stacktrace"]); ok == nil {
+			e.stacktrace = stacktrace
+		}
+		if tags, err := cast.ToStringSliceE(root["tags"]); err == nil {
+			e.tags = tags
+		}
+
+		e.user = root["user"]
+
+		if with, ok := cast.ToStringMapE(root["with"]); ok == nil {
+			e.with = with
+		}
+	}
+
+	return h.instance.Fire(e)
+}

--- a/log/hook_test.go
+++ b/log/hook_test.go
@@ -1,0 +1,149 @@
+package log
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goravel/framework/contracts/log"
+	mockslog "github.com/goravel/framework/mocks/log"
+)
+
+func TestHook_Fire(t *testing.T) {
+	var (
+		mockHook *mockslog.Hook
+
+		ctx        = context.Background()
+		code       = "123"
+		domain     = "example.com"
+		hint       = "hint"
+		level      = logrus.InfoLevel
+		message    = "message"
+		owner      = "owner"
+		request    = map[string]any{"key": "value"}
+		response   = map[string]any{"key": "value"}
+		stacktrace = map[string]any{"key": "value"}
+		now        = time.Now()
+		tags       = []string{"tag1", "tag2"}
+		user       = "user"
+		with       = map[string]any{"key": "value"}
+	)
+
+	tests := []struct {
+		name        string
+		entry       *logrus.Entry
+		setup       func()
+		expectError error
+	}{
+		{
+			name: "full data",
+			entry: &logrus.Entry{
+				Context: ctx,
+				Data: logrus.Fields{
+					"root": map[string]any{
+						"code":       code,
+						"domain":     domain,
+						"hint":       hint,
+						"owner":      owner,
+						"request":    request,
+						"response":   response,
+						"stacktrace": stacktrace,
+						"tags":       tags,
+						"user":       user,
+						"with":       with,
+					},
+				},
+				Level:   level,
+				Time:    now,
+				Message: message,
+			},
+			setup: func() {
+				mockHook.EXPECT().Fire(&Entry{
+					ctx:  ctx,
+					code: code,
+					data: map[string]any{
+						"root": map[string]any{
+							"code":       code,
+							"domain":     domain,
+							"hint":       hint,
+							"owner":      owner,
+							"request":    request,
+							"response":   response,
+							"stacktrace": stacktrace,
+							"tags":       tags,
+							"user":       user,
+							"with":       with,
+						},
+					},
+					domain:     domain,
+					hint:       hint,
+					level:      log.Level(level),
+					message:    message,
+					owner:      owner,
+					request:    request,
+					response:   response,
+					stacktrace: stacktrace,
+					tags:       tags,
+					time:       now,
+					user:       user,
+					with:       with,
+				}).Return(nil).Once()
+			},
+		},
+		{
+			name: "empty data",
+			entry: &logrus.Entry{
+				Context: ctx,
+				Data:    logrus.Fields{},
+				Level:   level,
+				Time:    now,
+				Message: message,
+			},
+			setup: func() {
+				mockHook.EXPECT().Fire(&Entry{
+					ctx:     ctx,
+					data:    map[string]any{},
+					level:   log.Level(level),
+					message: message,
+					time:    now,
+				}).Return(nil).Once()
+			},
+		},
+		{
+			name: "Fire returns error",
+			entry: &logrus.Entry{
+				Context: ctx,
+				Data:    logrus.Fields{},
+				Level:   level,
+				Time:    now,
+				Message: message,
+			},
+			setup: func() {
+				mockHook.EXPECT().Fire(&Entry{
+					ctx:     ctx,
+					data:    map[string]any{},
+					level:   log.Level(level),
+					message: message,
+					time:    now,
+				}).Return(assert.AnError).Once()
+			},
+			expectError: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHook = mockslog.NewHook(t)
+			tt.setup()
+
+			hook := &Hook{instance: mockHook}
+
+			err := hook.Fire(tt.entry)
+
+			assert.Equal(t, tt.expectError, err)
+		})
+	}
+}

--- a/log/logrus_writer.go
+++ b/log/logrus_writer.go
@@ -5,14 +5,15 @@ import (
 	"io"
 	"os"
 
+	"github.com/rotisserie/eris"
+	"github.com/sirupsen/logrus"
+
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/contracts/log"
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/log/logger"
-	"github.com/rotisserie/eris"
-	"github.com/sirupsen/logrus"
 )
 
 func NewLogrus() *logrus.Logger {

--- a/log/logrus_writer.go
+++ b/log/logrus_writer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/contracts/log"
 	"github.com/goravel/framework/errors"
+	"github.com/goravel/framework/log/formatter"
 	"github.com/goravel/framework/log/logger"
 )
 
@@ -308,6 +309,7 @@ func registerHook(config config.Config, json foundation.Json, instance *logrus.L
 
 		if config.GetBool(channelPath + ".print") {
 			instance.SetOutput(os.Stdout)
+			instance.SetFormatter(formatter.NewGeneral(config, json))
 		}
 	case log.DailyDriver:
 		logLogger := logger.NewDaily(config, json)
@@ -318,6 +320,7 @@ func registerHook(config config.Config, json foundation.Json, instance *logrus.L
 
 		if config.GetBool(channelPath + ".print") {
 			instance.SetOutput(os.Stdout)
+			instance.SetFormatter(formatter.NewGeneral(config, json))
 		}
 	case log.CustomDriver:
 		logLogger := config.Get(channelPath + ".via").(log.Logger)

--- a/log/logrus_writer.go
+++ b/log/logrus_writer.go
@@ -5,17 +5,14 @@ import (
 	"io"
 	"os"
 
-	"github.com/rotisserie/eris"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cast"
-
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/contracts/log"
 	"github.com/goravel/framework/errors"
-	"github.com/goravel/framework/log/formatter"
 	"github.com/goravel/framework/log/logger"
+	"github.com/rotisserie/eris"
+	"github.com/sirupsen/logrus"
 )
 
 func NewLogrus() *logrus.Logger {
@@ -27,56 +24,36 @@ func NewLogrus() *logrus.Logger {
 }
 
 type Writer struct {
-	code string
-
-	// context
-	context map[string]any
-	domain  string
-
-	hint     string
-	instance *logrus.Entry
-	message  string
-	owner    any
-
-	// http
-	request  http.ContextRequest
-	response http.ContextResponse
-
-	// stacktrace
+	code         string
+	domain       string
+	hint         string
+	instance     *logrus.Entry
+	message      string
+	owner        any
+	request      http.ContextRequest
+	response     http.ContextResponse
 	stackEnabled bool
 	stacktrace   map[string]any
-
-	tags []string
-
-	// user
-	user any
+	tags         []string
+	user         any
+	with         map[string]any
 }
 
 func NewWriter(instance *logrus.Entry) log.Writer {
 	return &Writer{
-		code: "",
-
-		// context
-		context: map[string]any{},
-		domain:  "",
-
-		hint:     "",
-		instance: instance,
-		message:  "",
-		owner:    nil,
-
-		// http
-		request:  nil,
-		response: nil,
-
-		// stacktrace
+		code:         "",
+		domain:       "",
+		hint:         "",
+		instance:     instance,
+		message:      "",
+		owner:        nil,
+		request:      nil,
+		response:     nil,
 		stackEnabled: false,
 		stacktrace:   nil,
-
-		tags: []string{},
-
-		// user
-		user: nil,
+		tags:         []string{},
+		user:         nil,
+		with:         map[string]any{},
 	}
 }
 
@@ -194,7 +171,7 @@ func (r *Writer) User(user any) log.Writer {
 // With adds key-value pairs to the context of the log entry
 func (r *Writer) With(data map[string]any) log.Writer {
 	for k, v := range data {
-		r.context[k] = v
+		r.with[k] = v
 	}
 
 	return r
@@ -225,55 +202,45 @@ func (r *Writer) withStackTrace(message string) {
 // resetAll resets all properties of the log.Writer for a new log entry.
 func (r *Writer) resetAll() {
 	r.code = ""
-	r.context = map[string]any{}
 	r.domain = ""
 	r.hint = ""
 	r.message = ""
 	r.owner = nil
 	r.request = nil
 	r.response = nil
-	r.tags = []string{}
-	r.user = nil
 	r.stacktrace = nil
 	r.stackEnabled = false
+	r.tags = []string{}
+	r.user = nil
+	r.with = map[string]any{}
 }
 
 // toMap returns a map representation of the error.
 func (r *Writer) toMap() map[string]any {
 	payload := map[string]any{}
 
-	if message := r.message; message != "" {
-		payload["message"] = message
-	}
-
 	if code := r.code; code != "" {
 		payload["code"] = code
 	}
-
+	if ctx := r.instance.Context; ctx != nil {
+		values := make(map[any]any)
+		getContextValues(ctx, values)
+		if len(values) > 0 {
+			payload["context"] = values
+		}
+	}
 	if domain := r.domain; domain != "" {
 		payload["domain"] = domain
 	}
-
-	if tags := r.tags; len(tags) > 0 {
-		payload["tags"] = tags
-	}
-
-	if context := r.context; len(context) > 0 {
-		payload["context"] = context
-	}
-
 	if hint := r.hint; hint != "" {
 		payload["hint"] = hint
 	}
-
+	if message := r.message; message != "" {
+		payload["message"] = message
+	}
 	if owner := r.owner; owner != nil {
 		payload["owner"] = owner
 	}
-
-	if r.user != nil {
-		payload["user"] = r.user
-	}
-
 	if req := r.request; req != nil {
 		payload["request"] = map[string]any{
 			"method": req.Method(),
@@ -282,7 +249,6 @@ func (r *Writer) toMap() map[string]any {
 			"body":   req.All(),
 		}
 	}
-
 	if res := r.response; res != nil {
 		payload["response"] = map[string]any{
 			"status": res.Origin().Status(),
@@ -291,9 +257,17 @@ func (r *Writer) toMap() map[string]any {
 			"size":   res.Origin().Size(),
 		}
 	}
-
 	if stacktrace := r.stacktrace; stacktrace != nil || r.stackEnabled {
 		payload["stacktrace"] = stacktrace
+	}
+	if tags := r.tags; len(tags) > 0 {
+		payload["tags"] = tags
+	}
+	if r.user != nil {
+		payload["user"] = r.user
+	}
+	if with := r.with; len(with) > 0 {
+		payload["with"] = with
 	}
 
 	// reset all properties for a new log entry
@@ -333,7 +307,6 @@ func registerHook(config config.Config, json foundation.Json, instance *logrus.L
 
 		if config.GetBool(channelPath + ".print") {
 			instance.SetOutput(os.Stdout)
-			instance.SetFormatter(formatter.NewGeneral(config, json))
 		}
 	case log.DailyDriver:
 		logLogger := logger.NewDaily(config, json)
@@ -344,7 +317,6 @@ func registerHook(config config.Config, json foundation.Json, instance *logrus.L
 
 		if config.GetBool(channelPath + ".print") {
 			instance.SetOutput(os.Stdout)
-			instance.SetFormatter(formatter.NewGeneral(config, json))
 		}
 	case log.CustomDriver:
 		logLogger := config.Get(channelPath + ".via").(log.Logger)
@@ -361,66 +333,4 @@ func registerHook(config config.Config, json foundation.Json, instance *logrus.L
 	instance.AddHook(hook)
 
 	return nil
-}
-
-type Hook struct {
-	instance log.Hook
-}
-
-func (h *Hook) Levels() []logrus.Level {
-	levels := h.instance.Levels()
-	var logrusLevels []logrus.Level
-	for _, item := range levels {
-		logrusLevels = append(logrusLevels, logrus.Level(item))
-	}
-
-	return logrusLevels
-}
-
-func (h *Hook) Fire(entry *logrus.Entry) error {
-	e := &Entry{
-		ctx:     entry.Context,
-		data:    map[string]any(entry.Data),
-		level:   log.Level(entry.Level),
-		time:    entry.Time,
-		message: entry.Message,
-	}
-
-	data := entry.Data
-	if len(data) > 0 {
-		root, err := cast.ToStringMapE(data["root"])
-		if err != nil {
-			return err
-		}
-
-		if code, ok := cast.ToStringE(root["code"]); ok == nil {
-			e.code = code
-		}
-
-		e.user = root["user"]
-
-		if tags, ok := cast.ToStringSliceE(root["tags"]); ok == nil {
-			e.tags = tags
-		}
-
-		e.owner = root["owner"]
-
-		if req, err := cast.ToStringMapE(root["tags"]); err == nil {
-			e.request = req
-		}
-
-		if res, err := cast.ToStringMapE(root["tags"]); err == nil {
-			e.response = res
-		}
-
-		if context, ok := cast.ToStringMapE(root["context"]); ok == nil {
-			e.with = context
-		}
-
-		if stacktrace, ok := cast.ToStringMapE(root["stacktrace"]); ok == nil {
-			e.stacktrace = stacktrace
-		}
-	}
-
-	return h.instance.Fire(e)
 }

--- a/log/logrus_writer_test.go
+++ b/log/logrus_writer_test.go
@@ -7,7 +7,6 @@ import (
 	nethttp "net/http"
 	"os"
 	"os/exec"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -51,14 +50,16 @@ func TestLogrus(t *testing.T) {
 		{
 			name: "WithContext",
 			setup: func() {
-				mockConfig.On("GetString", "logging.channels.daily.level").Return("debug").Once()
-				mockConfig.On("GetString", "logging.channels.single.level").Return("debug").Once()
+				mockDriverConfig(mockConfig)
 
 				log, err = NewApplication(mockConfig, j)
+				ctx := context.Background()
+				ctx = context.WithValue(ctx, "key", "value")
+				log.WithContext(ctx).Info("Goravel")
 			},
 			assert: func() {
-				writer := log.WithContext(context.Background())
-				assert.Equal(t, reflect.TypeOf(writer).String(), reflect.TypeOf(&Writer{}).String())
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ncontext: map[key:value]"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ncontext: map[key:value]"))
 			},
 		},
 		{
@@ -217,8 +218,8 @@ func TestLogrus(t *testing.T) {
 				log.Code("code").Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ncode: \"code\""))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ncode: \"code\""))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ncode: code"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ncode: code"))
 			},
 		},
 		{
@@ -230,8 +231,8 @@ func TestLogrus(t *testing.T) {
 				log.Hint("hint").Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nhint: \"hint\""))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nhint: \"hint\""))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nhint: hint"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nhint: hint"))
 			},
 		},
 		{
@@ -243,8 +244,8 @@ func TestLogrus(t *testing.T) {
 				log.In("domain").Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ndomain: \"domain\""))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ndomain: \"domain\""))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ndomain: domain"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ndomain: domain"))
 			},
 		},
 		{
@@ -256,8 +257,8 @@ func TestLogrus(t *testing.T) {
 				log.Owner("team@goravel.dev").Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nowner: \"team@goravel.dev\""))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nowner: \"team@goravel.dev\""))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nowner: team@goravel.dev"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nowner: team@goravel.dev"))
 			},
 		},
 		{
@@ -271,14 +272,12 @@ func TestLogrus(t *testing.T) {
 			assert: func() {
 				expectedParts := []string{
 					`test.info: Goravel`,
-					`request: {`,
-					`"method":"GET`,
-					`"uri":"http://localhost:3000/"`,
-					`"Sec-Fetch-User":["?1"]`,
-					`"Host":["localhost:3000"]`,
-					`"body":{`,
-					`"key1":"value1"`,
-					`"key2":"value2"`,
+					`request: `,
+					`method:GET`,
+					`uri:http://localhost:3000/`,
+					`Sec-Fetch-User:[?1]`,
+					`Host:[localhost:3000]`,
+					`body:map[key1:value1 key2:value2]`,
 				}
 
 				for _, part := range expectedParts {
@@ -298,11 +297,11 @@ func TestLogrus(t *testing.T) {
 			assert: func() {
 				expectedParts := []string{
 					`test.info: Goravel`,
-					`response: {`,
-					`"status":200`,
-					`"header":{"Content-Type":["text/plain; charset=utf-8"]}`,
-					`"body":{}`,
-					`"size":4`,
+					`response: map[`,
+					`status:200`,
+					`header:map[Content-Type:[text/plain; charset=utf-8]]`,
+					`body:body`,
+					`size:4`,
 				}
 
 				for _, part := range expectedParts {
@@ -320,8 +319,8 @@ func TestLogrus(t *testing.T) {
 				log.Tags("tag").Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ntags: [\"tag\"]"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ntags: [\"tag\"]"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ntags: [tag]"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ntags: [tag]"))
 			},
 		},
 		{
@@ -333,8 +332,8 @@ func TestLogrus(t *testing.T) {
 				log.User(map[string]any{"name": "kkumar-gcc"}).Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nuser: {\"name\":\"kkumar-gcc\"}"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nuser: {\"name\":\"kkumar-gcc\"}"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nuser: map[name:kkumar-gcc]"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nuser: map[name:kkumar-gcc]"))
 			},
 		},
 		{
@@ -346,8 +345,8 @@ func TestLogrus(t *testing.T) {
 				log.With(map[string]any{"key": "value"}).Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ncontext: {\"key\":\"value\"}"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ncontext: {\"key\":\"value\"}"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nwith: map[key:value]"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nwith: map[key:value]"))
 			},
 		},
 		{

--- a/log/logrus_writer_test.go
+++ b/log/logrus_writer_test.go
@@ -54,7 +54,7 @@ func TestLogrus(t *testing.T) {
 
 				log, err = NewApplication(mockConfig, j)
 				ctx := context.Background()
-				ctx = context.WithValue(ctx, "key", "value")
+				ctx = context.WithValue(ctx, testContextKey("key"), "value")
 				log.WithContext(ctx).Info("Goravel")
 			},
 			assert: func() {

--- a/log/logrus_writer_test.go
+++ b/log/logrus_writer_test.go
@@ -58,8 +58,8 @@ func TestLogrus(t *testing.T) {
 				log.WithContext(ctx).Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ncontext: map[key:value]"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ncontext: map[key:value]"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nContext: map[key:value]"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nContext: map[key:value]"))
 			},
 		},
 		{
@@ -218,8 +218,8 @@ func TestLogrus(t *testing.T) {
 				log.Code("code").Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ncode: code"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ncode: code"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nCode: code"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nCode: code"))
 			},
 		},
 		{
@@ -231,8 +231,8 @@ func TestLogrus(t *testing.T) {
 				log.Hint("hint").Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nhint: hint"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nhint: hint"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nHint: hint"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nHint: hint"))
 			},
 		},
 		{
@@ -244,8 +244,8 @@ func TestLogrus(t *testing.T) {
 				log.In("domain").Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ndomain: domain"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ndomain: domain"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nDomain: domain"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nDomain: domain"))
 			},
 		},
 		{
@@ -257,8 +257,8 @@ func TestLogrus(t *testing.T) {
 				log.Owner("team@goravel.dev").Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nowner: team@goravel.dev"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nowner: team@goravel.dev"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nOwner: team@goravel.dev"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nOwner: team@goravel.dev"))
 			},
 		},
 		{
@@ -272,7 +272,7 @@ func TestLogrus(t *testing.T) {
 			assert: func() {
 				expectedParts := []string{
 					`test.info: Goravel`,
-					`request: `,
+					`Request: `,
 					`method:GET`,
 					`uri:http://localhost:3000/`,
 					`Sec-Fetch-User:[?1]`,
@@ -297,7 +297,7 @@ func TestLogrus(t *testing.T) {
 			assert: func() {
 				expectedParts := []string{
 					`test.info: Goravel`,
-					`response: map[`,
+					`Response: map[`,
 					`status:200`,
 					`header:map[Content-Type:[text/plain; charset=utf-8]]`,
 					`body:body`,
@@ -319,8 +319,8 @@ func TestLogrus(t *testing.T) {
 				log.Tags("tag").Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ntags: [tag]"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ntags: [tag]"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nTags: [tag]"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nTags: [tag]"))
 			},
 		},
 		{
@@ -332,8 +332,8 @@ func TestLogrus(t *testing.T) {
 				log.User(map[string]any{"name": "kkumar-gcc"}).Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nuser: map[name:kkumar-gcc]"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nuser: map[name:kkumar-gcc]"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nUser: map[name:kkumar-gcc]"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nUser: map[name:kkumar-gcc]"))
 			},
 		},
 		{
@@ -345,8 +345,8 @@ func TestLogrus(t *testing.T) {
 				log.With(map[string]any{"key": "value"}).Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nwith: map[key:value]"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nwith: map[key:value]"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nWith: map[key:value]"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nWith: map[key:value]"))
 			},
 		},
 		{
@@ -358,8 +358,8 @@ func TestLogrus(t *testing.T) {
 				log.WithTrace().Info("Goravel")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.info: Goravel\ntrace:"))
-				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\ntrace:"))
+				assert.True(t, file.Contain(singleLog, "test.info: Goravel\nTrace:"))
+				assert.True(t, file.Contain(dailyLog, "test.info: Goravel\nTrace:"))
 			},
 		},
 		{
@@ -372,12 +372,12 @@ func TestLogrus(t *testing.T) {
 				log.Info("test info")
 			},
 			assert: func() {
-				assert.True(t, file.Contain(singleLog, "test.error: test error\ntrace:"))
+				assert.True(t, file.Contain(singleLog, "test.error: test error\nTrace:"))
 				assert.True(t, file.Contain(singleLog, "test.info: test info"))
-				assert.False(t, file.Contain(dailyLog, "test.info: test info\ntrace:"))
+				assert.False(t, file.Contain(dailyLog, "test.info: test info\nTrace:"))
 				assert.True(t, file.Contain(dailyLog, "test.error: test error"))
 				assert.True(t, file.Contain(dailyLog, "test.info: test info"))
-				assert.False(t, file.Contain(singleLog, "test.info: test info\ntrace:"))
+				assert.False(t, file.Contain(singleLog, "test.info: test info\nTrace:"))
 			},
 		},
 	}

--- a/log/utils.go
+++ b/log/utils.go
@@ -1,0 +1,45 @@
+package log
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func getContextValues(ctx any, values map[any]any) {
+	contextValues := reflect.Indirect(reflect.ValueOf(ctx))
+	contextKeys := reflect.TypeOf(ctx)
+	if contextKeys.Kind() == reflect.Ptr {
+		contextKeys = contextKeys.Elem()
+	}
+
+	if contextKeys.Kind() != reflect.Struct {
+		return
+	}
+
+	value := struct {
+		Key any
+		Val any
+	}{}
+
+	for i := 0; i < contextValues.NumField(); i++ {
+		reflectValue := contextValues.Field(i)
+		if !reflectValue.CanAddr() {
+			continue
+		}
+
+		reflectValue = reflect.NewAt(reflectValue.Type(), unsafe.Pointer(reflectValue.UnsafeAddr())).Elem()
+		reflectField := contextKeys.Field(i)
+
+		if reflectField.Name == "Context" {
+			getContextValues(reflectValue.Interface(), values)
+		} else if reflectField.Name == "key" {
+			value.Key = reflectValue.Interface()
+		} else if reflectField.Name == "val" {
+			value.Val = reflectValue.Interface()
+		}
+	}
+
+	if value.Key != nil {
+		values[value.Key] = value.Val
+	}
+}

--- a/log/utils_test.go
+++ b/log/utils_test.go
@@ -1,0 +1,33 @@
+package log
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gookit/goutil/testutil/assert"
+)
+
+func TestGetContextValues(t *testing.T) {
+	ctx := context.Background()
+	values := make(map[any]any)
+	getContextValues(ctx, values)
+	assert.Equal(t, make(map[any]any), values)
+
+	ctx = context.WithValue(ctx, "a", "b")
+	ctx = context.WithValue(ctx, 1, 2)
+	ctx = context.WithValue(ctx, "c", map[string]any{"d": "e"})
+
+	type T struct {
+		A string
+	}
+	ctx = context.WithValue(ctx, "d", T{A: "a"})
+
+	values = make(map[any]any)
+	getContextValues(ctx, values)
+	assert.Equal(t, map[any]any{
+		"a": "b",
+		1:   2,
+		"c": map[string]any{"d": "e"},
+		"d": T{A: "a"},
+	}, values)
+}

--- a/log/utils_test.go
+++ b/log/utils_test.go
@@ -7,20 +7,22 @@ import (
 	"github.com/gookit/goutil/testutil/assert"
 )
 
+type testContextKey any
+
 func TestGetContextValues(t *testing.T) {
 	ctx := context.Background()
 	values := make(map[any]any)
 	getContextValues(ctx, values)
 	assert.Equal(t, make(map[any]any), values)
 
-	ctx = context.WithValue(ctx, "a", "b")
-	ctx = context.WithValue(ctx, 1, 2)
-	ctx = context.WithValue(ctx, "c", map[string]any{"d": "e"})
+	ctx = context.WithValue(ctx, testContextKey("a"), "b")
+	ctx = context.WithValue(ctx, testContextKey(1), 2)
+	ctx = context.WithValue(ctx, testContextKey("c"), map[string]any{"d": "e"})
 
 	type T struct {
 		A string
 	}
-	ctx = context.WithValue(ctx, "d", T{A: "a"})
+	ctx = context.WithValue(ctx, testContextKey("d"), T{A: "a"})
 
 	values = make(map[any]any)
 	getContextValues(ctx, values)

--- a/mocks/log/Entry.go
+++ b/mocks/log/Entry.go
@@ -163,6 +163,96 @@ func (_c *Entry_Data_Call) RunAndReturn(run func() log.Data) *Entry_Data_Call {
 	return _c
 }
 
+// Domain provides a mock function with given fields:
+func (_m *Entry) Domain() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Domain")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// Entry_Domain_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Domain'
+type Entry_Domain_Call struct {
+	*mock.Call
+}
+
+// Domain is a helper method to define mock.On call
+func (_e *Entry_Expecter) Domain() *Entry_Domain_Call {
+	return &Entry_Domain_Call{Call: _e.mock.On("Domain")}
+}
+
+func (_c *Entry_Domain_Call) Run(run func()) *Entry_Domain_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Entry_Domain_Call) Return(_a0 string) *Entry_Domain_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Entry_Domain_Call) RunAndReturn(run func() string) *Entry_Domain_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Hint provides a mock function with given fields:
+func (_m *Entry) Hint() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Hint")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// Entry_Hint_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Hint'
+type Entry_Hint_Call struct {
+	*mock.Call
+}
+
+// Hint is a helper method to define mock.On call
+func (_e *Entry_Expecter) Hint() *Entry_Hint_Call {
+	return &Entry_Hint_Call{Call: _e.mock.On("Hint")}
+}
+
+func (_c *Entry_Hint_Call) Run(run func()) *Entry_Hint_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Entry_Hint_Call) Return(_a0 string) *Entry_Hint_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Entry_Hint_Call) RunAndReturn(run func() string) *Entry_Hint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Level provides a mock function with given fields:
 func (_m *Entry) Level() log.Level {
 	ret := _m.Called()

--- a/support/file/file.go
+++ b/support/file/file.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,7 +18,6 @@ func ClientOriginalExtension(file string) string {
 func Contain(file string, search string) bool {
 	if Exists(file) {
 		data, err := os.ReadFile(file)
-		fmt.Println(string(data))
 		if err != nil {
 			return false
 		}

--- a/support/file/file.go
+++ b/support/file/file.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,9 +19,11 @@ func ClientOriginalExtension(file string) string {
 func Contain(file string, search string) bool {
 	if Exists(file) {
 		data, err := os.ReadFile(file)
+		fmt.Println(string(data))
 		if err != nil {
 			return false
 		}
+
 		return strings.Contains(string(data), search)
 	}
 


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/282

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/5c6254a7-11ce-42fe-a958-af879a33c177" />

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced logging capabilities with new fields: `code`, `domain`, and `hint`.
  - Introduced a new `Hook` type for improved integration with the logging framework.
  - Added utility function `getContextValues` for extracting key-value pairs from context structures.
  - Modified the `WithContext` method to handle HTTP-specific contexts.
  - Improved data formatting with additional keys processed in logs.

- **Bug Fixes**
  - Improved error handling in log entry processing.

- **Tests**
  - Added comprehensive unit tests for the new `Hook` functionality and context value extraction.
  - Updated existing tests to reflect changes in log entry formatting and context handling.

- **Chores**
  - Streamlined logging assertions and context management for clarity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
