### PR TITLE
chore: add GetContent and PutContent methods to support/file

### DIFF
--- a/support/file/file.go
+++ b/support/file/file.go
@@ -11,28 +11,6 @@ import (
 	"github.com/goravel/framework/errors"
 )
 
-// Option represents an option for FilePutContents
-type Option func(*fileOptions)
-
-type fileOptions struct {
-	mode   os.FileMode
-	append bool
-}
-
-// WithMode sets the file mode for FilePutContents
-func WithMode(mode os.FileMode) Option {
-	return func(opts *fileOptions) {
-		opts.mode = mode
-	}
-}
-
-// WithAppend sets the append mode for FilePutContents
-func WithAppend(append bool) Option {
-	return func(opts *fileOptions) {
-		opts.append = append
-	}
-}
-
 func ClientOriginalExtension(file string) string {
 	return strings.ReplaceAll(filepath.Ext(file), ".", "")
 }
@@ -95,6 +73,16 @@ func Extension(file string, originalWhenUnknown ...bool) (string, error) {
 	return strings.TrimPrefix(mtype.Extension(), "."), nil
 }
 
+func GetContent(file string) (string, error) {
+	// Read the entire file
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
 func LastModified(file, timezone string) (time.Time, error) {
 	fileInfo, err := os.Stat(file)
 	if err != nil {
@@ -118,47 +106,9 @@ func MimeType(file string) (string, error) {
 	return mtype.String(), nil
 }
 
-func Remove(file string) error {
-	_, err := os.Stat(file)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-
-		return err
-	}
-
-	return os.RemoveAll(file)
-}
-
-func Size(file string) (int64, error) {
-	fileInfo, err := os.Open(file)
-	if err != nil {
-		return 0, err
-	}
-	defer fileInfo.Close()
-
-	fi, err := fileInfo.Stat()
-	if err != nil {
-		return 0, err
-	}
-
-	return fi.Size(), nil
-}
-
-func GetContent(file string) (string, error) {
-	// Read the entire file
-	data, err := os.ReadFile(file)
-	if err != nil {
-		return "", err
-	}
-
-	return string(data), nil
-}
-
 func PutContent(file string, content string, options ...Option) error {
 	// Default options
-	opts := &fileOptions{
+	opts := &option{
 		mode:   os.ModePerm,
 		append: false,
 	}
@@ -194,4 +144,32 @@ func PutContent(file string, content string, options ...Option) error {
 	}
 
 	return nil
+}
+
+func Remove(file string) error {
+	_, err := os.Stat(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	return os.RemoveAll(file)
+}
+
+func Size(file string) (int64, error) {
+	fileInfo, err := os.Open(file)
+	if err != nil {
+		return 0, err
+	}
+	defer fileInfo.Close()
+
+	fi, err := fileInfo.Stat()
+	if err != nil {
+		return 0, err
+	}
+
+	return fi.Size(), nil
 }

--- a/support/file/file.go
+++ b/support/file/file.go
@@ -11,23 +11,47 @@ import (
 	"github.com/goravel/framework/errors"
 )
 
+// Option represents an option for FilePutContents
+type Option func(*fileOptions)
+
+type fileOptions struct {
+	mode   os.FileMode
+	append bool
+}
+
+// WithMode sets the file mode for FilePutContents
+func WithMode(mode os.FileMode) Option {
+	return func(opts *fileOptions) {
+		opts.mode = mode
+	}
+}
+
+// WithAppend sets the append mode for FilePutContents
+func WithAppend(append bool) Option {
+	return func(opts *fileOptions) {
+		opts.append = append
+	}
+}
+
 func ClientOriginalExtension(file string) string {
 	return strings.ReplaceAll(filepath.Ext(file), ".", "")
 }
 
 func Contain(file string, search string) bool {
 	if Exists(file) {
-		data, err := os.ReadFile(file)
+		data, err := GetContent(file)
 		if err != nil {
 			return false
 		}
 
-		return strings.Contains(string(data), search)
+		return strings.Contains(data, search)
 	}
 
 	return false
 }
 
+// Create a file with the given content
+// Deprecated: Use PutContent instead
 func Create(file string, content string) error {
 	if err := os.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
 		return err
@@ -120,4 +144,54 @@ func Size(file string) (int64, error) {
 	}
 
 	return fi.Size(), nil
+}
+
+func GetContent(file string) (string, error) {
+	// Read the entire file
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func PutContent(file string, content string, options ...Option) error {
+	// Default options
+	opts := &fileOptions{
+		mode:   os.ModePerm,
+		append: false,
+	}
+
+	// Apply options
+	for _, option := range options {
+		option(opts)
+	}
+
+	// Create the directory if it doesn't exist
+	if err := os.MkdirAll(filepath.Dir(file), opts.mode); err != nil {
+		return err
+	}
+
+	// Open file with appropriate flags
+	flag := os.O_CREATE | os.O_WRONLY
+	if opts.append {
+		flag |= os.O_APPEND
+	} else {
+		flag |= os.O_TRUNC
+	}
+
+	// Open the file
+	f, err := os.OpenFile(file, flag, opts.mode)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Write the content
+	if _, err = f.WriteString(content); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/support/file/file_test.go
+++ b/support/file/file_test.go
@@ -75,16 +75,22 @@ func TestGetContent(t *testing.T) {
 }
 
 func TestPutContent(t *testing.T) {
+	// directory creation failure
+	assert.Error(t, PutContent("/proc/invalid/file.txt", "content"))
+	// write failure (create read-only dir)
+	readOnlyDir := path.Join(t.TempDir(), "readonly")
+	assert.NoError(t, os.Mkdir(readOnlyDir, 0444))
+	assert.Error(t, PutContent(path.Join(readOnlyDir, "file.txt"), "content"))
+	// create a file and put content
 	filePath := path.Join(t.TempDir(), "goravel.txt")
-	// Create a file and put content
 	assert.NoError(t, PutContent(filePath, "goravel"))
 	assert.True(t, Contain(filePath, "goravel"))
 	assert.Equal(t, 1, file.GetLineNum(filePath))
-	// Append content
+	// append content
 	assert.NoError(t, PutContent(filePath, "\nframework", WithAppend(true)))
 	assert.True(t, Contain(filePath, "goravel\nframework"))
 	assert.Equal(t, 2, file.GetLineNum(filePath))
-	// Overwrite content
+	// overwrite content
 	assert.NoError(t, PutContent(filePath, "welcome", WithMode(0644)))
 	assert.False(t, Contain(filePath, "goravel\nframework"))
 	assert.True(t, Contain(filePath, "welcome"))

--- a/support/file/file_test.go
+++ b/support/file/file_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/goravel/framework/support/env"
 	"github.com/goravel/framework/testing/file"
 )
 
@@ -75,12 +76,14 @@ func TestGetContent(t *testing.T) {
 }
 
 func TestPutContent(t *testing.T) {
-	// directory creation failure
-	assert.Error(t, PutContent("/proc/invalid/file.txt", "content"))
-	// write failure (create read-only dir)
-	readOnlyDir := path.Join(t.TempDir(), "readonly")
-	assert.NoError(t, os.Mkdir(readOnlyDir, 0444))
-	assert.Error(t, PutContent(path.Join(readOnlyDir, "file.txt"), "content"))
+	if !env.IsWindows() {
+		// directory creation failure
+		assert.Error(t, PutContent("/proc/invalid/file.txt", "content"))
+		// write failure (create read-only dir)
+		readOnlyDir := path.Join(t.TempDir(), "readonly")
+		assert.NoError(t, os.Mkdir(readOnlyDir, 0444))
+		assert.Error(t, PutContent(path.Join(readOnlyDir, "file.txt"), "content"))
+	}
 	// create a file and put content
 	filePath := path.Join(t.TempDir(), "goravel.txt")
 	assert.NoError(t, PutContent(filePath, "goravel"))

--- a/support/file/file_test.go
+++ b/support/file/file_test.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,13 +19,10 @@ func TestContain(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	pwd, _ := os.Getwd()
-	path := pwd + "/goravel/goravel.txt"
-	assert.Nil(t, Create(path, `goravel`))
-	assert.Equal(t, 1, file.GetLineNum(path))
-	assert.True(t, Exists(path))
-	assert.Nil(t, Remove(path))
-	assert.Nil(t, Remove(pwd+"/goravel"))
+	filePath := path.Join(t.TempDir(), "goravel.txt")
+	assert.Nil(t, Create(filePath, `goravel`))
+	assert.Equal(t, 1, file.GetLineNum(filePath))
+	assert.True(t, Exists(filePath))
 }
 
 func TestExists(t *testing.T) {
@@ -51,15 +49,44 @@ func TestMimeType(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	pwd, _ := os.Getwd()
-	path := pwd + "/goravel/goravel.txt"
-	assert.Nil(t, Create(path, `goravel`))
+	filePath := path.Join(pwd, "goravel/goravel.txt")
+	assert.Nil(t, Create(filePath, `goravel`))
 
-	assert.Nil(t, Remove(path))
-	assert.Nil(t, Remove(pwd+"/goravel"))
+	assert.Nil(t, Remove(filePath))
+	assert.Nil(t, Remove(path.Join(pwd, "goravel")))
 }
 
 func TestSize(t *testing.T) {
 	size, err := Size("../../logo.png")
 	assert.Nil(t, err)
 	assert.Equal(t, int64(10853), size)
+}
+
+func TestGetContent(t *testing.T) {
+	// file not exists
+	content, err := GetContent("files.go")
+	assert.NotNil(t, err)
+	assert.Empty(t, content)
+	// get content successfully
+	content, err = GetContent("../constant.go")
+	assert.Nil(t, err)
+	assert.NotNil(t, content)
+	assert.Contains(t, content, "const Version")
+}
+
+func TestPutContent(t *testing.T) {
+	filePath := path.Join(t.TempDir(), "goravel.txt")
+	// Create a file and put content
+	assert.NoError(t, PutContent(filePath, "goravel"))
+	assert.True(t, Contain(filePath, "goravel"))
+	assert.Equal(t, 1, file.GetLineNum(filePath))
+	// Append content
+	assert.NoError(t, PutContent(filePath, "\nframework", WithAppend(true)))
+	assert.True(t, Contain(filePath, "goravel\nframework"))
+	assert.Equal(t, 2, file.GetLineNum(filePath))
+	// Overwrite content
+	assert.NoError(t, PutContent(filePath, "welcome", WithMode(0644)))
+	assert.False(t, Contain(filePath, "goravel\nframework"))
+	assert.True(t, Contain(filePath, "welcome"))
+	assert.Equal(t, 1, file.GetLineNum(filePath))
 }

--- a/support/file/options.go
+++ b/support/file/options.go
@@ -1,0 +1,25 @@
+package file
+
+import "os"
+
+// Option represents an option for FilePutContents
+type Option func(*option)
+
+type option struct {
+	mode   os.FileMode
+	append bool
+}
+
+// WithAppend sets the append mode for FilePutContents
+func WithAppend(append bool) Option {
+	return func(opts *option) {
+		opts.append = append
+	}
+}
+
+// WithMode sets the file mode for FilePutContents
+func WithMode(mode os.FileMode) Option {
+	return func(opts *option) {
+		opts.mode = mode
+	}
+}


### PR DESCRIPTION
## 📑 Description

This PR introduces two new methods, `GetContent` and `PutContent`, to the support/file package in Goravel.

- GetContent: Retrieves the contents of a file as a string.

- PutContent: Writes a string to a file, creating or replacing it as needed.

Closes https://github.com/goravel/goravel/issues/?

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced file handling capabilities with more flexible content writing.
  - Added ability to configure file writing options (mode and append).
  - Introduced new methods for reading (`GetContent`) and writing (`PutContent`) file content.

- **Improvements**
  - Improved file operation functions with more robust error handling.
  - Tests have been updated for better isolation and reliability, including new test cases for `GetContent` and `PutContent`.

- **Deprecation**
  - Marked existing `Create` function as deprecated.

These updates provide developers with more granular control over file operations, making file management more intuitive and flexible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
