### PR TITLE
chore: improve artisan db:show,db:table command display information

### DIFF
--- a/contracts/database/schema/schema.go
+++ b/contracts/database/schema/schema.go
@@ -129,10 +129,12 @@ type Index struct {
 }
 
 type Table struct {
-	Comment string
-	Name    string
-	Schema  string
-	Size    int
+	Collation string
+	Comment   string
+	Engine    string
+	Name      string
+	Schema    string
+	Size      int
 }
 
 type Type struct {

--- a/database/console/show_command.go
+++ b/database/console/show_command.go
@@ -140,6 +140,7 @@ func (r *ShowCommand) getDataBaseInfo() (name, version, openConnections string, 
 			version = versionResult.Value
 			if strings.Contains(version, "MariaDB") {
 				name = "MariaDB"
+				version = strings.Trim(version[:strings.Index(version, "MariaDB")], "-")
 			}
 			if len(driver.openConnectionsQuery) > 0 {
 				var openConnectionsResult queryResult
@@ -167,11 +168,11 @@ func (r *ShowCommand) display(ctx console.Context, info databaseInfo) {
 		}
 		return
 	}(); size > 0 {
-		ctx.TwoColumnDetail("Total Size", fmt.Sprintf("%.3fMiB", float64(size)/1024/1024))
+		ctx.TwoColumnDetail("Total Size", fmt.Sprintf("%.3f MB", float64(size)/1024/1024))
 	}
 	ctx.NewLine()
 	if len(info.Tables) > 0 {
-		ctx.TwoColumnDetail("<fg=green;op=bold>Tables</>", "<fg=yellow;op=bold>Size (MiB)</>")
+		ctx.TwoColumnDetail("<fg=green;op=bold>Tables</>", "<fg=yellow;op=bold>Size (MB)</>")
 		for i := range info.Tables {
 			ctx.TwoColumnDetail(info.Tables[i].Name, fmt.Sprintf("%.3f", float64(info.Tables[i].Size)/1024/1024))
 		}

--- a/database/console/show_command_test.go
+++ b/database/console/show_command_test.go
@@ -30,15 +30,15 @@ func TestShowCommand(t *testing.T) {
 		mockQuery = mocksorm.NewQuery(t)
 	}
 	successCaseExpected := [][2]string{
-		{"<fg=green;op=bold>MariaDB</>", "MariaDB"},
+		{"<fg=green;op=bold>MariaDB</>", "test-version"},
 		{"Database", "db"},
 		{"Host", "host"},
 		{"Port", "port"},
 		{"Username", "username"},
 		{"Open Connections", "2"},
 		{"Tables", "1"},
-		{"Total Size", "0.000MiB"},
-		{"<fg=green;op=bold>Tables</>", "<fg=yellow;op=bold>Size (MiB)</>"},
+		{"Total Size", "0.000 MB"},
+		{"<fg=green;op=bold>Tables</>", "<fg=yellow;op=bold>Size (MB)</>"},
 		{"test", "0.000"},
 		{"<fg=green;op=bold>Views</>", "<fg=yellow;op=bold>Rows</>"},
 		{"test", "0"},
@@ -116,7 +116,7 @@ func TestShowCommand(t *testing.T) {
 				mockQuery.EXPECT().Raw("SHOW status WHERE variable_name = 'threads_connected';").Return(mockQuery).Once()
 				mockQuery.EXPECT().Scan(&queryResult{}).Run(func(dest interface{}) {
 					if d, ok := dest.(*queryResult); ok {
-						d.Value = "MariaDB"
+						d.Value = "test-version-MariaDB"
 					}
 				}).Return(nil).Once()
 				mockQuery.EXPECT().Scan(&queryResult{}).Run(func(dest interface{}) {

--- a/database/console/table_command.go
+++ b/database/console/table_command.go
@@ -101,24 +101,33 @@ func (r *TableCommand) display(ctx console.Context, table schema.Table) {
 		ctx.Error(fmt.Sprintf("Failed to get foreign keys: %s", err.Error()))
 		return
 	}
-	ctx.TwoColumnDetail(fmt.Sprintf("<fg=green;op=bold>%s</>", table.Name), "")
+	ctx.TwoColumnDetail(fmt.Sprintf("<fg=green;op=bold>%s</>", table.Name), fmt.Sprintf("<fg=gray>%s</>", table.Comment))
 	ctx.TwoColumnDetail("Columns", fmt.Sprintf("%d", len(columns)))
-	ctx.TwoColumnDetail("Size", fmt.Sprintf("%.3fMiB", float64(table.Size)/1024/1024))
+	ctx.TwoColumnDetail("Size", fmt.Sprintf("%.3f MB", float64(table.Size)/1024/1024))
+	if len(table.Engine) > 0 {
+		ctx.TwoColumnDetail("Engine", table.Engine)
+	}
+	if len(table.Collation) > 0 {
+		ctx.TwoColumnDetail("Collation", table.Collation)
+	}
 	if len(columns) > 0 {
 		ctx.NewLine()
 		ctx.TwoColumnDetail("<fg=green;op=bold>Column</>", "Type")
 		for i := range columns {
 			var (
 				key        = columns[i].Name
-				value      = columns[i].TypeName
+				value      = columns[i].Type
 				attributes []string
 			)
 			if columns[i].Autoincrement {
 				attributes = append(attributes, "autoincrement")
 			}
-			attributes = append(attributes, columns[i].Type)
+			attributes = append(attributes, columns[i].TypeName)
 			if columns[i].Nullable {
 				attributes = append(attributes, "nullable")
+			}
+			if len(columns[i].Collation) > 0 {
+				attributes = append(attributes, columns[i].Collation)
 			}
 			key = fmt.Sprintf("%s <fg=gray>%s</>", key, strings.Join(attributes, ", "))
 			if columns[i].Default != "" {
@@ -131,7 +140,7 @@ func (r *TableCommand) display(ctx console.Context, table schema.Table) {
 		ctx.NewLine()
 		ctx.TwoColumnDetail("<fg=green;op=bold>Index</>", "")
 		for i := range indexes {
-			var attributes []string
+			attributes := []string{indexes[i].Type}
 			if len(indexes[i].Columns) > 1 {
 				attributes = append(attributes, "compound")
 			}


### PR DESCRIPTION
## 📑 Description

- Adding table comments, collation, and engine details to the output.
- Changing table size units from `MiB` to `MB` for better readability.
- Enhancing column type and index type displays for clarity.
- Improving  `MariaDB `version output for consistency.

### Screenshot

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/afade62a-c81b-4974-9455-54a53eefdabd" />

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `Collation` and `Engine` fields to the `Table` struct
	- Enhanced database table information display with more details like table comment, engine, and collation

- **Bug Fixes**
	- Updated size measurement display from "MiB" to "MB" across multiple commands and tests

- **Documentation**
	- Improved output formatting for database table and console commands to provide more comprehensive information
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
