### PR TITLE
feat: [#540] Remove database.connections.*

### DIFF
--- a/config/application_test.go
+++ b/config/application_test.go
@@ -107,26 +107,22 @@ func (s *ApplicationTestSuite) TestGet() {
 func (s *ApplicationTestSuite) TestGetString() {
 	s.config.Add("database", map[string]any{
 		"default": s.config.Env("DB_CONNECTION", "mysql"),
-		"connections": map[string]any{
-			"mysql": map[string]any{
-				"host": s.config.Env("DB_HOST", "127.0.0.1"),
-			},
+		"migrations": map[string]any{
+			"table": "migrations",
 		},
 	})
 	s.customConfig.Add("database", map[string]any{
 		"default": s.customConfig.Env("DB_CONNECTION", "mysql"),
-		"connections": map[string]any{
-			"mysql": map[string]any{
-				"host": s.customConfig.Env("DB_HOST", "127.0.0.1"),
-			},
+		"migrations": map[string]any{
+			"table": "migrations",
 		},
 	})
 
 	s.Equal("goravel", s.config.GetString("APP_NAME", "goravel"))
-	s.Equal("127.0.0.1", s.config.GetString("database.connections.mysql.host"))
+	s.Equal("migrations", s.config.GetString("database.migrations.table"))
 	s.Equal("mysql", s.config.GetString("database.default"))
 	s.Equal("goravel", s.customConfig.GetString("APP_NAME", "goravel"))
-	s.Equal("127.0.0.1", s.customConfig.GetString("database.connections.mysql.host"))
+	s.Equal("migrations", s.customConfig.GetString("database.migrations.table"))
 	s.Equal("mysql", s.customConfig.GetString("database.default"))
 }
 

--- a/testing/docker/database.go
+++ b/testing/docker/database.go
@@ -68,8 +68,6 @@ func (r *Database) Ready() error {
 		return err
 	}
 
-	r.config.Add(fmt.Sprintf("database.connections.%s.port", r.connection), r.DatabaseDriver.Config().Port)
-
 	r.orm.Refresh()
 
 	return nil

--- a/testing/docker/database_test.go
+++ b/testing/docker/database_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	contractsdriver "github.com/goravel/framework/contracts/database/driver"
-	contractstesting "github.com/goravel/framework/contracts/testing"
 	"github.com/goravel/framework/errors"
 	mocksconfig "github.com/goravel/framework/mocks/config"
 	mocksconsole "github.com/goravel/framework/mocks/console"
@@ -171,10 +170,6 @@ func (s *DatabaseTestSuite) SetupTest() {
 }
 
 func (s *DatabaseTestSuite) TestReady() {
-	s.mockDatabaseDriver.EXPECT().Config().Return(contractstesting.DatabaseConfig{
-		Port: 1234,
-	}).Once()
-	s.mockConfig.EXPECT().Add("database.connections.postgres.port", 1234).Once()
 	s.mockOrm.EXPECT().Refresh().Once()
 	s.mockDatabaseDriver.EXPECT().Ready().Return(nil).Once()
 


### PR DESCRIPTION
## 📑 Description

Framework should not know `database.connections.*`, it is decided by the sub-DB packages.

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Testing**
	- Updated test configurations for database and migration settings
	- Simplified database connection configuration tests
	- Removed specific port configuration checks in test suite

- **Refactor**
	- Modified configuration structure for database migrations
	- Removed unnecessary configuration port settings

Note: These changes appear to be internal testing and configuration adjustments with minimal end-user impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
