### PR TITLE
feat: [#572] migrator support to rename column

### DIFF
--- a/contracts/database/schema/blueprint.go
+++ b/contracts/database/schema/blueprint.go
@@ -103,6 +103,8 @@ type Blueprint interface {
 	Primary(column ...string)
 	// Rename the table to a given name.
 	Rename(to string)
+	// RenameColumn Indicate that the given columns should be renamed.
+	RenameColumn(from, to string)
 	// RenameIndex Indicate that the given indexes should be renamed.
 	RenameIndex(from, to string)
 	// SetTable Set the table that the blueprint operates on.
@@ -138,7 +140,7 @@ type Blueprint interface {
 	// TinyText Create a new tiny text column on the table.
 	TinyText(column string) ColumnDefinition
 	// ToSql Get the raw SQL statements for the blueprint.
-	ToSql(grammar Grammar) []string
+	ToSql(grammar Grammar) ([]string, error)
 	// Unique Specify a unique index for the table.
 	Unique(column ...string) IndexDefinition
 	// UnsignedBigInteger Create a new unsigned big integer (8-byte) column on the table.

--- a/contracts/database/schema/column.go
+++ b/contracts/database/schema/column.go
@@ -64,6 +64,7 @@ type Column struct {
 	Collation     string
 	Comment       string
 	Default       string
+	Extra         string
 	Name          string
 	Nullable      bool
 	Type          string

--- a/contracts/database/schema/grammar.go
+++ b/contracts/database/schema/grammar.go
@@ -49,6 +49,8 @@ type Grammar interface {
 	CompilePrimary(blueprint Blueprint, command *Command) string
 	// CompileRename Compile a rename table command.
 	CompileRename(blueprint Blueprint, command *Command) string
+	// CompileRenameColumn Compile a rename column command.
+	CompileRenameColumn(schema Schema, blueprint Blueprint, command *Command) (string, error)
 	// CompileRenameIndex Compile a rename index command.
 	CompileRenameIndex(schema Schema, blueprint Blueprint, command *Command) []string
 	// CompileTables Compile the query to determine the tables.

--- a/database/schema/blueprint.go
+++ b/database/schema/blueprint.go
@@ -27,6 +27,7 @@ const (
 	CommandIndex        = "index"
 	CommandPrimary      = "primary"
 	CommandRename       = "rename"
+	CommandRenameColumn = "renameColumn"
 	CommandRenameIndex  = "renameIndex"
 	CommandUnique       = "unique"
 	DefaultStringLength = 255
@@ -61,8 +62,13 @@ func (r *Blueprint) Boolean(column string) schema.ColumnDefinition {
 }
 
 func (r *Blueprint) Build(query orm.Query, grammar schema.Grammar) error {
-	for _, sql := range r.ToSql(grammar) {
-		if _, err := query.Exec(sql); err != nil {
+	statements, err := r.ToSql(grammar)
+	if err != nil {
+		return err
+	}
+
+	for _, sql := range statements {
+		if _, err = query.Exec(sql); err != nil {
 			return err
 		}
 	}
@@ -335,6 +341,16 @@ func (r *Blueprint) Rename(to string) {
 	r.addCommand(command)
 }
 
+func (r *Blueprint) RenameColumn(from, to string) {
+	command := &schema.Command{
+		Name: CommandRenameColumn,
+		From: from,
+		To:   to,
+	}
+
+	r.addCommand(command)
+}
+
 func (r *Blueprint) RenameIndex(from, to string) {
 	command := &schema.Command{
 		Name: CommandRenameIndex,
@@ -449,7 +465,7 @@ func (r *Blueprint) TinyText(column string) schema.ColumnDefinition {
 	return r.createAndAddColumn("tinyText", column)
 }
 
-func (r *Blueprint) ToSql(grammar schema.Grammar) []string {
+func (r *Blueprint) ToSql(grammar schema.Grammar) ([]string, error) {
 	r.addImpliedCommands(grammar)
 
 	var statements []string
@@ -503,6 +519,12 @@ func (r *Blueprint) ToSql(grammar schema.Grammar) []string {
 			statements = append(statements, grammar.CompilePrimary(r, command))
 		case CommandRename:
 			statements = append(statements, grammar.CompileRename(r, command))
+		case CommandRenameColumn:
+			statement, err := grammar.CompileRenameColumn(r.schema, r, command)
+			if err != nil {
+				return statements, err
+			}
+			statements = append(statements, statement)
 		case CommandRenameIndex:
 			statements = append(statements, grammar.CompileRenameIndex(r.schema, r, command)...)
 		case CommandUnique:
@@ -510,7 +532,7 @@ func (r *Blueprint) ToSql(grammar schema.Grammar) []string {
 		}
 	}
 
-	return statements
+	return statements, nil
 }
 
 func (r *Blueprint) Unique(column ...string) schema.IndexDefinition {

--- a/database/schema/blueprint_test.go
+++ b/database/schema/blueprint_test.go
@@ -661,7 +661,8 @@ func (s *BlueprintTestSuite) TestToSql() {
 			test.setup()
 
 			// Execute ToSql
-			statements := s.blueprint.ToSql(mockGrammar)
+			statements, err := s.blueprint.ToSql(mockGrammar)
+			s.NoError(err)
 
 			// Verify results
 			s.Equal(test.expectedSQL, statements)

--- a/database/schema/column.go
+++ b/database/schema/column.go
@@ -24,6 +24,13 @@ type ColumnDefinition struct {
 	useCurrentOnUpdate *bool
 }
 
+func NewColumnDefinition(name string, ttype string) schema.ColumnDefinition {
+	return &ColumnDefinition{
+		name:  &name,
+		ttype: convert.Pointer(ttype),
+	}
+}
+
 func (r *ColumnDefinition) AutoIncrement() schema.ColumnDefinition {
 	r.autoIncrement = convert.Pointer(true)
 

--- a/mocks/database/schema/Blueprint.go
+++ b/mocks/database/schema/Blueprint.go
@@ -2306,6 +2306,40 @@ func (_c *Blueprint_Rename_Call) RunAndReturn(run func(string)) *Blueprint_Renam
 	return _c
 }
 
+// RenameColumn provides a mock function with given fields: from, to
+func (_m *Blueprint) RenameColumn(from string, to string) {
+	_m.Called(from, to)
+}
+
+// Blueprint_RenameColumn_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RenameColumn'
+type Blueprint_RenameColumn_Call struct {
+	*mock.Call
+}
+
+// RenameColumn is a helper method to define mock.On call
+//   - from string
+//   - to string
+func (_e *Blueprint_Expecter) RenameColumn(from interface{}, to interface{}) *Blueprint_RenameColumn_Call {
+	return &Blueprint_RenameColumn_Call{Call: _e.mock.On("RenameColumn", from, to)}
+}
+
+func (_c *Blueprint_RenameColumn_Call) Run(run func(from string, to string)) *Blueprint_RenameColumn_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *Blueprint_RenameColumn_Call) Return() *Blueprint_RenameColumn_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *Blueprint_RenameColumn_Call) RunAndReturn(run func(string, string)) *Blueprint_RenameColumn_Call {
+	_c.Run(run)
+	return _c
+}
+
 // RenameIndex provides a mock function with given fields: from, to
 func (_m *Blueprint) RenameIndex(from string, to string) {
 	_m.Called(from, to)
@@ -3191,7 +3225,7 @@ func (_c *Blueprint_TinyText_Call) RunAndReturn(run func(string) schema.ColumnDe
 }
 
 // ToSql provides a mock function with given fields: grammar
-func (_m *Blueprint) ToSql(grammar schema.Grammar) []string {
+func (_m *Blueprint) ToSql(grammar schema.Grammar) ([]string, error) {
 	ret := _m.Called(grammar)
 
 	if len(ret) == 0 {
@@ -3199,6 +3233,10 @@ func (_m *Blueprint) ToSql(grammar schema.Grammar) []string {
 	}
 
 	var r0 []string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(schema.Grammar) ([]string, error)); ok {
+		return rf(grammar)
+	}
 	if rf, ok := ret.Get(0).(func(schema.Grammar) []string); ok {
 		r0 = rf(grammar)
 	} else {
@@ -3207,7 +3245,13 @@ func (_m *Blueprint) ToSql(grammar schema.Grammar) []string {
 		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(schema.Grammar) error); ok {
+		r1 = rf(grammar)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Blueprint_ToSql_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ToSql'
@@ -3228,12 +3272,12 @@ func (_c *Blueprint_ToSql_Call) Run(run func(grammar schema.Grammar)) *Blueprint
 	return _c
 }
 
-func (_c *Blueprint_ToSql_Call) Return(_a0 []string) *Blueprint_ToSql_Call {
-	_c.Call.Return(_a0)
+func (_c *Blueprint_ToSql_Call) Return(_a0 []string, _a1 error) *Blueprint_ToSql_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *Blueprint_ToSql_Call) RunAndReturn(run func(schema.Grammar) []string) *Blueprint_ToSql_Call {
+func (_c *Blueprint_ToSql_Call) RunAndReturn(run func(schema.Grammar) ([]string, error)) *Blueprint_ToSql_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/database/schema/Grammar.go
+++ b/mocks/database/schema/Grammar.go
@@ -1175,6 +1175,64 @@ func (_c *Grammar_CompileRename_Call) RunAndReturn(run func(schema.Blueprint, *s
 	return _c
 }
 
+// CompileRenameColumn provides a mock function with given fields: _a0, blueprint, command
+func (_m *Grammar) CompileRenameColumn(_a0 schema.Schema, blueprint schema.Blueprint, command *schema.Command) (string, error) {
+	ret := _m.Called(_a0, blueprint, command)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CompileRenameColumn")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(schema.Schema, schema.Blueprint, *schema.Command) (string, error)); ok {
+		return rf(_a0, blueprint, command)
+	}
+	if rf, ok := ret.Get(0).(func(schema.Schema, schema.Blueprint, *schema.Command) string); ok {
+		r0 = rf(_a0, blueprint, command)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(schema.Schema, schema.Blueprint, *schema.Command) error); ok {
+		r1 = rf(_a0, blueprint, command)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Grammar_CompileRenameColumn_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompileRenameColumn'
+type Grammar_CompileRenameColumn_Call struct {
+	*mock.Call
+}
+
+// CompileRenameColumn is a helper method to define mock.On call
+//   - _a0 schema.Schema
+//   - blueprint schema.Blueprint
+//   - command *schema.Command
+func (_e *Grammar_Expecter) CompileRenameColumn(_a0 interface{}, blueprint interface{}, command interface{}) *Grammar_CompileRenameColumn_Call {
+	return &Grammar_CompileRenameColumn_Call{Call: _e.mock.On("CompileRenameColumn", _a0, blueprint, command)}
+}
+
+func (_c *Grammar_CompileRenameColumn_Call) Run(run func(_a0 schema.Schema, blueprint schema.Blueprint, command *schema.Command)) *Grammar_CompileRenameColumn_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(schema.Schema), args[1].(schema.Blueprint), args[2].(*schema.Command))
+	})
+	return _c
+}
+
+func (_c *Grammar_CompileRenameColumn_Call) Return(_a0 string, _a1 error) *Grammar_CompileRenameColumn_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Grammar_CompileRenameColumn_Call) RunAndReturn(run func(schema.Schema, schema.Blueprint, *schema.Command) (string, error)) *Grammar_CompileRenameColumn_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CompileRenameIndex provides a mock function with given fields: _a0, blueprint, command
 func (_m *Grammar) CompileRenameIndex(_a0 schema.Schema, blueprint schema.Blueprint, command *schema.Command) []string {
 	ret := _m.Called(_a0, blueprint, command)

--- a/tests/query.go
+++ b/tests/query.go
@@ -51,7 +51,11 @@ func (r *TestQuery) CreateTable(testTables ...TestTable) {
 
 	for table, sql := range newTestTables(driverName, r.Driver().Grammar()).All() {
 		if (len(testTables) == 0 && table != TestTableSchema) || slices.Contains(testTables, table) {
-			if _, err := r.query.Exec(sql()); err != nil {
+			statements, err := sql()
+			if err == nil {
+				_, err = r.query.Exec(statements[0])
+			}
+			if err != nil {
 				panic(fmt.Sprintf("create table %v failed: %v", table, err))
 			}
 		}

--- a/tests/schema_test.go
+++ b/tests/schema_test.go
@@ -1851,6 +1851,26 @@ func (s *SchemaSuite) TestPrimary() {
 	}
 }
 
+func (s *SchemaSuite) TestRenameColumn() {
+	for driver, testQuery := range s.driverToTestQuery {
+		s.Run(driver, func() {
+			schema := newSchema(testQuery, s.driverToTestQuery)
+			table := "rename_column"
+
+			s.NoError(schema.Create(table, func(table contractsschema.Blueprint) {
+				table.String("before")
+			}))
+			s.True(schema.HasColumn(table, "before"))
+
+			s.NoError(schema.Table(table, func(table contractsschema.Blueprint) {
+				table.RenameColumn("before", "after")
+			}))
+			s.False(schema.HasColumn(table, "before"))
+			s.True(schema.HasColumn(table, "after"))
+		})
+	}
+}
+
 func (s *SchemaSuite) TestID_Postgres() {
 	if s.driverToTestQuery[postgres.Name] == nil {
 		s.T().Skip("Skip test")

--- a/tests/table.go
+++ b/tests/table.go
@@ -32,8 +32,8 @@ func newTestTables(driver string, grammar contractsschema.Grammar) *testTables {
 	return &testTables{driver: driver, grammar: grammar}
 }
 
-func (r *testTables) All() map[TestTable]func() string {
-	return map[TestTable]func() string{
+func (r *testTables) All() map[TestTable]func() ([]string, error) {
+	return map[TestTable]func() ([]string, error){
 		TestTableAddresses: r.addresses,
 		TestTableAuthors:   r.authors,
 		TestTableBooks:     r.books,
@@ -50,7 +50,7 @@ func (r *testTables) All() map[TestTable]func() string {
 	}
 }
 
-func (r *testTables) peoples() string {
+func (r *testTables) peoples() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "peoples")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -58,10 +58,10 @@ func (r *testTables) peoples() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) reviews() string {
+func (r *testTables) reviews() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "reviews")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -69,10 +69,10 @@ func (r *testTables) reviews() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) products() string {
+func (r *testTables) products() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "products")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -80,10 +80,10 @@ func (r *testTables) products() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) users() string {
+func (r *testTables) users() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "users")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -93,10 +93,10 @@ func (r *testTables) users() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) user() string {
+func (r *testTables) user() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "user")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -106,10 +106,10 @@ func (r *testTables) user() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) addresses() string {
+func (r *testTables) addresses() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "addresses")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -119,10 +119,10 @@ func (r *testTables) addresses() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) books() string {
+func (r *testTables) books() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "books")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -131,10 +131,10 @@ func (r *testTables) books() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) authors() string {
+func (r *testTables) authors() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "authors")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -143,10 +143,10 @@ func (r *testTables) authors() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) roles() string {
+func (r *testTables) roles() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "roles")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -155,10 +155,10 @@ func (r *testTables) roles() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) houses() string {
+func (r *testTables) houses() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "houses")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -168,10 +168,10 @@ func (r *testTables) houses() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) phones() string {
+func (r *testTables) phones() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "phones")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -181,10 +181,10 @@ func (r *testTables) phones() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) roleUser() string {
+func (r *testTables) roleUser() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "role_user")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
@@ -193,15 +193,15 @@ func (r *testTables) roleUser() string {
 	blueprint.Timestamps()
 	blueprint.SoftDeletes()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }
 
-func (r *testTables) schema() string {
+func (r *testTables) schema() ([]string, error) {
 	blueprint := schema.NewBlueprint(nil, "", "goravel.schemas")
 	blueprint.Create()
 	blueprint.BigIncrements("id")
 	blueprint.String("name")
 	blueprint.Timestamps()
 
-	return blueprint.ToSql(r.grammar)[0]
+	return blueprint.ToSql(r.grammar)
 }


### PR DESCRIPTION
## 📑 Description

Go migrator support to rename column

```go
func (r *M20250108083539UpdateTestTable) Up() error {
	return facades.Schema().Table("test", func(table schema.Blueprint) {
		table.RenameColumn("rename_column_before", "rename_column_after")
	})
}
```

Closes https://github.com/goravel/goravel/issues/572

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to rename database columns, enhancing flexibility during schema updates and migrations.
  - Added a new field to the Column structure to accommodate additional information.
  - Introduced a new constructor function for creating column definitions.

- **Bug Fixes**
  - Improved error handling in SQL statement generation and execution processes.

- **Tests**
  - Added comprehensive tests to ensure the column renaming functionality works correctly across various database systems.
  - Enhanced existing tests to include error handling for SQL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
