### PR TITLE
feat: [#579] Go Migrator Support Custom Column Types

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -276,11 +276,12 @@ func (s *AuthTestSuite) TestParse_Success() {
 	s.mockCache.EXPECT().GetBool("jwt:disabled:"+token, false).Return(false).Once()
 
 	payload, err := s.auth.Parse(token)
+	now := carbon.Now()
 	s.Equal(&contractsauth.Payload{
 		Guard:    testUserGuard,
 		Key:      "1",
-		ExpireAt: jwt.NewNumericDate(carbon.Now().AddMinutes(2).StdTime()).Local(),
-		IssuedAt: jwt.NewNumericDate(carbon.Now().StdTime()).Local(),
+		ExpireAt: jwt.NewNumericDate(now.AddMinutes(2).StdTime()).Local(),
+		IssuedAt: jwt.NewNumericDate(now.StdTime()).Local(),
 	}, payload)
 	s.Nil(err)
 }
@@ -296,11 +297,12 @@ func (s *AuthTestSuite) TestParse_SuccessWithPrefix() {
 	s.mockCache.EXPECT().GetBool("jwt:disabled:"+token, false).Return(false).Once()
 
 	payload, err := s.auth.Parse("Bearer " + token)
+	now := carbon.Now()
 	s.Equal(&contractsauth.Payload{
 		Guard:    testUserGuard,
 		Key:      "1",
-		ExpireAt: jwt.NewNumericDate(carbon.Now().AddMinutes(2).StdTime()).Local(),
-		IssuedAt: jwt.NewNumericDate(carbon.Now().StdTime()).Local(),
+		ExpireAt: jwt.NewNumericDate(now.AddMinutes(2).StdTime()).Local(),
+		IssuedAt: jwt.NewNumericDate(now.StdTime()).Local(),
 	}, payload)
 	s.Nil(err)
 

--- a/contracts/database/schema/blueprint.go
+++ b/contracts/database/schema/blueprint.go
@@ -15,6 +15,8 @@ type Blueprint interface {
 	Build(query orm.Query, grammar Grammar) error
 	// Char Create a new char column on the table.
 	Char(column string, length ...int) ColumnDefinition
+	// Column Create a new custom type column on the table.
+	Column(column string, ttype string) ColumnDefinition
 	// Create Indicate that the table needs to be created.
 	Create()
 	// Date Create a new date column on the table.

--- a/database/schema/blueprint.go
+++ b/database/schema/blueprint.go
@@ -60,6 +60,10 @@ func (r *Blueprint) Char(column string, length ...int) schema.ColumnDefinition {
 	return columnImpl
 }
 
+func (r *Blueprint) Column(column, ttype string) schema.ColumnDefinition {
+	return r.createAndAddColumn(ttype, column)
+}
+
 func (r *Blueprint) Create() {
 	r.addCommand(&schema.Command{
 		Name: constants.CommandCreate,

--- a/database/schema/grammars/utils.go
+++ b/database/schema/grammars/utils.go
@@ -59,5 +59,5 @@ func getType(grammar schema.Grammar, column schema.ColumnDefinition) string {
 		return callResult[0].String()
 	}
 
-	return ""
+	return column.GetType()
 }

--- a/database/schema/grammars/utils_test.go
+++ b/database/schema/grammars/utils_test.go
@@ -55,9 +55,9 @@ func TestGetType(t *testing.T) {
 
 	// invalid type
 	mockColumn1 := mocksschema.NewColumnDefinition(t)
-	mockColumn1.EXPECT().GetType().Return("invalid").Once()
+	mockColumn1.EXPECT().GetType().Return("invalid").Twice()
 
 	mockGrammar1 := mocksschema.NewGrammar(t)
 
-	assert.Empty(t, getType(mockGrammar1, mockColumn1))
+	assert.Equal(t, "invalid", getType(mockGrammar1, mockColumn1))
 }

--- a/database/schema/schema_test.go
+++ b/database/schema/schema_test.go
@@ -219,6 +219,14 @@ func (s *SchemaSuite) TestColumnTypes_Postgres() {
 			s.Equal("timestamp(2) without time zone", column.Type)
 			s.Equal("timestamp", column.TypeName)
 		}
+		if column.Name == "custom_type" {
+			s.False(column.Autoincrement)
+			s.Equal("This is a custom type column", column.Comment)
+			s.Empty(column.Default)
+			s.False(column.Nullable)
+			s.Equal("macaddr", column.Type)
+			s.Equal("macaddr", column.TypeName)
+		}
 		if column.Name == "date" {
 			s.False(column.Autoincrement)
 			s.Empty(column.Collation)
@@ -547,6 +555,14 @@ func (s *SchemaSuite) TestColumnTypes_Sqlite() {
 			s.Equal("datetime", column.Type)
 			s.Equal("datetime", column.TypeName)
 		}
+		if column.Name == "custom_type" {
+			s.False(column.Autoincrement)
+			s.Empty(column.Comment)
+			s.Empty(column.Default)
+			s.False(column.Nullable)
+			s.Equal("geometry", column.Type)
+			s.Equal("geometry", column.TypeName)
+		}
 		if column.Name == "date" {
 			s.False(column.Autoincrement)
 			s.Empty(column.Comment)
@@ -840,6 +856,14 @@ func (s *SchemaSuite) TestColumnTypes_Mysql() {
 			s.True(column.Nullable)
 			s.Equal("timestamp(2)", column.Type)
 			s.Equal("timestamp", column.TypeName)
+		}
+		if column.Name == "custom_type" {
+			s.False(column.Autoincrement)
+			s.Equal("This is a custom type column", column.Comment)
+			s.Empty(column.Default)
+			s.False(column.Nullable)
+			s.Equal("geometry", column.Type)
+			s.Equal("geometry", column.TypeName)
 		}
 		if column.Name == "date" {
 			s.False(column.Autoincrement)
@@ -1163,6 +1187,14 @@ func (s *SchemaSuite) TestColumnTypes_Sqlserver() {
 			s.True(column.Nullable)
 			s.Equal("datetime2(22)", column.Type)
 			s.Equal("datetime2", column.TypeName)
+		}
+		if column.Name == "custom_type" {
+			s.False(column.Autoincrement)
+			s.Empty(column.Comment)
+			s.Empty(column.Default)
+			s.False(column.Nullable)
+			s.Equal("geometry", column.Type)
+			s.Equal("geometry", column.TypeName)
 		}
 		if column.Name == "date" {
 			s.False(column.Autoincrement)
@@ -2362,6 +2394,11 @@ func (s *SchemaSuite) createTableAndAssertColumnsForColumnMethods(schema contrac
 		table.BigInteger("big_integer").Comment("This is a big_integer column")
 		table.Boolean("boolean_default").Default(true).Comment("This is a boolean column with default value")
 		table.Char("char").Comment("This is a char column")
+		if schema.GetConnection() != database.DriverPostgres.String() {
+			table.Column("custom_type", "geometry").Comment("This is a custom type column")
+		} else {
+			table.Column("custom_type", "macaddr").Comment("This is a custom type column")
+		}
 		table.Date("date").Comment("This is a date column")
 		table.DateTime("date_time", 3).Comment("This is a date time column")
 		table.DateTimeTz("date_time_tz", 3).Comment("This is a date time with time zone column")
@@ -2401,11 +2438,13 @@ func (s *SchemaSuite) createTableAndAssertColumnsForColumnMethods(schema contrac
 
 	columnListing := schema.GetColumnListing(table)
 
-	s.Equal(34, len(columnListing))
+	s.Equal(35, len(columnListing))
 	s.Contains(columnListing, "another_deleted_at")
 	s.Contains(columnListing, "big_integer")
+	s.Contains(columnListing, "boolean_default")
 	s.Contains(columnListing, "char")
 	s.Contains(columnListing, "created_at")
+	s.Contains(columnListing, "custom_type")
 	s.Contains(columnListing, "date")
 	s.Contains(columnListing, "date_time")
 	s.Contains(columnListing, "date_time_tz")

--- a/mocks/database/schema/Blueprint.go
+++ b/mocks/database/schema/Blueprint.go
@@ -275,6 +275,55 @@ func (_c *Blueprint_Char_Call) RunAndReturn(run func(string, ...int) schema.Colu
 	return _c
 }
 
+// Column provides a mock function with given fields: column, ttype
+func (_m *Blueprint) Column(column string, ttype string) schema.ColumnDefinition {
+	ret := _m.Called(column, ttype)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Column")
+	}
+
+	var r0 schema.ColumnDefinition
+	if rf, ok := ret.Get(0).(func(string, string) schema.ColumnDefinition); ok {
+		r0 = rf(column, ttype)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(schema.ColumnDefinition)
+		}
+	}
+
+	return r0
+}
+
+// Blueprint_Column_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Column'
+type Blueprint_Column_Call struct {
+	*mock.Call
+}
+
+// Column is a helper method to define mock.On call
+//   - column string
+//   - ttype string
+func (_e *Blueprint_Expecter) Column(column interface{}, ttype interface{}) *Blueprint_Column_Call {
+	return &Blueprint_Column_Call{Call: _e.mock.On("Column", column, ttype)}
+}
+
+func (_c *Blueprint_Column_Call) Run(run func(column string, ttype string)) *Blueprint_Column_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *Blueprint_Column_Call) Return(_a0 schema.ColumnDefinition) *Blueprint_Column_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Blueprint_Column_Call) RunAndReturn(run func(string, string) schema.ColumnDefinition) *Blueprint_Column_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Create provides a mock function with no fields
 func (_m *Blueprint) Create() {
 	_m.Called()


### PR DESCRIPTION
## 📑 Description

Go Migrator Support for Custom Column Types,like 

```go
table.Column("geometry", "geometry").Comment("This is a geometry column")
```

Closes https://github.com/goravel/goravel/issues/579

Resolve https://github.com/goravel/goravel/issues/568

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
