### PR TITLE
chore: optimize make:command for auto-generated Signature and simplified method receivers

### DIFF
--- a/auth/console/jwt_secret_command.go
+++ b/auth/console/jwt_secret_command.go
@@ -21,27 +21,27 @@ func NewJwtSecretCommand(config config.Config) *JwtSecretCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *JwtSecretCommand) Signature() string {
+func (r *JwtSecretCommand) Signature() string {
 	return "jwt:secret"
 }
 
 // Description The console command description.
-func (receiver *JwtSecretCommand) Description() string {
+func (r *JwtSecretCommand) Description() string {
 	return "Set the JWTAuth secret key used to sign the tokens"
 }
 
 // Extend The console command extend.
-func (receiver *JwtSecretCommand) Extend() command.Extend {
+func (r *JwtSecretCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "jwt",
 	}
 }
 
 // Handle Execute the console command.
-func (receiver *JwtSecretCommand) Handle(ctx console.Context) error {
-	key := receiver.generateRandomKey()
+func (r *JwtSecretCommand) Handle(ctx console.Context) error {
+	key := r.generateRandomKey()
 
-	if err := receiver.setSecretInEnvironmentFile(key); err != nil {
+	if err := r.setSecretInEnvironmentFile(key); err != nil {
 		ctx.Error(err.Error())
 
 		return nil
@@ -53,19 +53,19 @@ func (receiver *JwtSecretCommand) Handle(ctx console.Context) error {
 }
 
 // generateRandomKey Generate a random key for the application.
-func (receiver *JwtSecretCommand) generateRandomKey() string {
+func (r *JwtSecretCommand) generateRandomKey() string {
 	return str.Random(32)
 }
 
 // setSecretInEnvironmentFile Set the application key in the environment file.
-func (receiver *JwtSecretCommand) setSecretInEnvironmentFile(key string) error {
-	currentKey := receiver.config.GetString("jwt.secret")
+func (r *JwtSecretCommand) setSecretInEnvironmentFile(key string) error {
+	currentKey := r.config.GetString("jwt.secret")
 
 	if currentKey != "" {
 		return errors.New("exist jwt secret")
 	}
 
-	err := receiver.writeNewEnvironmentFileWith(key)
+	err := r.writeNewEnvironmentFileWith(key)
 
 	if err != nil {
 		return err
@@ -75,13 +75,13 @@ func (receiver *JwtSecretCommand) setSecretInEnvironmentFile(key string) error {
 }
 
 // writeNewEnvironmentFileWith Write a new environment file with the given key.
-func (receiver *JwtSecretCommand) writeNewEnvironmentFileWith(key string) error {
+func (r *JwtSecretCommand) writeNewEnvironmentFileWith(key string) error {
 	content, err := os.ReadFile(support.EnvPath)
 	if err != nil {
 		return err
 	}
 
-	newContent := strings.Replace(string(content), "JWT_SECRET="+receiver.config.GetString("jwt.secret"), "JWT_SECRET="+key, 1)
+	newContent := strings.Replace(string(content), "JWT_SECRET="+r.config.GetString("jwt.secret"), "JWT_SECRET="+key, 1)
 
 	err = os.WriteFile(support.EnvPath, []byte(newContent), 0644)
 	if err != nil {

--- a/auth/console/policy_make_command.go
+++ b/auth/console/policy_make_command.go
@@ -18,17 +18,17 @@ func NewPolicyMakeCommand() *PolicyMakeCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *PolicyMakeCommand) Signature() string {
+func (r *PolicyMakeCommand) Signature() string {
 	return "make:policy"
 }
 
 // Description The console command description.
-func (receiver *PolicyMakeCommand) Description() string {
+func (r *PolicyMakeCommand) Description() string {
 	return "Create a new policy class"
 }
 
 // Extend The console command extend.
-func (receiver *PolicyMakeCommand) Extend() command.Extend {
+func (r *PolicyMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -42,14 +42,14 @@ func (receiver *PolicyMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *PolicyMakeCommand) Handle(ctx console.Context) error {
+func (r *PolicyMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "policy", ctx.Argument(0), filepath.Join("app", "policies"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		return err
 	}
 
@@ -58,12 +58,12 @@ func (receiver *PolicyMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *PolicyMakeCommand) getStub() string {
+func (r *PolicyMakeCommand) getStub() string {
 	return PolicyStubs{}.Policy()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *PolicyMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *PolicyMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyPolicy", structName)
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
 

--- a/cache/console/clear_command.go
+++ b/cache/console/clear_command.go
@@ -15,25 +15,25 @@ func NewClearCommand(cache cache.Cache) *ClearCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *ClearCommand) Signature() string {
+func (r *ClearCommand) Signature() string {
 	return "cache:clear"
 }
 
 // Description The console command description.
-func (receiver *ClearCommand) Description() string {
+func (r *ClearCommand) Description() string {
 	return "Flush the application cache"
 }
 
 // Extend The console command extend.
-func (receiver *ClearCommand) Extend() command.Extend {
+func (r *ClearCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "cache",
 	}
 }
 
 // Handle Execute the console command.
-func (receiver *ClearCommand) Handle(ctx console.Context) error {
-	if receiver.cache.Flush() {
+func (r *ClearCommand) Handle(ctx console.Context) error {
+	if r.cache.Flush() {
 		ctx.Success("Application cache cleared")
 	} else {
 		ctx.Error("Clear Application cache Failed")

--- a/console/console/build_command.go
+++ b/console/console/build_command.go
@@ -22,17 +22,17 @@ func NewBuildCommand(config config.Config) *BuildCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *BuildCommand) Signature() string {
+func (r *BuildCommand) Signature() string {
 	return "build"
 }
 
 // Description The console command description.
-func (receiver *BuildCommand) Description() string {
+func (r *BuildCommand) Description() string {
 	return "Build the application"
 }
 
 // Extend The console command extend.
-func (receiver *BuildCommand) Extend() command.Extend {
+func (r *BuildCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "build",
 		Flags: []command.Flag{
@@ -59,9 +59,9 @@ func (receiver *BuildCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *BuildCommand) Handle(ctx console.Context) error {
+func (r *BuildCommand) Handle(ctx console.Context) error {
 	var err error
-	if receiver.config.GetString("app.env") == "production" {
+	if r.config.GetString("app.env") == "production" {
 		ctx.Warning("**************************************")
 		ctx.Warning("*     Application In Production!     *")
 		ctx.Warning("**************************************")
@@ -99,7 +99,7 @@ func (receiver *BuildCommand) Handle(ctx console.Context) error {
 
 	if err := ctx.Spinner("Building...", console.SpinnerOption{
 		Action: func() error {
-			return receiver.build(os, generateCommand(ctx.Option("name"), ctx.OptionBool("static")))
+			return r.build(os, generateCommand(ctx.Option("name"), ctx.OptionBool("static")))
 		},
 	}); err != nil {
 		ctx.Error(fmt.Sprintf("Build error: %v", err))
@@ -110,7 +110,7 @@ func (receiver *BuildCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *BuildCommand) build(system string, command []string) error {
+func (r *BuildCommand) build(system string, command []string) error {
 	os.Setenv("CGO_ENABLED", "0")
 	os.Setenv("GOOS", system)
 	os.Setenv("GOARCH", "amd64")

--- a/console/console/key_generate_command.go
+++ b/console/console/key_generate_command.go
@@ -23,25 +23,25 @@ func NewKeyGenerateCommand(config config.Config) *KeyGenerateCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *KeyGenerateCommand) Signature() string {
+func (r *KeyGenerateCommand) Signature() string {
 	return "key:generate"
 }
 
 // Description The console command description.
-func (receiver *KeyGenerateCommand) Description() string {
+func (r *KeyGenerateCommand) Description() string {
 	return "Set the application key"
 }
 
 // Extend The console command extend.
-func (receiver *KeyGenerateCommand) Extend() command.Extend {
+func (r *KeyGenerateCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "key",
 	}
 }
 
 // Handle Execute the console command.
-func (receiver *KeyGenerateCommand) Handle(ctx console.Context) error {
-	if receiver.config.GetString("app.env") == "production" {
+func (r *KeyGenerateCommand) Handle(ctx console.Context) error {
+	if r.config.GetString("app.env") == "production" {
 		color.Warningln("**************************************")
 		color.Warningln("*     Application In Production!     *")
 		color.Warningln("**************************************")
@@ -58,8 +58,8 @@ func (receiver *KeyGenerateCommand) Handle(ctx console.Context) error {
 		}
 	}
 
-	key := receiver.generateRandomKey()
-	if err := receiver.writeNewEnvironmentFileWith(key); err != nil {
+	key := r.generateRandomKey()
+	if err := r.writeNewEnvironmentFileWith(key); err != nil {
 		ctx.Error(err.Error())
 
 		return nil
@@ -71,18 +71,18 @@ func (receiver *KeyGenerateCommand) Handle(ctx console.Context) error {
 }
 
 // generateRandomKey Generate a random key for the application.
-func (receiver *KeyGenerateCommand) generateRandomKey() string {
+func (r *KeyGenerateCommand) generateRandomKey() string {
 	return str.Random(32)
 }
 
 // writeNewEnvironmentFileWith Write a new environment file with the given key.
-func (receiver *KeyGenerateCommand) writeNewEnvironmentFileWith(key string) error {
+func (r *KeyGenerateCommand) writeNewEnvironmentFileWith(key string) error {
 	content, err := os.ReadFile(support.EnvPath)
 	if err != nil {
 		return err
 	}
 
-	newContent := strings.Replace(string(content), "APP_KEY="+receiver.config.GetString("app.key"), "APP_KEY="+key, 1)
+	newContent := strings.Replace(string(content), "APP_KEY="+r.config.GetString("app.key"), "APP_KEY="+key, 1)
 
 	err = os.WriteFile(support.EnvPath, []byte(newContent), 0644)
 	if err != nil {

--- a/console/console/make_command.go
+++ b/console/console/make_command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/goravel/framework/contracts/console/command"
 	supportconsole "github.com/goravel/framework/support/console"
 	"github.com/goravel/framework/support/file"
+	"github.com/goravel/framework/support/str"
 )
 
 type MakeCommand struct {
@@ -18,31 +19,31 @@ func NewMakeCommand() *MakeCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *MakeCommand) Signature() string {
+func (r *MakeCommand) Signature() string {
 	return "make:command"
 }
 
 // Description The console command description.
-func (receiver *MakeCommand) Description() string {
+func (r *MakeCommand) Description() string {
 	return "Create a new Artisan command"
 }
 
 // Extend The console command extend.
-func (receiver *MakeCommand) Extend() command.Extend {
+func (r *MakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 	}
 }
 
 // Handle Execute the console command.
-func (receiver *MakeCommand) Handle(ctx console.Context) error {
+func (r *MakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "command", ctx.Argument(0), filepath.Join("app", "console", "commands"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		return err
 	}
 
@@ -51,14 +52,15 @@ func (receiver *MakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *MakeCommand) getStub() string {
+func (r *MakeCommand) getStub() string {
 	return Stubs{}.Command()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *MakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *MakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyCommand", structName)
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
+	stub = strings.ReplaceAll(stub, "DummySignature", str.Of(structName).Kebab().Prepend("app:").String())
 
 	return stub
 }

--- a/console/console/make_command_test.go
+++ b/console/console/make_command_test.go
@@ -24,6 +24,7 @@ func TestMakeCommand(t *testing.T) {
 	mockContext.EXPECT().Success("Console command created successfully").Once()
 	assert.Nil(t, makeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/console/commands/clean_cache.go"))
+	assert.True(t, file.Contain("app/console/commands/clean_cache.go", "app:clean-cache"))
 
 	mockContext.EXPECT().Argument(0).Return("CleanCache").Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
@@ -37,6 +38,7 @@ func TestMakeCommand(t *testing.T) {
 	assert.True(t, file.Exists("app/console/commands/Goravel/clean_cache.go"))
 	assert.True(t, file.Contain("app/console/commands/Goravel/clean_cache.go", "package Goravel"))
 	assert.True(t, file.Contain("app/console/commands/Goravel/clean_cache.go", "type CleanCache struct"))
+	assert.True(t, file.Contain("app/console/commands/Goravel/clean_cache.go", "app:clean-cache"))
 
 	assert.Nil(t, file.Remove("app"))
 }

--- a/console/console/stubs.go
+++ b/console/console/stubs.go
@@ -26,7 +26,7 @@ func (r *DummyCommand) Description() string {
 
 // Extend The console command extend.
 func (r *DummyCommand) Extend() command.Extend {
-	return command.Extend{}
+	return command.Extend{Category: "app"}
 }
 
 // Handle Execute the console command.

--- a/console/console/stubs.go
+++ b/console/console/stubs.go
@@ -3,7 +3,7 @@ package console
 type Stubs struct {
 }
 
-func (receiver Stubs) Command() string {
+func (r Stubs) Command() string {
 	return `package DummyPackage
 
 import (
@@ -15,22 +15,22 @@ type DummyCommand struct {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *DummyCommand) Signature() string {
-	return "command:name"
+func (r *DummyCommand) Signature() string {
+	return "DummySignature"
 }
 
 // Description The console command description.
-func (receiver *DummyCommand) Description() string {
+func (r *DummyCommand) Description() string {
 	return "Command description"
 }
 
 // Extend The console command extend.
-func (receiver *DummyCommand) Extend() command.Extend {
+func (r *DummyCommand) Extend() command.Extend {
 	return command.Extend{}
 }
 
 // Handle Execute the console command.
-func (receiver *DummyCommand) Handle(ctx console.Context) error {
+func (r *DummyCommand) Handle(ctx console.Context) error {
 	
 	return nil
 }

--- a/database/console/factory_make_command.go
+++ b/database/console/factory_make_command.go
@@ -18,17 +18,17 @@ func NewFactoryMakeCommand() *FactoryMakeCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *FactoryMakeCommand) Signature() string {
+func (r *FactoryMakeCommand) Signature() string {
 	return "make:factory"
 }
 
 // Description The console command description.
-func (receiver *FactoryMakeCommand) Description() string {
+func (r *FactoryMakeCommand) Description() string {
 	return "Create a new factory class"
 }
 
 // Extend The console command extend.
-func (receiver *FactoryMakeCommand) Extend() command.Extend {
+func (r *FactoryMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -42,14 +42,14 @@ func (receiver *FactoryMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *FactoryMakeCommand) Handle(ctx console.Context) error {
+func (r *FactoryMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "factory", ctx.Argument(0), filepath.Join("database", "factories"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
@@ -59,12 +59,12 @@ func (receiver *FactoryMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *FactoryMakeCommand) getStub() string {
+func (r *FactoryMakeCommand) getStub() string {
 	return Stubs{}.Factory()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *FactoryMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *FactoryMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyFactory", structName)
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
 

--- a/database/console/model_make_command.go
+++ b/database/console/model_make_command.go
@@ -18,17 +18,17 @@ func NewModelMakeCommand() *ModelMakeCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *ModelMakeCommand) Signature() string {
+func (r *ModelMakeCommand) Signature() string {
 	return "make:model"
 }
 
 // Description The console command description.
-func (receiver *ModelMakeCommand) Description() string {
+func (r *ModelMakeCommand) Description() string {
 	return "Create a new model class"
 }
 
 // Extend The console command extend.
-func (receiver *ModelMakeCommand) Extend() command.Extend {
+func (r *ModelMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -42,14 +42,14 @@ func (receiver *ModelMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *ModelMakeCommand) Handle(ctx console.Context) error {
+func (r *ModelMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "model", ctx.Argument(0), filepath.Join("app", "models"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		return err
 	}
 
@@ -58,12 +58,12 @@ func (receiver *ModelMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *ModelMakeCommand) getStub() string {
+func (r *ModelMakeCommand) getStub() string {
 	return Stubs{}.Model()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *ModelMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *ModelMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyModel", structName)
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
 

--- a/database/console/observer_make_command.go
+++ b/database/console/observer_make_command.go
@@ -18,17 +18,17 @@ func NewObserverMakeCommand() *ObserverMakeCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *ObserverMakeCommand) Signature() string {
+func (r *ObserverMakeCommand) Signature() string {
 	return "make:observer"
 }
 
 // Description The console command description.
-func (receiver *ObserverMakeCommand) Description() string {
+func (r *ObserverMakeCommand) Description() string {
 	return "Create a new observer class"
 }
 
 // Extend The console command extend.
-func (receiver *ObserverMakeCommand) Extend() command.Extend {
+func (r *ObserverMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -42,14 +42,14 @@ func (receiver *ObserverMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *ObserverMakeCommand) Handle(ctx console.Context) error {
+func (r *ObserverMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "observer", ctx.Argument(0), filepath.Join("app", "observers"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		return err
 	}
 
@@ -58,12 +58,12 @@ func (receiver *ObserverMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *ObserverMakeCommand) getStub() string {
+func (r *ObserverMakeCommand) getStub() string {
 	return Stubs{}.Observer()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *ObserverMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *ObserverMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyObserver", structName)
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
 

--- a/database/console/seeder_make_command.go
+++ b/database/console/seeder_make_command.go
@@ -18,17 +18,17 @@ func NewSeederMakeCommand() *SeederMakeCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *SeederMakeCommand) Signature() string {
+func (r *SeederMakeCommand) Signature() string {
 	return "make:seeder"
 }
 
 // Description The console command description.
-func (receiver *SeederMakeCommand) Description() string {
+func (r *SeederMakeCommand) Description() string {
 	return "Create a new seeder class"
 }
 
 // Extend The console command extend.
-func (receiver *SeederMakeCommand) Extend() command.Extend {
+func (r *SeederMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -42,14 +42,14 @@ func (receiver *SeederMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *SeederMakeCommand) Handle(ctx console.Context) error {
+func (r *SeederMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "seeder", ctx.Argument(0), filepath.Join("database", "seeders"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		return err
 	}
 
@@ -58,12 +58,12 @@ func (receiver *SeederMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *SeederMakeCommand) getStub() string {
+func (r *SeederMakeCommand) getStub() string {
 	return Stubs{}.Seeder()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *SeederMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *SeederMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummySeeder", structName)
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
 

--- a/event/console/event_make_command.go
+++ b/event/console/event_make_command.go
@@ -14,17 +14,17 @@ type EventMakeCommand struct {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *EventMakeCommand) Signature() string {
+func (r *EventMakeCommand) Signature() string {
 	return "make:event"
 }
 
 // Description The console command description.
-func (receiver *EventMakeCommand) Description() string {
+func (r *EventMakeCommand) Description() string {
 	return "Create a new event class"
 }
 
 // Extend The console command extend.
-func (receiver *EventMakeCommand) Extend() command.Extend {
+func (r *EventMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -38,14 +38,14 @@ func (receiver *EventMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *EventMakeCommand) Handle(ctx console.Context) error {
+func (r *EventMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "event", ctx.Argument(0), filepath.Join("app", "events"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		return err
 	}
 
@@ -54,12 +54,12 @@ func (receiver *EventMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *EventMakeCommand) getStub() string {
+func (r *EventMakeCommand) getStub() string {
 	return Stubs{}.Event()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *EventMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *EventMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyEvent", structName)
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
 

--- a/event/console/listener_make_command.go
+++ b/event/console/listener_make_command.go
@@ -15,17 +15,17 @@ type ListenerMakeCommand struct {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *ListenerMakeCommand) Signature() string {
+func (r *ListenerMakeCommand) Signature() string {
 	return "make:listener"
 }
 
 // Description The console command description.
-func (receiver *ListenerMakeCommand) Description() string {
+func (r *ListenerMakeCommand) Description() string {
 	return "Create a new listener class"
 }
 
 // Extend The console command extend.
-func (receiver *ListenerMakeCommand) Extend() command.Extend {
+func (r *ListenerMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -39,14 +39,14 @@ func (receiver *ListenerMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *ListenerMakeCommand) Handle(ctx console.Context) error {
+func (r *ListenerMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "listener", ctx.Argument(0), filepath.Join("app", "listeners"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		return err
 	}
 
@@ -55,12 +55,12 @@ func (receiver *ListenerMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *ListenerMakeCommand) getStub() string {
+func (r *ListenerMakeCommand) getStub() string {
 	return Stubs{}.Listener()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *ListenerMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *ListenerMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyListener", structName)
 	stub = strings.ReplaceAll(stub, "DummyName", str.Of(structName).Snake().String())
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)

--- a/foundation/console/package_make_command.go
+++ b/foundation/console/package_make_command.go
@@ -17,17 +17,17 @@ func NewPackageMakeCommand() *PackageMakeCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *PackageMakeCommand) Signature() string {
+func (r *PackageMakeCommand) Signature() string {
 	return "make:package"
 }
 
 // Description The console command description.
-func (receiver *PackageMakeCommand) Description() string {
+func (r *PackageMakeCommand) Description() string {
 	return "Create a package template"
 }
 
 // Extend The console command extend.
-func (receiver *PackageMakeCommand) Extend() command.Extend {
+func (r *PackageMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -42,7 +42,7 @@ func (receiver *PackageMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *PackageMakeCommand) Handle(ctx console.Context) error {
+func (r *PackageMakeCommand) Handle(ctx console.Context) error {
 	pkg := ctx.Argument(0)
 	if pkg == "" {
 		var err error

--- a/foundation/console/test_make_command.go
+++ b/foundation/console/test_make_command.go
@@ -17,17 +17,17 @@ func NewTestMakeCommand() *TestMakeCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *TestMakeCommand) Signature() string {
+func (r *TestMakeCommand) Signature() string {
 	return "make:test"
 }
 
 // Description The console command description.
-func (receiver *TestMakeCommand) Description() string {
+func (r *TestMakeCommand) Description() string {
 	return "Create a new test class"
 }
 
 // Extend The console command extend.
-func (receiver *TestMakeCommand) Extend() command.Extend {
+func (r *TestMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -41,16 +41,16 @@ func (receiver *TestMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *TestMakeCommand) Handle(ctx console.Context) error {
+func (r *TestMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "test", ctx.Argument(0), "tests")
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	stub := receiver.getStub()
+	stub := r.getStub()
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(stub, m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(stub, m.GetPackageName(), m.GetStructName())); err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
@@ -60,12 +60,12 @@ func (receiver *TestMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *TestMakeCommand) getStub() string {
+func (r *TestMakeCommand) getStub() string {
 	return Stubs{}.Test()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *TestMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *TestMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyTest", structName)
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
 

--- a/http/console/controller_make_command.go
+++ b/http/console/controller_make_command.go
@@ -14,17 +14,17 @@ type ControllerMakeCommand struct {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *ControllerMakeCommand) Signature() string {
+func (r *ControllerMakeCommand) Signature() string {
 	return "make:controller"
 }
 
 // Description The console command description.
-func (receiver *ControllerMakeCommand) Description() string {
+func (r *ControllerMakeCommand) Description() string {
 	return "Create a new controller class"
 }
 
 // Extend The console command extend.
-func (receiver *ControllerMakeCommand) Extend() command.Extend {
+func (r *ControllerMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -43,19 +43,19 @@ func (receiver *ControllerMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *ControllerMakeCommand) Handle(ctx console.Context) error {
+func (r *ControllerMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "controller", ctx.Argument(0), filepath.Join("app", "http", "controllers"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	stub := receiver.getStub()
+	stub := r.getStub()
 	if ctx.OptionBool("resource") {
-		stub = receiver.getResourceStub()
+		stub = r.getResourceStub()
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(stub, m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(stub, m.GetPackageName(), m.GetStructName())); err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
@@ -65,16 +65,16 @@ func (receiver *ControllerMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *ControllerMakeCommand) getStub() string {
+func (r *ControllerMakeCommand) getStub() string {
 	return Stubs{}.Controller()
 }
 
-func (receiver *ControllerMakeCommand) getResourceStub() string {
+func (r *ControllerMakeCommand) getResourceStub() string {
 	return Stubs{}.ResourceController()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *ControllerMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *ControllerMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyController", structName)
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
 

--- a/http/console/middleware_make_command.go
+++ b/http/console/middleware_make_command.go
@@ -14,17 +14,17 @@ type MiddlewareMakeCommand struct {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *MiddlewareMakeCommand) Signature() string {
+func (r *MiddlewareMakeCommand) Signature() string {
 	return "make:middleware"
 }
 
 // Description The console command description.
-func (receiver *MiddlewareMakeCommand) Description() string {
+func (r *MiddlewareMakeCommand) Description() string {
 	return "Create a new middleware class"
 }
 
 // Extend The console command extend.
-func (receiver *MiddlewareMakeCommand) Extend() command.Extend {
+func (r *MiddlewareMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -38,14 +38,14 @@ func (receiver *MiddlewareMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *MiddlewareMakeCommand) Handle(ctx console.Context) error {
+func (r *MiddlewareMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "middleware", ctx.Argument(0), filepath.Join("app", "http", "middleware"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
@@ -55,12 +55,12 @@ func (receiver *MiddlewareMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *MiddlewareMakeCommand) getStub() string {
+func (r *MiddlewareMakeCommand) getStub() string {
 	return Stubs{}.Middleware()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *MiddlewareMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *MiddlewareMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyMiddleware", structName)
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
 

--- a/http/console/request_make_command.go
+++ b/http/console/request_make_command.go
@@ -14,17 +14,17 @@ type RequestMakeCommand struct {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *RequestMakeCommand) Signature() string {
+func (r *RequestMakeCommand) Signature() string {
 	return "make:request"
 }
 
 // Description The console command description.
-func (receiver *RequestMakeCommand) Description() string {
+func (r *RequestMakeCommand) Description() string {
 	return "Create a new request class"
 }
 
 // Extend The console command extend.
-func (receiver *RequestMakeCommand) Extend() command.Extend {
+func (r *RequestMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -38,14 +38,14 @@ func (receiver *RequestMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *RequestMakeCommand) Handle(ctx console.Context) error {
+func (r *RequestMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "request", ctx.Argument(0), filepath.Join("app", "http", "requests"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
@@ -55,12 +55,12 @@ func (receiver *RequestMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *RequestMakeCommand) getStub() string {
+func (r *RequestMakeCommand) getStub() string {
 	return Stubs{}.Request()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *RequestMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *RequestMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyRequest", structName)
 	stub = strings.ReplaceAll(stub, "DummyField", "Name string `form:\"name\" json:\"name\"`")
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)

--- a/mail/console/mail_make_command.go
+++ b/mail/console/mail_make_command.go
@@ -18,17 +18,17 @@ func NewMailMakeCommand() *MailMakeCommand {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *MailMakeCommand) Signature() string {
+func (r *MailMakeCommand) Signature() string {
 	return "make:mail"
 }
 
 // Description The console command description.
-func (receiver *MailMakeCommand) Description() string {
+func (r *MailMakeCommand) Description() string {
 	return "Create a new mail class"
 }
 
 // Extend The console command extend.
-func (receiver *MailMakeCommand) Extend() command.Extend {
+func (r *MailMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -42,14 +42,14 @@ func (receiver *MailMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *MailMakeCommand) Handle(ctx console.Context) error {
+func (r *MailMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "mail", ctx.Argument(0), filepath.Join("app", "mails"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
@@ -59,12 +59,12 @@ func (receiver *MailMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *MailMakeCommand) getStub() string {
+func (r *MailMakeCommand) getStub() string {
 	return Stubs{}.Mail()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *MailMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *MailMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyMail", structName)
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
 

--- a/queue/console/job_make_command.go
+++ b/queue/console/job_make_command.go
@@ -15,17 +15,17 @@ type JobMakeCommand struct {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *JobMakeCommand) Signature() string {
+func (r *JobMakeCommand) Signature() string {
 	return "make:job"
 }
 
 // Description The console command description.
-func (receiver *JobMakeCommand) Description() string {
+func (r *JobMakeCommand) Description() string {
 	return "Create a new job class"
 }
 
 // Extend The console command extend.
-func (receiver *JobMakeCommand) Extend() command.Extend {
+func (r *JobMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -39,14 +39,14 @@ func (receiver *JobMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *JobMakeCommand) Handle(ctx console.Context) error {
+func (r *JobMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "job", ctx.Argument(0), filepath.Join("app", "jobs"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
@@ -56,12 +56,12 @@ func (receiver *JobMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *JobMakeCommand) getStub() string {
+func (r *JobMakeCommand) getStub() string {
 	return JobStubs{}.Job()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *JobMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *JobMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyJob", structName)
 	stub = strings.ReplaceAll(stub, "DummyName", str.Of(structName).Snake().String())
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)

--- a/validation/console/filter_make_command.go
+++ b/validation/console/filter_make_command.go
@@ -15,17 +15,17 @@ type FilterMakeCommand struct {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *FilterMakeCommand) Signature() string {
+func (r *FilterMakeCommand) Signature() string {
 	return "make:filter"
 }
 
 // Description The console command description.
-func (receiver *FilterMakeCommand) Description() string {
+func (r *FilterMakeCommand) Description() string {
 	return "Create a new filter class"
 }
 
 // Extend The console command extend.
-func (receiver *FilterMakeCommand) Extend() command.Extend {
+func (r *FilterMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -39,14 +39,14 @@ func (receiver *FilterMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *FilterMakeCommand) Handle(ctx console.Context) error {
+func (r *FilterMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "filter", ctx.Argument(0), filepath.Join("app", "filters"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
@@ -56,12 +56,12 @@ func (receiver *FilterMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *FilterMakeCommand) getStub() string {
+func (r *FilterMakeCommand) getStub() string {
 	return Stubs{}.Filter()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *FilterMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *FilterMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyFilter", structName)
 	stub = strings.ReplaceAll(stub, "DummyName", str.Of(structName).Snake().String())
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)

--- a/validation/console/rule_make_command.go
+++ b/validation/console/rule_make_command.go
@@ -15,17 +15,17 @@ type RuleMakeCommand struct {
 }
 
 // Signature The name and signature of the console command.
-func (receiver *RuleMakeCommand) Signature() string {
+func (r *RuleMakeCommand) Signature() string {
 	return "make:rule"
 }
 
 // Description The console command description.
-func (receiver *RuleMakeCommand) Description() string {
+func (r *RuleMakeCommand) Description() string {
 	return "Create a new rule class"
 }
 
 // Extend The console command extend.
-func (receiver *RuleMakeCommand) Extend() command.Extend {
+func (r *RuleMakeCommand) Extend() command.Extend {
 	return command.Extend{
 		Category: "make",
 		Flags: []command.Flag{
@@ -39,14 +39,14 @@ func (receiver *RuleMakeCommand) Extend() command.Extend {
 }
 
 // Handle Execute the console command.
-func (receiver *RuleMakeCommand) Handle(ctx console.Context) error {
+func (r *RuleMakeCommand) Handle(ctx console.Context) error {
 	m, err := supportconsole.NewMake(ctx, "rule", ctx.Argument(0), filepath.Join("app", "rules"))
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := file.Create(m.GetFilePath(), receiver.populateStub(receiver.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
+	if err := file.Create(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}
@@ -56,12 +56,12 @@ func (receiver *RuleMakeCommand) Handle(ctx console.Context) error {
 	return nil
 }
 
-func (receiver *RuleMakeCommand) getStub() string {
+func (r *RuleMakeCommand) getStub() string {
 	return Stubs{}.Rule()
 }
 
 // populateStub Populate the place-holders in the command stub.
-func (receiver *RuleMakeCommand) populateStub(stub string, packageName, structName string) string {
+func (r *RuleMakeCommand) populateStub(stub string, packageName, structName string) string {
 	stub = strings.ReplaceAll(stub, "DummyRule", structName)
 	stub = strings.ReplaceAll(stub, "DummyName", str.Of(structName).Snake().String())
 	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)


### PR DESCRIPTION
## 📑 Description

1. Automatic Generation of the Signature Property
Enhance the make:command functionality to automatically generate the Signature property based on the command’s name.
For example:
```shell
artisan make:command SendEmails
```

Automatically generates:

```go
func (r *SendEmails) Signature() string {
	return "app:send-emails"
}
```

2. Simplified Receiver Names in Command Struct Methods
Update the receiver names in all command struct methods for consistency and simplicity.
For example:

```go
func (receiver *MakeCommand) Description() string {
    return "Create a new Artisan command"
}
```

To:

```go
func (r *MakeCommand) Description() string {
    return "Create a new Artisan command"
}
```

These changes aim to streamline the developer experience, reduce manual effort, and improve code readability.

Closes https://github.com/goravel/goravel/issues/?

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
    - Updated method receiver variable names from `receiver` to `r` across multiple command structs in various packages.
    - Consistent naming convention applied to improve code readability.
    - No functional changes to the existing code logic or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
