### PR TITLE
chore: rename Stop to Shutdown

### DIFF
--- a/contracts/route/route.go
+++ b/contracts/route/route.go
@@ -30,8 +30,8 @@ type Route interface {
 	RunTLSWithCert(host, certFile, keyFile string) error
 	// ServeHTTP serves HTTP requests.
 	ServeHTTP(writer http.ResponseWriter, request *http.Request)
-	// Stop gracefully stop the serve.
-	Stop(ctx ...context.Context) error
+	// Shutdown gracefully stop the serve.
+	Shutdown(ctx ...context.Context) error
 	// Test method to simulate HTTP requests (Fiber driver only)
 	Test(request *http.Request) (*http.Response, error)
 }

--- a/contracts/schedule/schedule.go
+++ b/contracts/schedule/schedule.go
@@ -13,6 +13,6 @@ type Schedule interface {
 	Register(events []Event)
 	// Run schedules.
 	Run()
-	// Stop schedules.
-	Stop(ctx ...context.Context) error
+	// Shutdown schedules.
+	Shutdown(ctx ...context.Context) error
 }

--- a/contracts/testing/testing.go
+++ b/contracts/testing/testing.go
@@ -39,8 +39,8 @@ type DatabaseDriver interface {
 	Image(image Image)
 	// Ready checks if the database is ready, the Build method needs to be called first.
 	Ready() error
-	// Stop the database.
-	Stop() error
+	// Shutdown the database.
+	Shutdown() error
 }
 
 type DatabaseConfig struct {

--- a/database/gorm/query_test.go
+++ b/database/gorm/query_test.go
@@ -54,7 +54,7 @@ func (s *QueryTestSuite) SetupTest() {}
 
 func (s *QueryTestSuite) TearDownSuite() {
 	if s.queries[database.DriverSqlite] != nil {
-		s.NoError(s.queries[database.DriverSqlite].Docker().Stop())
+		s.NoError(s.queries[database.DriverSqlite].Docker().Shutdown())
 	}
 }
 
@@ -3638,7 +3638,7 @@ func TestCustomConnection(t *testing.T) {
 	assert.NotNil(t, query.Create(&person))
 	assert.True(t, person.ID == 0)
 
-	assert.NoError(t, sqliteDocker.Stop())
+	assert.NoError(t, sqliteDocker.Shutdown())
 }
 
 func TestFilterFindConditions(t *testing.T) {
@@ -3801,8 +3801,8 @@ func TestReadWriteSeparate(t *testing.T) {
 		})
 	}
 
-	assert.NoError(t, dbs[database.DriverSqlite]["read"].Docker().Stop())
-	assert.NoError(t, dbs[database.DriverSqlite]["write"].Docker().Stop())
+	assert.NoError(t, dbs[database.DriverSqlite]["read"].Docker().Shutdown())
+	assert.NoError(t, dbs[database.DriverSqlite]["write"].Docker().Shutdown())
 }
 
 func TestTablePrefixAndSingular(t *testing.T) {
@@ -3827,7 +3827,7 @@ func TestTablePrefixAndSingular(t *testing.T) {
 	}
 
 	if dbs[database.DriverSqlite] != nil {
-		assert.NoError(t, dbs[database.DriverSqlite].Docker().Stop())
+		assert.NoError(t, dbs[database.DriverSqlite].Docker().Shutdown())
 	}
 }
 

