### PR TITLE
feat: [#272] The Orm module can set DSN directly

### DIFF
--- a/contracts/database/config.go
+++ b/contracts/database/config.go
@@ -15,6 +15,7 @@ func (d Driver) String() string {
 
 // Config Used in config/database.go
 type Config struct {
+	Dsn      string
 	Host     string
 	Port     int
 	Database string

--- a/database/db/config_builder.go
+++ b/database/db/config_builder.go
@@ -55,6 +55,9 @@ func (c *ConfigBuilder) fillDefault(configs []database.Config) []database.FullCo
 			Singular:   c.config.GetBool(fmt.Sprintf("database.connections.%s.singular", c.connection)),
 		}
 		if driver != database.DriverSqlite {
+			if fullConfig.Dsn == "" {
+				fullConfig.Dsn = c.config.GetString(fmt.Sprintf("database.connections.%s.dsn", c.connection))
+			}
 			if fullConfig.Host == "" {
 				fullConfig.Host = c.config.GetString(fmt.Sprintf("database.connections.%s.host", c.connection))
 			}

--- a/database/db/config_builder_test.go
+++ b/database/db/config_builder_test.go
@@ -105,6 +105,7 @@ func (s *ConfigTestSuite) TestWrites() {
 }
 
 func (s *ConfigTestSuite) TestFillDefault() {
+	dsn := "dsn"
 	host := "localhost"
 	port := 3306
 	database := "forge"
@@ -133,6 +134,7 @@ func (s *ConfigTestSuite) TestFillDefault() {
 				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.prefix", s.connection)).Return(prefix).Once()
 				s.mockConfig.EXPECT().GetBool(fmt.Sprintf("database.connections.%s.singular", s.connection)).Return(singular).Once()
 				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.driver", s.connection)).Return("mysql").Once()
+				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.dsn", s.connection)).Return(dsn).Once()
 				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.host", s.connection)).Return(host).Once()
 				s.mockConfig.EXPECT().GetInt(fmt.Sprintf("database.connections.%s.port", s.connection)).Return(port).Once()
 				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.database", s.connection)).Return(database).Once()
@@ -150,6 +152,7 @@ func (s *ConfigTestSuite) TestFillDefault() {
 					Charset:    charset,
 					Loc:        loc,
 					Config: contractsdatabase.Config{
+						Dsn:      dsn,
 						Host:     host,
 						Port:     port,
 						Database: database,
@@ -163,6 +166,7 @@ func (s *ConfigTestSuite) TestFillDefault() {
 			name: "success when configs have item",
 			configs: []contractsdatabase.Config{
 				{
+					Dsn:      dsn,
 					Host:     host,
 					Port:     port,
 					Database: database,
@@ -186,6 +190,7 @@ func (s *ConfigTestSuite) TestFillDefault() {
 					Charset:    charset,
 					Loc:        loc,
 					Config: contractsdatabase.Config{
+						Dsn:      dsn,
 						Database: database,
 						Host:     host,
 						Port:     port,

--- a/database/db/dsn.go
+++ b/database/db/dsn.go
@@ -7,6 +7,10 @@ import (
 )
 
 func Dsn(config database.FullConfig) string {
+	if config.Dsn != "" {
+		return config.Dsn
+	}
+
 	if config.Host == "" && config.Driver != database.DriverSqlite {
 		return ""
 	}

--- a/database/db/dsn_test.go
+++ b/database/db/dsn_test.go
@@ -38,6 +38,15 @@ func TestDsn(t *testing.T) {
 			},
 		},
 		{
+			name: "dsn is not empty",
+			config: database.FullConfig{
+				Config: database.Config{
+					Dsn: "dsn",
+				},
+			},
+			expectDsn: "dsn",
+		},
+		{
 			name: "mysql",
 			config: database.FullConfig{
 				Config:  testConfig,

--- a/database/gorm/test_utils.go
+++ b/database/gorm/test_utils.go
@@ -276,6 +276,7 @@ func (r *MockMysql) ReadWrite(readDatabaseConfig testing.DatabaseConfig) {
 	r.mockConfig.On("Get", fmt.Sprintf("database.connections.%s.write", r.connection)).Return([]contractsdatabase.Config{
 		{Host: "127.0.0.1", Database: r.database, Port: r.port, Username: r.user, Password: r.password},
 	})
+	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.dsn", r.connection)).Return("")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.prefix", r.connection)).Return("")
 	r.mockConfig.On("GetBool", fmt.Sprintf("database.connections.%s.singular", r.connection)).Return(false)
 	r.basic()
@@ -302,6 +303,7 @@ func (r *MockMysql) single() {
 	r.mockConfig.On("Get", fmt.Sprintf("database.connections.%s.read", r.connection)).Return(nil)
 	r.mockConfig.On("Get", fmt.Sprintf("database.connections.%s.write", r.connection)).Return(nil)
 	r.mockConfig.On("GetBool", "app.debug").Return(true)
+	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.dsn", r.connection)).Return("")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.host", r.connection)).Return("127.0.0.1")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.username", r.connection)).Return(r.user)
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.password", r.connection)).Return(r.password)
@@ -347,6 +349,7 @@ func (r *MockPostgres) ReadWrite(readDatabaseConfig testing.DatabaseConfig) {
 	r.mockConfig.On("Get", fmt.Sprintf("database.connections.%s.write", r.connection)).Return([]contractsdatabase.Config{
 		{Host: "127.0.0.1", Database: r.database, Port: r.port, Username: r.user, Password: r.password},
 	})
+	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.dsn", r.connection)).Return("")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.prefix", r.connection)).Return("")
 	r.mockConfig.On("GetBool", fmt.Sprintf("database.connections.%s.singular", r.connection)).Return(false)
 	r.basic()
@@ -373,6 +376,7 @@ func (r *MockPostgres) basic() {
 func (r *MockPostgres) single() {
 	r.mockConfig.On("Get", fmt.Sprintf("database.connections.%s.read", r.connection)).Return(nil)
 	r.mockConfig.On("Get", fmt.Sprintf("database.connections.%s.write", r.connection)).Return(nil)
+	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.dsn", r.connection)).Return("")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.host", r.connection)).Return("127.0.0.1")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.username", r.connection)).Return(r.user)
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.password", r.connection)).Return(r.password)
@@ -475,6 +479,7 @@ func (r *MockSqlserver) ReadWrite(readDatabaseConfig testing.DatabaseConfig) {
 	r.mockConfig.On("Get", fmt.Sprintf("database.connections.%s.write", r.connection)).Return([]contractsdatabase.Config{
 		{Host: "127.0.0.1", Database: r.database, Port: r.port, Username: r.user, Password: r.password},
 	})
+	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.dsn", r.connection)).Return("")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.prefix", r.connection)).Return("")
 	r.mockConfig.On("GetBool", fmt.Sprintf("database.connections.%s.singular", r.connection)).Return(false)
 	r.basic()
@@ -498,6 +503,7 @@ func (r *MockSqlserver) basic() {
 func (r *MockSqlserver) single() {
 	r.mockConfig.On("Get", fmt.Sprintf("database.connections.%s.read", r.connection)).Return(nil)
 	r.mockConfig.On("Get", fmt.Sprintf("database.connections.%s.write", r.connection)).Return(nil)
+	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.dsn", r.connection)).Return("")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.host", r.connection)).Return("127.0.0.1")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.username", r.connection)).Return(r.user)
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.password", r.connection)).Return(r.password)

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -323,6 +323,7 @@ func (s *ApplicationTestSuite) TestMakeOrm() {
 	mockConfig.EXPECT().GetString("database.connections.postgres.driver").Return(contractsdatabase.DriverPostgres.String()).Twice()
 	mockConfig.EXPECT().GetString("database.connections.postgres.prefix").Return("").Twice()
 	mockConfig.EXPECT().GetBool("database.connections.postgres.singular").Return(true).Twice()
+	mockConfig.EXPECT().GetString("database.connections.postgres.dsn").Return("").Twice()
 	mockConfig.EXPECT().GetString("database.connections.postgres.host").Return("localhost").Twice()
 	mockConfig.EXPECT().GetString("database.connections.postgres.username").Return(config.Username).Twice()
 	mockConfig.EXPECT().GetString("database.connections.postgres.password").Return(config.Password).Twice()


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/272

Migrated successfully from local:

<img width="917" alt="image" src="https://github.com/user-attachments/assets/2a690e59-9d09-4852-9371-28faf2354514" />

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Dsn` field in the database configuration, enhancing connection handling.
  
- **Bug Fixes**
	- Improved logic to ensure the `Dsn` field is populated correctly when not set.

- **Tests**
	- Expanded test coverage for the `fillDefault` method and the `Dsn` function to validate new configurations.
  
- **Chores**
	- Updated mock configurations for various database drivers to include the new `Dsn` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
