### PR TITLE
feat: [#374] The postgres driver supports set schema

### DIFF
--- a/contracts/database/config.go
+++ b/contracts/database/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	Database string
 	Username string
 	Password string
+	// Only for Postgres and Sqlserver
+	Schema string
 }
 
 // FullConfig Fill the default value for Config

--- a/contracts/database/config.go
+++ b/contracts/database/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	Database string
 	Username string
 	Password string
-	// Only for Postgres and Sqlserver
+	// Only for Postgres
 	Schema string
 }
 

--- a/database/db/config_builder.go
+++ b/database/db/config_builder.go
@@ -73,6 +73,9 @@ func (c *ConfigBuilder) fillDefault(configs []database.Config) []database.FullCo
 			if driver == database.DriverMysql || driver == database.DriverSqlserver {
 				fullConfig.Charset = c.config.GetString(fmt.Sprintf("database.connections.%s.charset", c.connection))
 			}
+			if fullConfig.Schema == "" && driver == database.DriverPostgres {
+				fullConfig.Schema = c.config.GetString(fmt.Sprintf("database.connections.%s.schema", c.connection), "public")
+			}
 			if driver == database.DriverMysql {
 				fullConfig.Loc = c.config.GetString(fmt.Sprintf("database.connections.%s.loc", c.connection))
 			}

--- a/database/db/dsn.go
+++ b/database/db/dsn.go
@@ -20,8 +20,8 @@ func Dsn(config database.FullConfig) string {
 		return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=%s&parseTime=%t&loc=%s&multiStatements=true",
 			config.Username, config.Password, config.Host, config.Port, config.Database, config.Charset, true, config.Loc)
 	case database.DriverPostgres:
-		return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&timezone=%s",
-			config.Username, config.Password, config.Host, config.Port, config.Database, config.Sslmode, config.Timezone)
+		return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&timezone=%s&search_path=%s",
+			config.Username, config.Password, config.Host, config.Port, config.Database, config.Sslmode, config.Timezone, config.Schema)
 	case database.DriverSqlite:
 		return fmt.Sprintf("%s?multi_stmts=true", config.Database)
 	case database.DriverSqlserver:

--- a/database/db/dsn_test.go
+++ b/database/db/dsn_test.go
@@ -15,6 +15,7 @@ const (
 	testDatabase = "forge"
 	testUsername = "root"
 	testPassword = "123123"
+	testSchema   = "public"
 )
 
 var testConfig = database.Config{
@@ -23,6 +24,7 @@ var testConfig = database.Config{
 	Database: testDatabase,
 	Username: testUsername,
 	Password: testPassword,
+	Schema:   testSchema,
 }
 
 func TestDsn(t *testing.T) {
@@ -65,8 +67,8 @@ func TestDsn(t *testing.T) {
 				Sslmode:  "disable",
 				Timezone: "UTC",
 			},
-			expectDsn: fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&timezone=%s",
-				testUsername, testPassword, testHost, testPort, testDatabase, "disable", "UTC"),
+			expectDsn: fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&timezone=%s&search_path=%s",
+				testUsername, testPassword, testHost, testPort, testDatabase, "disable", "UTC", testSchema),
 		},
 		{
 			name: "sqlite",

--- a/database/gorm/query_test.go
+++ b/database/gorm/query_test.go
@@ -3831,6 +3831,22 @@ func TestTablePrefixAndSingular(t *testing.T) {
 	}
 }
 