--- a/database/migration/sql_migrator_test.go
+++ b/database/migration/sql_migrator_test.go
@@ -39,7 +39,7 @@ func (s *SqlMigratorSuite) SetupTest() {
 func (s *SqlMigratorSuite) TearDownTest() {
 	s.NoError(file.Remove("database"))
 	if s.driverToTestQuery[contractsdatabase.DriverSqlite] != nil {
-		s.NoError(s.driverToTestQuery[contractsdatabase.DriverSqlite].Docker().Stop())
+		s.NoError(s.driverToTestQuery[contractsdatabase.DriverSqlite].Docker().Shutdown())
 	}
 }
 

--- a/database/orm/orm_test.go
+++ b/database/orm/orm_test.go
@@ -62,7 +62,7 @@ func (s *OrmSuite) SetupTest() {
 
 func (s *OrmSuite) TearDownSuite() {
 	if s.testQueries[database.DriverSqlite] != nil {
-		s.NoError(s.testQueries[database.DriverSqlite].Docker().Stop())
+		s.NoError(s.testQueries[database.DriverSqlite].Docker().Shutdown())
 	}
 }
 

--- a/database/schema/schema_test.go
+++ b/database/schema/schema_test.go
@@ -59,7 +59,7 @@ func (s *SchemaSuite) SetupTest() {
 
 func (s *SchemaSuite) TearDownTest() {
 	if s.driverToTestQuery[database.DriverSqlite] != nil {
-		s.NoError(s.driverToTestQuery[database.DriverSqlite].Docker().Stop())
+		s.NoError(s.driverToTestQuery[database.DriverSqlite].Docker().Shutdown())
 	}
 }
 

--- a/mail/application_test.go
+++ b/mail/application_test.go
@@ -45,7 +45,7 @@ func TestApplicationTestSuite(t *testing.T) {
 		redisPort: redisDocker.Config().Port,
 	})
 
-	assert.Nil(t, redisDocker.Stop())
+	assert.Nil(t, redisDocker.Shutdown())
 }
 
 func (s *ApplicationTestSuite) SetupTest() {}

--- a/mocks/route/Route.go
+++ b/mocks/route/Route.go
@@ -861,6 +861,65 @@ func (_c *Route_ServeHTTP_Call) RunAndReturn(run func(nethttp.ResponseWriter, *n
 	return _c
 }
 
+// Shutdown provides a mock function with given fields: ctx
+func (_m *Route) Shutdown(ctx ...context.Context) error {
+	_va := make([]interface{}, len(ctx))
+	for _i := range ctx {
+		_va[_i] = ctx[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Shutdown")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(...context.Context) error); ok {
+		r0 = rf(ctx...)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Route_Shutdown_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Shutdown'
+type Route_Shutdown_Call struct {
+	*mock.Call
+}
+
+// Shutdown is a helper method to define mock.On call
+//   - ctx ...context.Context
+func (_e *Route_Expecter) Shutdown(ctx ...interface{}) *Route_Shutdown_Call {
+	return &Route_Shutdown_Call{Call: _e.mock.On("Shutdown",
+		append([]interface{}{}, ctx...)...)}
+}
+
+func (_c *Route_Shutdown_Call) Run(run func(ctx ...context.Context)) *Route_Shutdown_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]context.Context, len(args)-0)
+		for i, a := range args[0:] {
+			if a != nil {
+				variadicArgs[i] = a.(context.Context)
+			}
+		}
+		run(variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Route_Shutdown_Call) Return(_a0 error) *Route_Shutdown_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Route_Shutdown_Call) RunAndReturn(run func(...context.Context) error) *Route_Shutdown_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Static provides a mock function with given fields: relativePath, root
 func (_m *Route) Static(relativePath string, root string) {
 	_m.Called(relativePath, root)
@@ -959,65 +1018,6 @@ func (_c *Route_StaticFile_Call) Return() *Route_StaticFile_Call {
 }
 
 func (_c *Route_StaticFile_Call) RunAndReturn(run func(string, string)) *Route_StaticFile_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// Stop provides a mock function with given fields: ctx
-func (_m *Route) Stop(ctx ...context.Context) error {
-	_va := make([]interface{}, len(ctx))
-	for _i := range ctx {
-		_va[_i] = ctx[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	if len(ret) == 0 {
-		panic("no return value specified for Stop")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(...context.Context) error); ok {
-		r0 = rf(ctx...)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// Route_Stop_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Stop'
-type Route_Stop_Call struct {
-	*mock.Call
-}
-
-// Stop is a helper method to define mock.On call
-//   - ctx ...context.Context
-func (_e *Route_Expecter) Stop(ctx ...interface{}) *Route_Stop_Call {
-	return &Route_Stop_Call{Call: _e.mock.On("Stop",
-		append([]interface{}{}, ctx...)...)}
-}
-
-func (_c *Route_Stop_Call) Run(run func(ctx ...context.Context)) *Route_Stop_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]context.Context, len(args)-0)
-		for i, a := range args[0:] {
-			if a != nil {
-				variadicArgs[i] = a.(context.Context)
-			}
-		}
-		run(variadicArgs...)
-	})
-	return _c
-}
-
-func (_c *Route_Stop_Call) Return(_a0 error) *Route_Stop_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Route_Stop_Call) RunAndReturn(run func(...context.Context) error) *Route_Stop_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/schedule/Schedule.go
+++ b/mocks/schedule/Schedule.go
@@ -183,8 +183,8 @@ func (_c *Schedule_Run_Call) RunAndReturn(run func()) *Schedule_Run_Call {
 	return _c
 }
 
-// Stop provides a mock function with given fields: ctx
-func (_m *Schedule) Stop(ctx ...context.Context) error {
+// Shutdown provides a mock function with given fields: ctx
+func (_m *Schedule) Shutdown(ctx ...context.Context) error {
 	_va := make([]interface{}, len(ctx))
 	for _i := range ctx {
 		_va[_i] = ctx[_i]
@@ -194,7 +194,7 @@ func (_m *Schedule) Stop(ctx ...context.Context) error {
 	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
-		panic("no return value specified for Stop")
+		panic("no return value specified for Shutdown")
 	}
 
 	var r0 error
@@ -207,19 +207,19 @@ func (_m *Schedule) Stop(ctx ...context.Context) error {
 	return r0
 }
 
-// Schedule_Stop_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Stop'
-type Schedule_Stop_Call struct {
+// Schedule_Shutdown_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Shutdown'
+type Schedule_Shutdown_Call struct {
 	*mock.Call
 }
 
-// Stop is a helper method to define mock.On call
+// Shutdown is a helper method to define mock.On call
 //   - ctx ...context.Context
-func (_e *Schedule_Expecter) Stop(ctx ...interface{}) *Schedule_Stop_Call {
-	return &Schedule_Stop_Call{Call: _e.mock.On("Stop",
+func (_e *Schedule_Expecter) Shutdown(ctx ...interface{}) *Schedule_Shutdown_Call {
+	return &Schedule_Shutdown_Call{Call: _e.mock.On("Shutdown",
 		append([]interface{}{}, ctx...)...)}
 }
 
-func (_c *Schedule_Stop_Call) Run(run func(ctx ...context.Context)) *Schedule_Stop_Call {
+func (_c *Schedule_Shutdown_Call) Run(run func(ctx ...context.Context)) *Schedule_Shutdown_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		variadicArgs := make([]context.Context, len(args)-0)
 		for i, a := range args[0:] {
@@ -232,12 +232,12 @@ func (_c *Schedule_Stop_Call) Run(run func(ctx ...context.Context)) *Schedule_St
 	return _c
 }
 
-func (_c *Schedule_Stop_Call) Return(_a0 error) *Schedule_Stop_Call {
+func (_c *Schedule_Shutdown_Call) Return(_a0 error) *Schedule_Shutdown_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Schedule_Stop_Call) RunAndReturn(run func(...context.Context) error) *Schedule_Stop_Call {
+func (_c *Schedule_Shutdown_Call) RunAndReturn(run func(...context.Context) error) *Schedule_Shutdown_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/testing/Database.go
+++ b/mocks/testing/Database.go
@@ -444,12 +444,12 @@ func (_c *Database_Seed_Call) RunAndReturn(run func(...seeder.Seeder) error) *Da
 	return _c
 }
 
-// Stop provides a mock function with given fields:
-func (_m *Database) Stop() error {
+// Shutdown provides a mock function with given fields:
+func (_m *Database) Shutdown() error {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for Stop")
+		panic("no return value specified for Shutdown")
 	}
 
 	var r0 error
@@ -462,29 +462,29 @@ func (_m *Database) Stop() error {
 	return r0
 }
 
-// Database_Stop_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Stop'
-type Database_Stop_Call struct {
+// Database_Shutdown_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Shutdown'
+type Database_Shutdown_Call struct {
 	*mock.Call
 }
 
-// Stop is a helper method to define mock.On call
-func (_e *Database_Expecter) Stop() *Database_Stop_Call {
-	return &Database_Stop_Call{Call: _e.mock.On("Stop")}
+// Shutdown is a helper method to define mock.On call
+func (_e *Database_Expecter) Shutdown() *Database_Shutdown_Call {
+	return &Database_Shutdown_Call{Call: _e.mock.On("Shutdown")}
 }
 
-func (_c *Database_Stop_Call) Run(run func()) *Database_Stop_Call {
+func (_c *Database_Shutdown_Call) Run(run func()) *Database_Shutdown_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *Database_Stop_Call) Return(_a0 error) *Database_Stop_Call {
+func (_c *Database_Shutdown_Call) Return(_a0 error) *Database_Shutdown_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *Database_Stop_Call) RunAndReturn(run func() error) *Database_Stop_Call {
+func (_c *Database_Shutdown_Call) RunAndReturn(run func() error) *Database_Shutdown_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/testing/DatabaseDriver.go
+++ b/mocks/testing/DatabaseDriver.go
@@ -338,12 +338,12 @@ func (_c *DatabaseDriver_Ready_Call) RunAndReturn(run func() error) *DatabaseDri
 	return _c
 }
 
-// Stop provides a mock function with given fields:
-func (_m *DatabaseDriver) Stop() error {
+// Shutdown provides a mock function with given fields:
+func (_m *DatabaseDriver) Shutdown() error {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
-		panic("no return value specified for Stop")
+		panic("no return value specified for Shutdown")
 	}
 
 	var r0 error
@@ -356,29 +356,29 @@ func (_m *DatabaseDriver) Stop() error {
 	return r0
 }
 
-// DatabaseDriver_Stop_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Stop'
-type DatabaseDriver_Stop_Call struct {
+// DatabaseDriver_Shutdown_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Shutdown'
+type DatabaseDriver_Shutdown_Call struct {
 	*mock.Call
 }
 
-// Stop is a helper method to define mock.On call
-func (_e *DatabaseDriver_Expecter) Stop() *DatabaseDriver_Stop_Call {
-	return &DatabaseDriver_Stop_Call{Call: _e.mock.On("Stop")}
+// Shutdown is a helper method to define mock.On call
+func (_e *DatabaseDriver_Expecter) Shutdown() *DatabaseDriver_Shutdown_Call {
+	return &DatabaseDriver_Shutdown_Call{Call: _e.mock.On("Shutdown")}
 }
 
-func (_c *DatabaseDriver_Stop_Call) Run(run func()) *DatabaseDriver_Stop_Call {
+func (_c *DatabaseDriver_Shutdown_Call) Run(run func()) *DatabaseDriver_Shutdown_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *DatabaseDriver_Stop_Call) Return(_a0 error) *DatabaseDriver_Stop_Call {
+func (_c *DatabaseDriver_Shutdown_Call) Return(_a0 error) *DatabaseDriver_Shutdown_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *DatabaseDriver_Stop_Call) RunAndReturn(run func() error) *DatabaseDriver_Stop_Call {
+func (_c *DatabaseDriver_Shutdown_Call) RunAndReturn(run func() error) *DatabaseDriver_Shutdown_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/queue/application_test.go
+++ b/queue/application_test.go
@@ -52,7 +52,7 @@ func TestQueueTestSuite(t *testing.T) {
 		port: redisDocker.Config().Port,
 	})
 
-	assert.Nil(t, redisDocker.Stop())
+	assert.Nil(t, redisDocker.Shutdown())
 }
 
 func (s *QueueTestSuite) SetupTest() {

--- a/schedule/application.go
+++ b/schedule/application.go
@@ -49,7 +49,7 @@ func (app *Application) Run() {
 	app.cron.Run()
 }
 
-func (app *Application) Stop(ctx ...context.Context) error {
+func (app *Application) Shutdown(ctx ...context.Context) error {
 	if len(ctx) == 0 {
 		ctx = append(ctx, context.Background())
 	}

--- a/schedule/application_test.go
+++ b/schedule/application_test.go
@@ -59,7 +59,7 @@ func (s *ApplicationTestSuite) TestCallAndCommand() {
 
 	time.Sleep(60 * time.Second)
 
-	s.NoError(app.Stop())
+	s.NoError(app.Shutdown())
 	s.Equal(1, immediatelyCall)
 	s.Equal(30, delayIfStillRunningCall)
 	s.Equal(15, skipIfStillRunningCall)
@@ -97,8 +97,8 @@ func (s *ApplicationTestSuite) TestOnOneServer() {
 
 	time.Sleep(2 * time.Second)
 
-	s.NoError(app.Stop())
-	s.NoError(app1.Stop())
+	s.NoError(app.Shutdown())
+	s.NoError(app1.Shutdown())
 
 	s.Equal(1, immediatelyCall)
 }
@@ -118,7 +118,7 @@ func (s *ApplicationTestSuite) TestStop() {
 
 	time.Sleep(2 * time.Second)
 
-	s.NoError(app.Stop())
+	s.NoError(app.Shutdown())
 	s.Equal(1, immediatelyCall)
 }
 
@@ -140,6 +140,6 @@ func (s *ApplicationTestSuite) TestStopWithContext() {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	s.EqualError(app.Stop(ctx), "context deadline exceeded")
+	s.EqualError(app.Shutdown(ctx), "context deadline exceeded")
 	s.Equal(0, immediatelyCall)
 }

--- a/schedule/application_test.go
+++ b/schedule/application_test.go
@@ -103,7 +103,7 @@ func (s *ApplicationTestSuite) TestOnOneServer() {
 	s.Equal(1, immediatelyCall)
 }
 
-func (s *ApplicationTestSuite) TestStop() {
+func (s *ApplicationTestSuite) TestShutdown() {
 	immediatelyCall := 0
 
 	app := NewApplication(nil, nil, nil, false)
@@ -122,7 +122,7 @@ func (s *ApplicationTestSuite) TestStop() {
 	s.Equal(1, immediatelyCall)
 }
 
-func (s *ApplicationTestSuite) TestStopWithContext() {
+func (s *ApplicationTestSuite) TestShutdownWithContext() {
 	immediatelyCall := 0
 
 	app := NewApplication(nil, nil, nil, false)

--- a/support/docker/container_manager_test.go
+++ b/support/docker/container_manager_test.go
@@ -37,7 +37,7 @@ func (s *ContainerManagerTestSuite) TestGet() {
 	driver, err = s.containerManager.Get(ContainerTypeSqlite)
 	s.NoError(err)
 	s.NotNil(driver)
-	s.NoError(driver.Stop())
+	s.NoError(driver.Shutdown())
 
 	driver, err = s.containerManager.Get(ContainerTypeSqlserver)
 	s.NoError(err)

--- a/support/docker/docker_test.go
+++ b/support/docker/docker_test.go
@@ -90,7 +90,7 @@ func TestDatabase(t *testing.T) {
 
 				if test.containerType == ContainerTypeSqlite {
 					for _, driver := range drivers {
-						assert.NoError(t, driver.Stop())
+						assert.NoError(t, driver.Shutdown())
 					}
 				}
 			}

--- a/support/docker/mysql.go
+++ b/support/docker/mysql.go
@@ -154,7 +154,7 @@ func (r *MysqlImpl) Ready() error {
 	return err
 }
 
-func (r *MysqlImpl) Stop() error {
+func (r *MysqlImpl) Shutdown() error {
 	if _, err := run(fmt.Sprintf("docker stop %s", r.containerID)); err != nil {
 		return fmt.Errorf("stop Mysql error: %v", err)
 	}

--- a/support/docker/mysql_test.go
+++ b/support/docker/mysql_test.go
@@ -73,7 +73,7 @@ INSERT INTO users (name) VALUES ('goravel');
 	s.NoError(err)
 	s.NotNil(databaseDriver)
 
-	s.Nil(s.mysql.Stop())
+	s.Nil(s.mysql.Shutdown())
 }
 
 func (s *MysqlTestSuite) TestDriver() {

--- a/support/docker/postgres.go
+++ b/support/docker/postgres.go
@@ -127,7 +127,7 @@ func (r *PostgresImpl) Ready() error {
 	return r.close(gormDB)
 }
 
-func (r *PostgresImpl) Stop() error {
+func (r *PostgresImpl) Shutdown() error {
 	if _, err := run(fmt.Sprintf("docker stop %s", r.containerID)); err != nil {
 		return fmt.Errorf("stop Postgres error: %v", err)
 	}

--- a/support/docker/postgres_test.go
+++ b/support/docker/postgres_test.go
@@ -81,7 +81,7 @@ func (s *PostgresTestSuite) TestBuild() {
 	s.NoError(err)
 	s.NotNil(databaseDriver)
 
-	s.Nil(s.postgres.Stop())
+	s.Nil(s.postgres.Shutdown())
 }
 
 func (s *PostgresTestSuite) TestDriver() {

--- a/support/docker/redis.go
+++ b/support/docker/redis.go
@@ -52,7 +52,7 @@ func (receiver *Redis) Config() RedisConfig {
 	}
 }
 
-func (receiver *Redis) Stop() error {
+func (receiver *Redis) Shutdown() error {
 	if _, err := run(fmt.Sprintf("docker stop %s", receiver.containerID)); err != nil {
 		return fmt.Errorf("stop Redis docker error: %v", err)
 	}

--- a/support/docker/redis_test.go
+++ b/support/docker/redis_test.go
@@ -43,5 +43,5 @@ func (s *RedisTestSuite) TestBuild() {
 	s.Nil(instance.Set(ctx, "hello", "goravel", 10*time.Second).Err())
 	s.Equal("goravel", instance.Get(ctx, "hello").Val())
 
-	s.Nil(s.redis.Stop())
+	s.Nil(s.redis.Shutdown())
 }

--- a/support/docker/sqlite.go
+++ b/support/docker/sqlite.go
@@ -49,7 +49,7 @@ func (r *SqliteImpl) Driver() database.Driver {
 }
 
 func (r *SqliteImpl) Fresh() error {
-	if err := r.Stop(); err != nil {
+	if err := r.Shutdown(); err != nil {
 		return err
 	}
 
@@ -69,7 +69,7 @@ func (r *SqliteImpl) Ready() error {
 	return err
 }
 
-func (r *SqliteImpl) Stop() error {
+func (r *SqliteImpl) Shutdown() error {
 	if err := file.Remove(r.database); err != nil {
 		return fmt.Errorf("stop Sqlite error: %v", err)
 	}

--- a/support/docker/sqlite_test.go
+++ b/support/docker/sqlite_test.go
@@ -69,9 +69,9 @@ INSERT INTO users (name) VALUES ('goravel');
 	databaseDriver, err := s.sqlite.Database("another")
 	s.NoError(err)
 	s.NotNil(databaseDriver)
-	s.NoError(databaseDriver.Stop())
+	s.NoError(databaseDriver.Shutdown())
 
-	s.Nil(s.sqlite.Stop())
+	s.Nil(s.sqlite.Shutdown())
 }
 
 func (s *SqliteTestSuite) TestDriver() {

--- a/support/docker/sqlserver.go
+++ b/support/docker/sqlserver.go
@@ -115,7 +115,7 @@ func (r *SqlserverImpl) Ready() error {
 	return err
 }
 
-func (r *SqlserverImpl) Stop() error {
+func (r *SqlserverImpl) Shutdown() error {
 	if _, err := run(fmt.Sprintf("docker stop %s", r.containerID)); err != nil {
 		return fmt.Errorf("stop Sqlserver error: %v", err)
 	}

--- a/support/docker/sqlserver_test.go
+++ b/support/docker/sqlserver_test.go
@@ -76,7 +76,7 @@ func (s *SqlserverTestSuite) TestBuild() {
 	s.NoError(err)
 	s.NotNil(databaseDriver)
 
-	s.Nil(s.sqlserver.Stop())
+	s.Nil(s.sqlserver.Shutdown())
 }
 
 func (s *SqlserverTestSuite) TestDriver() {

--- a/testing/docker/database_test.go
+++ b/testing/docker/database_test.go
@@ -110,7 +110,7 @@ func TestNewDatabase(t *testing.T) {
 
 			assert.Nil(t, err)
 			assert.NotNil(t, gotDatabase)
-			assert.NoError(t, gotDatabase.Stop())
+			assert.NoError(t, gotDatabase.Shutdown())
 		})
 	}
 }
@@ -153,7 +153,7 @@ func (s *DatabaseTestSuite) TestBuild() {
 
 	s.Nil(s.database.Build())
 	s.True(s.database.Config().Port > 0)
-	s.Nil(s.database.Stop())
+	s.Nil(s.database.Shutdown())
 }
 
 func (s *DatabaseTestSuite) TestConfig() {

--- a/testing/docker/docker_test.go
+++ b/testing/docker/docker_test.go
@@ -51,7 +51,7 @@ func (s *DockerTestSuite) TestDatabase() {
 
 	databaseImpl := database.(*Database)
 	s.Equal("mysql", databaseImpl.connection)
-	s.NoError(database.Stop())
+	s.NoError(database.Shutdown())
 
 	mockConfig = mocksconfig.NewConfig(s.T())
 	mockConfig.EXPECT().GetString("database.connections.postgres.driver").Return("postgres").Once()
@@ -72,5 +72,5 @@ func (s *DockerTestSuite) TestDatabase() {
 
 	databaseImpl = database.(*Database)
 	s.Equal("postgres", databaseImpl.connection)
-	s.NoError(database.Stop())
+	s.NoError(database.Shutdown())
 }


### PR DESCRIPTION
## 📑 Description

Shutdown means closing a server gracefully. Stop means interrupting a server directly. So, for us, `Shutdown` is better than `Stop`.

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `Shutdown` method to replace the previous `Stop` method across various components, enhancing clarity in functionality.

- **Bug Fixes**
	- Improved error handling in the `Build` and `Fresh` methods of the SQL Server implementation.

- **Tests**
	- Updated test cases to reflect the renaming of the `Stop` method to `Shutdown`, ensuring accurate validation of shutdown procedures across multiple test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
