### PR TITLE
feat: add color printing utilities

### DIFF
--- a/support/color/print.go
+++ b/support/color/print.go
@@ -1,0 +1,93 @@
+package color
+
+import "github.com/pterm/pterm"
+
+/*
+Package color provides utilities for rendering and printing colorized text using color tags.
+
+The color tags are automatically parsed and rendered.
+
+Supported Features:
+1. Style Tags:
+   Use predefined style tags to format text. Example:
+   color.Print("<suc>he</><comment>llo</>, <cyan>wel</><red>come</>")
+
+2. Custom Color Attributes:
+   Use specific color attributes for more granular control. Example:
+   color.Println("<fg=11aa23>he</><bg=120,35,156>llo</>, <fg=167;bg=232>wel</><fg=red>come</>")
+*/
+
+// Print renders color tags and prints the provided arguments without a newline.
+//
+// Example:
+//
+// color.Print("<suc>Hello</>, <red>World</>")
+func Print(a ...any) {
+	pterm.Print(a...)
+}
+
+// Println renders color tags and prints the provided arguments with a newline.
+//
+// Example:
+//
+// color.Println("<cyan>Welcome</>, <green>to</>, <yellow>Go</>")
+func Println(a ...any) {
+	pterm.Println(a...)
+}
+
+// Printf formats a string with the provided arguments, renders color tags, and prints the result.
+//
+// Example:
+//
+// color.Printf("<red>Error:</> %s\n", err)
+func Printf(format string, a ...any) {
+	pterm.Printf(format, a...)
+}
+
+// Printfln formats a string with the provided arguments, renders color tags,
+// and prints the result with a newline.
+//
+// Example:
+//
+// color.Printfln("<success>Success:</> %s", message)
+func Printfln(format string, a ...any) {
+	pterm.Printfln(format, a...)
+}
+
+// Sprint renders color tags and returns the formatted string.
+//
+// Example:
+//
+// result := color.Sprint("<blue>Processing...</>")
+func Sprint(a ...any) string {
+	return pterm.Sprint(a...)
+}
+
+// Sprintln renders color tags and returns the formatted string with a newline.
+//
+// Example:
+//
+// result := color.Sprintln("<fg=yellow;op=bold>Loading complete.</>")
+func Sprintln(a ...any) string {
+	return pterm.Sprintln(a...)
+}
+
+// Sprintf formats a string with the provided arguments, renders color tags,
+// and returns the formatted result.
+//
+// Example:
+//
+// result := color.Sprintf("<red>Error:</> %s", err)
+func Sprintf(format string, a ...any) string {
+	return pterm.Sprintf(format, a...)
+}
+
+// Sprintfln formats a string with the provided arguments, renders color tags,
+// and returns the formatted result with a newline.
+//
+// Example:
+//
+// result := color.Sprintfln("<green>Task completed:</> %s", taskName)
+func Sprintfln(format string, a ...any) string {
+	return pterm.Sprintfln(format, a...)
+}

--- a/support/color/print_test.go
+++ b/support/color/print_test.go
@@ -1,0 +1,69 @@
+package color
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColorHTMLLikeTag(t *testing.T) {
+	var tests = []struct {
+		name     string
+		actual   string
+		expected string
+	}{
+		{
+			name:     "print with style tag:red",
+			actual:   CaptureOutput(func(io.Writer) { Print("<red>MSG</>") }),
+			expected: "\x1b[0;31mMSG\x1b[0m",
+		},
+		{
+			name:     "print with style tag:bold",
+			actual:   CaptureOutput(func(io.Writer) { Println("<bold>MSG</>") }),
+			expected: "\x1b[1mMSG\x1b[0m\n",
+		},
+		{
+			name:     "print with style tag:info",
+			actual:   CaptureOutput(func(io.Writer) { Printf("<info>%s</>", "MSG") }),
+			expected: "\x1b[0;32mMSG\x1b[0m",
+		},
+
+		{
+			name:     "print with color attributes tag:fg=red",
+			actual:   CaptureOutput(func(io.Writer) { Printfln("<fg=red>%s</>", "MSG") }),
+			expected: "\x1b[31mMSG\x1b[0m\n",
+		},
+		{
+			name:     "print with color attributes tag:bg=blue",
+			actual:   CaptureOutput(func(io.Writer) { Print("<bg=blue>MSG</>") }),
+			expected: "\x1b[44mMSG\x1b[0m",
+		},
+		{
+			name:     "print with color attributes tag:fg=red;bg=blue",
+			actual:   Sprint("<fg=red;bg=blue>MSG</>"),
+			expected: "\x1b[31;44mMSG\x1b[0m",
+		},
+		{
+			name:     "print with color attributes tag:op=bold",
+			actual:   Sprintln("<op=bold>MSG</>"),
+			expected: "\x1b[1mMSG\x1b[0m\n",
+		},
+		{
+			name:     "print with color attributes tag:fg=red;bg=blue;op=bold",
+			actual:   Sprintf("<fg=red;bg=blue;op=bold>%s</>", "MSG"),
+			expected: "\x1b[31;44;1mMSG\x1b[0m",
+		},
+		{
+			name:     "print with color attributes tag:fg=11aa23;bg=120,35,156;op=underscore",
+			actual:   Sprintfln("<fg=11aa23;bg=120,35,156;op=underscore>%s</>", "MSG"),
+			expected: "\x1b[38;2;17;170;35;48;2;120;35;156;4mMSG\x1b[0m\n",
+		},
+	}
+	for _, tt := range tests {
+		_ = tt
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.actual)
+		})
+	}
+}


### PR DESCRIPTION
## 📑 Description

Package color provides utilities for rendering and printing colorized text using color tags.

The color tags are automatically parsed and rendered.

Supported Features:
1. Style Tags:
   Use predefined style tags to format text. Example:
   `color.Print("<suc>he</><comment>llo</>, <cyan>wel</><red>come</>")`

2. Custom Color Attributes:
   Use specific color attributes for more granular control. Example:
  ` color.Println("<fg=11aa23>he</><bg=120,35,156>llo</>, <fg=167;bg=232>wel</><fg=red>come</>")`

<img width="187" alt="image" src="https://github.com/user-attachments/assets/ac78570e-3462-4612-9602-c3493dea726e" />

Color tag more detail in https://gookit.github.io/color/#/?id=html-like-tag-usage

Closes https://github.com/goravel/goravel/issues/?

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