+func TestSchema(t *testing.T) {
+	postgresDocker := supportdocker.Postgres()
+	require.NoError(t, postgresDocker.Ready())
+
+	testQuery := NewTestQueryWithSchema(postgresDocker, "goravel")
+	testQuery.CreateTable(TestTableUsers)
+
+	user := User{Name: "first_user"}
+	assert.Nil(t, testQuery.Query().Create(&user))
+	assert.True(t, user.ID > 0)
+
+	var user1 User
+	assert.Nil(t, testQuery.Query().Where("name", "first_user").First(&user1))
+	assert.True(t, user1.ID > 0)
+}
+
 func paginator(page string, limit string) func(methods contractsorm.Query) contractsorm.Query {
 	return func(query contractsorm.Query) contractsorm.Query {
 		page, _ := strconv.Atoi(page)

--- a/database/gorm/query_test.go
+++ b/database/gorm/query_test.go
@@ -3832,6 +3832,10 @@ func TestTablePrefixAndSingular(t *testing.T) {
 }
 
 func TestSchema(t *testing.T) {
+	if env.IsWindows() {
+		t.Skip("Skip test that using Docker")
+	}
+
 	postgresDocker := supportdocker.Postgres()
 	require.NoError(t, postgresDocker.Ready())
 

--- a/database/gorm/test_utils.go
+++ b/database/gorm/test_utils.go
@@ -35,6 +35,7 @@ type testMockDriver interface {
 	Common()
 	ReadWrite(readDatabaseConfig testing.DatabaseConfig)
 	WithPrefixAndSingular()
+	WithSchema(schema string)
 }
 
 type TestQueries struct {
@@ -145,7 +146,13 @@ func (r *TestQueries) queries(withPrefixAndSingular bool) map[contractsdatabase.
 	}
 
 	for driver, docker := range driverToDocker {
-		query := NewTestQuery(docker, withPrefixAndSingular)
+		var query *TestQuery
+		if withPrefixAndSingular {
+			query = NewTestQueryWithPrefixAndSingular(docker)
+		} else {
+			query = NewTestQuery(docker)
+		}
+
 		driverToTestQuery[driver] = query
 	}
 
@@ -159,28 +166,75 @@ type TestQuery struct {
 	query      orm.Query
 }
 
-func NewTestQuery(docker testing.DatabaseDriver, withPrefixAndSingular ...bool) *TestQuery {
+func NewTestQuery(docker testing.DatabaseDriver) *TestQuery {
 	mockConfig := &mocksconfig.Config{}
 	mockDriver := getMockDriver(docker, mockConfig, docker.Driver().String())
-
 	testQuery := &TestQuery{
 		docker:     docker,
 		mockConfig: mockConfig,
 		mockDriver: mockDriver,
 	}
 
-	var (
-		query *Query
-		err   error
-	)
-	if len(withPrefixAndSingular) > 0 && withPrefixAndSingular[0] {
-		mockDriver.WithPrefixAndSingular()
-		query, err = BuildQuery(testContext, mockConfig, docker.Driver().String(), nil, nil)
-	} else {
-		mockDriver.Common()
-		query, err = BuildQuery(testContext, mockConfig, docker.Driver().String(), nil, nil)
+	mockDriver.Common()
+	query, err := BuildQuery(testContext, mockConfig, docker.Driver().String(), nil, nil)
+	if err != nil {
+		panic(fmt.Sprintf("connect to %s failed: %v", docker.Driver().String(), err))
 	}
 
+	testQuery.query = query
+
+	return testQuery
+}
+
+func NewTestQueryWithPrefixAndSingular(docker testing.DatabaseDriver) *TestQuery {
+	mockConfig := &mocksconfig.Config{}
+	mockDriver := getMockDriver(docker, mockConfig, docker.Driver().String())
+	testQuery := &TestQuery{
+		docker:     docker,
+		mockConfig: mockConfig,
+		mockDriver: mockDriver,
+	}
+
+	mockDriver.WithPrefixAndSingular()
+	query, err := BuildQuery(testContext, mockConfig, docker.Driver().String(), nil, nil)
+	if err != nil {
+		panic(fmt.Sprintf("connect to %s failed: %v", docker.Driver().String(), err))
+	}
+
+	testQuery.query = query
+
+	return testQuery
+}
+
+func NewTestQueryWithSchema(docker testing.DatabaseDriver, schema string) *TestQuery {
+	if docker.Driver() != contractsdatabase.DriverPostgres && docker.Driver() != contractsdatabase.DriverSqlserver {
+		panic(fmt.Sprintf("%s does not support schema", docker.Driver().String()))
+	}
+
+	// Create schema before build query with the schema
+	mockConfig := &mocksconfig.Config{}
+	mockDriver := getMockDriver(docker, mockConfig, docker.Driver().String())
+	mockDriver.WithPrefixAndSingular()
+	query, err := BuildQuery(testContext, mockConfig, docker.Driver().String(), nil, nil)
+	if err != nil {
+		panic(fmt.Sprintf("connect to %s failed: %v", docker.Driver().String(), err))
+	}
+
+	if _, err := query.Exec(fmt.Sprintf("CREATE SCHEMA %s", schema)); err != nil {
+		panic(fmt.Sprintf("create schema %s failed: %v", schema, err))
+	}
+
+	mockConfig = &mocksconfig.Config{}
+	mockDriver = getMockDriver(docker, mockConfig, docker.Driver().String())
+	testQuery := &TestQuery{
+		docker:     docker,
+		mockConfig: mockConfig,
+		mockDriver: mockDriver,
+	}
+
+	mockDriver.WithSchema(schema)
+
+	query, err = BuildQuery(testContext, mockConfig, docker.Driver().String(), nil, nil)
 	if err != nil {
 		panic(fmt.Sprintf("connect to %s failed: %v", docker.Driver().String(), err))
 	}
@@ -261,8 +315,6 @@ func NewMockMysql(mockConfig *mocksconfig.Config, connection, database, username
 }
 
 func (r *MockMysql) Common() {
-	r.mockConfig.On("GetString", "database.default").Return("mysql")
-	r.mockConfig.On("GetString", "database.migrations.table").Return("migrations")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.prefix", r.connection)).Return("")
 	r.mockConfig.On("GetBool", fmt.Sprintf("database.connections.%s.singular", r.connection)).Return(false)
 	r.single()
@@ -288,6 +340,8 @@ func (r *MockMysql) WithPrefixAndSingular() {
 	r.single()
 	r.basic()
 }
+
+func (r *MockMysql) WithSchema(schema string) {}
 
 func (r *MockMysql) basic() {
 	r.mockConfig.On("GetBool", "app.debug").Return(true)
@@ -334,10 +388,9 @@ func NewMockPostgres(mockConfig *mocksconfig.Config, connection, database, usern
 }
 
 func (r *MockPostgres) Common() {
-	r.mockConfig.On("GetString", "database.default").Return("postgres")
-	r.mockConfig.On("GetString", "database.migrations.table").Return("migrations")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.prefix", r.connection)).Return("")
 	r.mockConfig.On("GetBool", fmt.Sprintf("database.connections.%s.singular", r.connection)).Return(false)
+	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.schema", r.connection), "public").Return("public")
 	r.single()
 	r.basic()
 }
@@ -352,12 +405,22 @@ func (r *MockPostgres) ReadWrite(readDatabaseConfig testing.DatabaseConfig) {
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.dsn", r.connection)).Return("")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.prefix", r.connection)).Return("")
 	r.mockConfig.On("GetBool", fmt.Sprintf("database.connections.%s.singular", r.connection)).Return(false)
+	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.schema", r.connection), "public").Return("public")
 	r.basic()
 }
 
 func (r *MockPostgres) WithPrefixAndSingular() {
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.prefix", r.connection)).Return("goravel_")
 	r.mockConfig.On("GetBool", fmt.Sprintf("database.connections.%s.singular", r.connection)).Return(true)
+	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.schema", r.connection), "public").Return("public")
+	r.single()
+	r.basic()
+}
+
+func (r *MockPostgres) WithSchema(schema string) {
+	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.prefix", r.connection)).Return("")
+	r.mockConfig.On("GetBool", fmt.Sprintf("database.connections.%s.singular", r.connection)).Return(false)
+	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.schema", r.connection), "public").Return(schema)
 	r.single()
 	r.basic()
 }
@@ -368,7 +431,6 @@ func (r *MockPostgres) basic() {
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.sslmode", r.connection)).Return("disable")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.timezone", r.connection)).Return("UTC")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.database", r.connection)).Return(r.database)
-	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.search_path", r.connection), "public").Return("public")
 
 	mockPool(r.mockConfig)
 }
@@ -401,8 +463,6 @@ func NewMockSqlite(mockConfig *mocksconfig.Config, connection, database string) 
 }
 
 func (r *MockSqlite) Common() {
-	r.mockConfig.On("GetString", "database.default").Return("sqlite")
-	r.mockConfig.On("GetString", "database.migrations.table").Return("migrations")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.prefix", r.connection)).Return("")
 	r.mockConfig.On("GetBool", fmt.Sprintf("database.connections.%s.singular", r.connection)).Return(false)
 	r.single()
@@ -427,6 +487,8 @@ func (r *MockSqlite) WithPrefixAndSingular() {
 	r.single()
 	r.basic()
 }
+
+func (r *MockSqlite) WithSchema(schema string) {}
 
 func (r *MockSqlite) basic() {
 	r.mockConfig.On("GetBool", "app.debug").Return(true)
@@ -464,8 +526,6 @@ func NewMockSqlserver(mockConfig *mocksconfig.Config, connection, database, user
 }
 
 func (r *MockSqlserver) Common() {
-	r.mockConfig.On("GetString", "database.default").Return("sqlserver")
-	r.mockConfig.On("GetString", "database.migrations.table").Return("migrations")
 	r.mockConfig.On("GetString", fmt.Sprintf("database.connections.%s.prefix", r.connection)).Return("")
 	r.mockConfig.On("GetBool", fmt.Sprintf("database.connections.%s.singular", r.connection)).Return(false)
 	r.single()
@@ -491,6 +551,8 @@ func (r *MockSqlserver) WithPrefixAndSingular() {
 	r.single()
 	r.basic()
 }
+
+func (r *MockSqlserver) WithSchema(schema string) {}
 
 func (r *MockSqlserver) basic() {
 	r.mockConfig.On("GetBool", "app.debug").Return(true)

--- a/database/gorm/test_utils.go
+++ b/database/gorm/test_utils.go
@@ -341,7 +341,9 @@ func (r *MockMysql) WithPrefixAndSingular() {
 	r.basic()
 }
 
-func (r *MockMysql) WithSchema(schema string) {}
+func (r *MockMysql) WithSchema(schema string) {
+	panic("mysql does not support schema")
+}
 
 func (r *MockMysql) basic() {
 	r.mockConfig.On("GetBool", "app.debug").Return(true)
@@ -488,7 +490,9 @@ func (r *MockSqlite) WithPrefixAndSingular() {
 	r.basic()
 }
 
-func (r *MockSqlite) WithSchema(schema string) {}
+func (r *MockSqlite) WithSchema(schema string) {
+	panic("sqlite does not support schema")
+}
 
 func (r *MockSqlite) basic() {
 	r.mockConfig.On("GetBool", "app.debug").Return(true)
@@ -552,7 +556,9 @@ func (r *MockSqlserver) WithPrefixAndSingular() {
 	r.basic()
 }
 
-func (r *MockSqlserver) WithSchema(schema string) {}
+func (r *MockSqlserver) WithSchema(schema string) {
+	panic("sqlserver does not support schema for now")
+}
 
 func (r *MockSqlserver) basic() {
 	r.mockConfig.On("GetBool", "app.debug").Return(true)

--- a/database/migration/default_migrator_test.go
+++ b/database/migration/default_migrator_test.go
@@ -2,7 +2,6 @@ package migration
 
 import (
 	"errors"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	contractsdatabase "github.com/goravel/framework/contracts/database"

--- a/database/migration/default_migrator_test.go
+++ b/database/migration/default_migrator_test.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"errors"
+	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"path/filepath"
@@ -42,13 +43,35 @@ func TestDefaultMigratorWithDBSuite(t *testing.T) {
 }
 
 func (s *DefaultMigratorWithDBSuite) SetupTest() {
-	// TODO Add other drivers
 	postgresDocker := docker.Postgres()
-	s.NoError(postgresDocker.Ready())
+	s.Require().NoError(postgresDocker.Ready())
 
-	postgresQuery := gorm.NewTestQuery(postgresDocker, true)
+	postgresQuery := gorm.NewTestQueryWithPrefixAndSingular(postgresDocker)
+
+	sqliteDocker := docker.Sqlite()
+	sqliteQuery := gorm.NewTestQueryWithPrefixAndSingular(sqliteDocker)
+
+	mysqlDocker := docker.Mysql()
+	s.Require().NoError(mysqlDocker.Ready())
+
+	mysqlQuery := gorm.NewTestQueryWithPrefixAndSingular(mysqlDocker)
+
+	sqlserverDocker := docker.Sqlserver()
+	s.Require().NoError(sqlserverDocker.Ready())
+
+	sqlserverQuery := gorm.NewTestQueryWithPrefixAndSingular(sqlserverDocker)
+
 	s.driverToTestQuery = map[contractsdatabase.Driver]*gorm.TestQuery{
-		contractsdatabase.DriverPostgres: postgresQuery,
+		contractsdatabase.DriverPostgres:  postgresQuery,
+		contractsdatabase.DriverSqlite:    sqliteQuery,
+		contractsdatabase.DriverMysql:     mysqlQuery,
+		contractsdatabase.DriverSqlserver: sqlserverQuery,
+	}
+}
+
+func (s *DefaultMigratorWithDBSuite) TearDownTest() {
+	if s.driverToTestQuery[contractsdatabase.DriverSqlite] != nil {
+		s.NoError(s.driverToTestQuery[contractsdatabase.DriverSqlite].Docker().Shutdown())
 	}
 }
 
@@ -92,6 +115,24 @@ func (s *DefaultMigratorWithDBSuite) TestStatus() {
 			s.NoError(migrator.Status())
 		})
 	}
+}
+
+func TestDefaultMigratorWithWithSchema(t *testing.T) {
+	postgresDocker := docker.Postgres()
+	require.NoError(t, postgresDocker.Ready())
+
+	postgresQuery := gorm.NewTestQueryWithSchema(postgresDocker, "goravel")
+	schema := databaseschema.GetTestSchema(postgresQuery, map[contractsdatabase.Driver]*gorm.TestQuery{
+		contractsdatabase.DriverPostgres: postgresQuery,
+	})
+	testMigration := NewTestMigration(schema)
+	schema.Register([]contractsschema.Migration{
+		testMigration,
+	})
+	migrator := NewDefaultMigrator(nil, schema, "migrations")
+
+	assert.NoError(t, migrator.Run())
+	assert.True(t, schema.HasTable("users"))
 }
 
 type DefaultMigratorSuite struct {

--- a/database/migration/repository_test.go
+++ b/database/migration/repository_test.go
@@ -29,7 +29,7 @@ func (s *RepositoryTestSuite) SetupTest() {
 	postgresDocker := docker.Postgres()
 	s.Require().NoError(postgresDocker.Ready())
 
-	postgresQuery := gorm.NewTestQuery(postgresDocker, true)
+	postgresQuery := gorm.NewTestQueryWithPrefixAndSingular(postgresDocker)
 	s.driverToTestQuery = map[database.Driver]*gorm.TestQuery{
 		database.DriverPostgres: postgresQuery,
 	}

--- a/database/schema/blueprint.go
+++ b/database/schema/blueprint.go
@@ -229,7 +229,6 @@ func (r *Blueprint) GetCommands() []*schema.Command {
 }
 
 func (r *Blueprint) GetTableName() string {
-	// TODO Add schema for Postgres
 	return r.table
 }
 

--- a/database/schema/blueprint_test.go
+++ b/database/schema/blueprint_test.go
@@ -370,13 +370,10 @@ func (s *BlueprintTestSuite) TestToSql() {
 	for driver, grammar := range s.grammars {
 		// Create a table
 		s.blueprint.Create()
-		s.blueprint.String("name")
-		// TODO Add below when implementing the comment method
-		//s.blueprint.String("name").Comment("comment")
-		//s.blueprint.Comment("comment")
+		s.blueprint.String("name").Comment("comment")
 
 		if driver == database.DriverPostgres {
-			s.Len(s.blueprint.ToSql(grammar), 1)
+			s.Len(s.blueprint.ToSql(grammar), 2)
 		} else {
 			s.Empty(s.blueprint.ToSql(grammar))
 		}

--- a/database/schema/common_schema_test.go
+++ b/database/schema/common_schema_test.go
@@ -28,7 +28,7 @@ func (s *CommonSchemaSuite) SetupTest() {
 	postgresDocker := docker.Postgres()
 	s.Require().NoError(postgresDocker.Ready())
 
-	postgresQuery := gorm.NewTestQuery(postgresDocker, true)
+	postgresQuery := gorm.NewTestQueryWithPrefixAndSingular(postgresDocker)
 	s.driverToTestQuery = map[database.Driver]*gorm.TestQuery{
 		database.DriverPostgres: postgresQuery,
 	}

--- a/database/schema/schema.go
+++ b/database/schema/schema.go
@@ -44,7 +44,7 @@ func NewSchema(config config.Config, log log.Log, orm contractsorm.Orm, migratio
 
 	switch driver {
 	case contractsdatabase.DriverPostgres:
-		schema = config.GetString(fmt.Sprintf("database.connections.%s.search_path", orm.Name()), "public")
+		schema = config.GetString(fmt.Sprintf("database.connections.%s.schema", orm.Name()), "public")
 
 		postgresGrammar := grammars.NewPostgres(prefix)
 		driverSchema = NewPostgresSchema(postgresGrammar, orm, schema, prefix)

--- a/database/schema/schema_test.go
+++ b/database/schema/schema_test.go
@@ -2332,6 +2332,10 @@ func (s *SchemaSuite) createTableAndAssertColumnsForColumnMethods(schema contrac
 }
 
 func TestSpecificSchema(t *testing.T) {
+	if env.IsWindows() {
+		t.Skip("Skip test that using Docker")
+	}
+
 	schema := "goravel"
 	table := "table"
 	postgresDocker := docker.Postgres()

--- a/database/schema/schema_test.go
+++ b/database/schema/schema_test.go
@@ -1,12 +1,12 @@
 package schema
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
 	"github.com/spf13/cast"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goravel/framework/contracts/database"

--- a/database/schema/schema_test.go
+++ b/database/schema/schema_test.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -33,20 +35,20 @@ func (s *SchemaSuite) SetupTest() {
 	postgresDocker := docker.Postgres()
 	s.Require().NoError(postgresDocker.Ready())
 
-	postgresQuery := gorm.NewTestQuery(postgresDocker, true)
+	postgresQuery := gorm.NewTestQueryWithPrefixAndSingular(postgresDocker)
 
 	sqliteDocker := docker.Sqlite()
-	sqliteQuery := gorm.NewTestQuery(sqliteDocker, true)
+	sqliteQuery := gorm.NewTestQueryWithPrefixAndSingular(sqliteDocker)
 
 	mysqlDocker := docker.Mysql()
 	s.Require().NoError(mysqlDocker.Ready())
 
-	mysqlQuery := gorm.NewTestQuery(mysqlDocker, true)
+	mysqlQuery := gorm.NewTestQueryWithPrefixAndSingular(mysqlDocker)
 
 	sqlserverDocker := docker.Sqlserver()
 	s.Require().NoError(sqlserverDocker.Ready())
 
-	sqlserverQuery := gorm.NewTestQuery(sqlserverDocker, true)
+	sqlserverQuery := gorm.NewTestQueryWithPrefixAndSingular(sqlserverDocker)
 
 	s.prefix = "goravel_"
 	s.driverToTestQuery = map[database.Driver]*gorm.TestQuery{
@@ -2149,7 +2151,7 @@ func (s *SchemaSuite) TestTableMethods() {
 			s.NoError(schema.Drop(tableThree))
 			s.False(schema.HasTable(tableThree))
 
-			testQuery.MockConfig().EXPECT().GetString("database.connections.postgres.search_path").Return("").Once()
+			testQuery.MockConfig().EXPECT().GetString("database.connections.postgres.schema").Return("").Once()
 
 			s.NoError(schema.DropAllTables())
 			s.False(schema.HasTable(tableFour))
@@ -2327,4 +2329,26 @@ func (s *SchemaSuite) createTableAndAssertColumnsForColumnMethods(schema contrac
 	s.Contains(columnListing, "unsigned_integer")
 	s.Contains(columnListing, "unsigned_big_integer")
 	s.Contains(columnListing, "updated_at")
+}
+
+func TestSpecificSchema(t *testing.T) {
+	schema := "goravel"
+	table := "table"
+	postgresDocker := docker.Postgres()
+	require.NoError(t, postgresDocker.Ready())
+
+	postgresQuery := gorm.NewTestQueryWithSchema(postgresDocker, schema)
+	testSchema := GetTestSchema(postgresQuery, map[database.Driver]*gorm.TestQuery{
+		database.DriverPostgres: postgresQuery,
+	})
+
+	assert.NoError(t, testSchema.Create(table, func(table contractsschema.Blueprint) {
+		table.String("name")
+	}))
+	tables, err := testSchema.GetTables()
+
+	assert.NoError(t, err)
+	assert.Len(t, tables, 1)
+	assert.Equal(t, "table", tables[0].Name)
+	assert.Equal(t, schema, tables[0].Schema)
 }

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -331,6 +331,7 @@ func (s *ApplicationTestSuite) TestMakeOrm() {
 	mockConfig.EXPECT().GetString("database.connections.postgres.sslmode").Return("disable").Twice()
 	mockConfig.EXPECT().GetString("database.connections.postgres.timezone").Return("UTC").Twice()
 	mockConfig.EXPECT().GetString("database.connections.postgres.database").Return(config.Database).Twice()
+	mockConfig.EXPECT().GetString("database.connections.postgres.schema", "public").Return("public").Twice()
 	mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
 	mockConfig.EXPECT().GetInt("database.pool.max_idle_conns", 10).Return(10).Once()
 	mockConfig.EXPECT().GetInt("database.pool.max_open_conns", 100).Return(100).Once()


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/374

Tested locally, will implement sqlserver schema in next PR.

<img width="1054" alt="iShot_2024-12-18_17 48 32" src="https://github.com/user-attachments/assets/9d89daaa-ad82-4add-b891-c81a425784c6" />

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for a new `Schema` field in PostgreSQL database configurations.
	- Enhanced connection string for PostgreSQL to include the `search_path` parameter.
	- Introduced new test cases to validate schema-related functionality.

- **Bug Fixes**
	- Improved handling of default schema values in PostgreSQL configurations.

- **Tests**
	- Expanded test coverage for schema management and PostgreSQL configurations.
	- Updated existing tests to utilize new schema handling methods and improved error handling.

- **Chores**
	- Refactored test utilities for better schema handling and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
