### PR TITLE
fix: should not print error when session doesn't exist

### DIFF
--- a/errors/list.go
+++ b/errors/list.go
@@ -126,7 +126,6 @@ var (
 	SessionDriverExtensionFailed = New("session failed to extend session [%s] driver [%v]")
 	SessionDriverIsNotSet        = New("session driver is not set")
 	SessionDriverNotSupported    = New("session driver [%s] not supported")
-	SessionNotFound              = New("session [%s] not found")
 
 	UnknownFileExtension = New("unknown file extension")
 

--- a/session/driver/file.go
+++ b/session/driver/file.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support/carbon"
 	"github.com/goravel/framework/support/file"
 )
@@ -80,7 +79,7 @@ func (f *File) Read(id string) (string, error) {
 		}
 	}
 
-	return "", errors.SessionNotFound.Args(id)
+	return "", nil
 }
 
 func (f *File) Write(id string, data string) error {

--- a/session/driver/file_test.go
+++ b/session/driver/file_test.go
@@ -39,7 +39,7 @@ func (f *FileTestSuite) TestDestroy() {
 	f.Nil(driver.Destroy("foo"))
 
 	value, err = driver.Read("foo")
-	f.NotNil(err)
+	f.Nil(err)
 	f.Equal("", value)
 }
 
@@ -58,7 +58,7 @@ func (f *FileTestSuite) TestGc() {
 	f.Nil(driver.Gc(300))
 
 	value, err = driver.Read("foo")
-	f.NotNil(err)
+	f.Nil(err)
 	f.Equal("", value)
 	carbon.UnsetTestNow()
 
@@ -88,7 +88,7 @@ func (f *FileTestSuite) TestRead() {
 
 	carbon.SetTestNow(carbon.Now(carbon.UTC).AddMinutes(f.getMinutes()).AddSecond())
 	value, err = driver.Read("foo")
-	f.NotNil(err)
+	f.Nil(err)
 	f.Equal("", value)
 	carbon.UnsetTestNow()
 }

--- a/session/session.go
+++ b/session/session.go
@@ -244,10 +244,13 @@ func (s *Session) readFromHandler() map[string]any {
 		return nil
 	}
 	var data map[string]any
-	if err := s.json.Unmarshal([]byte(value), &data); err != nil {
-		color.Errorln(err)
-		return nil
+	if value != "" {
+		if err := s.json.Unmarshal([]byte(value), &data); err != nil {
+			color.Errorln(err)
+			return nil
+		}
 	}
+
 	return data
 }
 


### PR DESCRIPTION
## 📑 Description

<img width="717" alt="image" src="https://github.com/user-attachments/assets/49596ffc-545e-479c-acdc-4d7220f1d296" />

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced robustness of session handling by preventing unnecessary processing of empty values.

- **Bug Fixes**
	- Adjusted expected outcomes in tests to reflect the new behavior of the `Read` method, which now returns no error for non-existent sessions.
	- Removed specific session not found error handling, simplifying error management.

- **Tests**
	- Updated assertions in the test suite to expect no errors when reading from destroyed or garbage-collected files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
