### PR TITLE
feat: Move bindings to config

### DIFF
--- a/auth/service_provider.go
+++ b/auth/service_provider.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/goravel/framework/auth/access"
 	"github.com/goravel/framework/auth/console"
-	frameworkconfig "github.com/goravel/framework/config"
+	frameworkcontracts "github.com/goravel/framework/contracts"
 	contractconsole "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/contracts/http"
@@ -15,8 +15,8 @@ import (
 type ServiceProvider struct {
 }
 
-func (database *ServiceProvider) Register(app foundation.Application) {
-	app.BindWith(frameworkconfig.BindingAuth, func(app foundation.Application, parameters map[string]any) (any, error) {
+func (auth *ServiceProvider) Register(app foundation.Application) {
+	app.BindWith(frameworkcontracts.BindingAuth, func(app foundation.Application, parameters map[string]any) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleAuth)
@@ -40,16 +40,16 @@ func (database *ServiceProvider) Register(app foundation.Application) {
 		return NewAuth(config.GetString("auth.defaults.guard"),
 			cacheFacade, config, ctx, ormFacade), nil
 	})
-	app.Singleton(frameworkconfig.BindingGate, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkcontracts.BindingGate, func(app foundation.Application) (any, error) {
 		return access.NewGate(context.Background()), nil
 	})
 }
 
-func (database *ServiceProvider) Boot(app foundation.Application) {
-	database.registerCommands(app)
+func (auth *ServiceProvider) Boot(app foundation.Application) {
+	auth.registerCommands(app)
 }
 
-func (database *ServiceProvider) registerCommands(app foundation.Application) {
+func (auth *ServiceProvider) registerCommands(app foundation.Application) {
 	app.Commands([]contractconsole.Command{
 		console.NewJwtSecretCommand(app.MakeConfig()),
 		console.NewPolicyMakeCommand(),

--- a/auth/service_provider.go
+++ b/auth/service_provider.go
@@ -5,22 +5,18 @@ import (
 
 	"github.com/goravel/framework/auth/access"
 	"github.com/goravel/framework/auth/console"
+	frameworkconfig "github.com/goravel/framework/config"
 	contractconsole "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/errors"
 )
 
-const (
-	BindingAuth = "goravel.auth"
-	BindingGate = "goravel.gate"
-)
-
 type ServiceProvider struct {
 }
 
 func (database *ServiceProvider) Register(app foundation.Application) {
-	app.BindWith(BindingAuth, func(app foundation.Application, parameters map[string]any) (any, error) {
+	app.BindWith(frameworkconfig.BindingAuth, func(app foundation.Application, parameters map[string]any) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleAuth)
@@ -44,7 +40,7 @@ func (database *ServiceProvider) Register(app foundation.Application) {
 		return NewAuth(config.GetString("auth.defaults.guard"),
 			cacheFacade, config, ctx, ormFacade), nil
 	})
-	app.Singleton(BindingGate, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingGate, func(app foundation.Application) (any, error) {
 		return access.NewGate(context.Background()), nil
 	})
 }

--- a/cache/service_provider.go
+++ b/cache/service_provider.go
@@ -2,7 +2,7 @@ package cache
 
 import (
 	"github.com/goravel/framework/cache/console"
-	frameworkconfig "github.com/goravel/framework/config"
+	frameworkcontracts "github.com/goravel/framework/contracts"
 	contractsconsole "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
@@ -11,8 +11,8 @@ import (
 type ServiceProvider struct {
 }
 
-func (database *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(frameworkconfig.BindingCache, func(app foundation.Application) (any, error) {
+func (cache *ServiceProvider) Register(app foundation.Application) {
+	app.Singleton(frameworkcontracts.BindingCache, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleCache)
@@ -29,11 +29,11 @@ func (database *ServiceProvider) Register(app foundation.Application) {
 	})
 }
 
-func (database *ServiceProvider) Boot(app foundation.Application) {
-	database.registerCommands(app)
+func (cache *ServiceProvider) Boot(app foundation.Application) {
+	cache.registerCommands(app)
 }
 
-func (database *ServiceProvider) registerCommands(app foundation.Application) {
+func (cache *ServiceProvider) registerCommands(app foundation.Application) {
 	app.Commands([]contractsconsole.Command{
 		console.NewClearCommand(app.MakeCache()),
 	})

--- a/cache/service_provider.go
+++ b/cache/service_provider.go
@@ -2,18 +2,17 @@ package cache
 
 import (
 	"github.com/goravel/framework/cache/console"
+	frameworkconfig "github.com/goravel/framework/config"
 	contractsconsole "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
 
-const Binding = "goravel.cache"
-
 type ServiceProvider struct {
 }
 
 func (database *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingCache, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleCache)

--- a/config/binding.go
+++ b/config/binding.go
@@ -1,0 +1,27 @@
+package config
+
+const (
+	BindingConsole     = "goravel.console"
+	BindingAuth        = "goravel.auth"
+	BindingGate        = "goravel.gate"
+	BindingCache       = "goravel.cache"
+	BindingCrypt       = "goravel.crypt"
+	BindingEvent       = "goravel.event"
+	BindingGrpc        = "goravel.grpc"
+	BindingHash        = "goravel.hash"
+	BindingTranslation = "goravel.translation"
+	BindingLog         = "goravel.log"
+	BindingMail        = "goravel.mail"
+	BindingOrm         = "goravel.orm"
+	BindingQueue       = "goravel.queue"
+	BindingRateLimiter = "goravel.rate_limiter"
+	BindingView        = "goravel.view"
+	BindingRoute       = "goravel.route"
+	BindingSchedule    = "goravel.schedule"
+	BindingSchema      = "goravel.schema"
+	BindingSession     = "goravel.session"
+	BindingFilesystem  = "goravel.filesystem"
+	BindingTesting     = "goravel.testing"
+	BindingValidation  = "goravel.validation"
+	BindingSeeder      = "goravel.seeder"
+)

--- a/config/service_provider.go
+++ b/config/service_provider.go
@@ -1,17 +1,16 @@
 package config
 
 import (
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/support"
 )
-
-const Binding = "goravel.config"
 
 type ServiceProvider struct {
 }
 
 func (config *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return NewApplication(support.EnvPath), nil
 	})
 }

--- a/console/service_provider.go
+++ b/console/service_provider.go
@@ -1,19 +1,18 @@
 package console
 
 import (
+	"github.com/goravel/framework/config"
 	"github.com/goravel/framework/console/console"
 	consolecontract "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/support/color"
 )
 
-const Binding = "goravel.console"
-
 type ServiceProvider struct {
 }
 
 func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(config.BindingConsole, func(app foundation.Application) (any, error) {
 		name := "artisan"
 		usage := "Goravel Framework"
 		usageText := "artisan [global options] command [options] [arguments...]"

--- a/console/service_provider.go
+++ b/console/service_provider.go
@@ -1,8 +1,7 @@
 package console
 
 import (
-	"github.com/goravel/framework/config"
-	"github.com/goravel/framework/console/console"
+	"github.com/goravel/framework/contracts"
 	consolecontract "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/support/color"
@@ -11,8 +10,8 @@ import (
 type ServiceProvider struct {
 }
 
-func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(config.BindingConsole, func(app foundation.Application) (any, error) {
+func (console *ServiceProvider) Register(app foundation.Application) {
+	app.Singleton(contracts.BindingConsole, func(app foundation.Application) (any, error) {
 		name := "artisan"
 		usage := "Goravel Framework"
 		usageText := "artisan [global options] command [options] [arguments...]"
@@ -20,11 +19,11 @@ func (receiver *ServiceProvider) Register(app foundation.Application) {
 	})
 }
 
-func (receiver *ServiceProvider) Boot(app foundation.Application) {
-	receiver.registerCommands(app)
+func (console *ServiceProvider) Boot(app foundation.Application) {
+	console.registerCommands(app)
 }
 
-func (receiver *ServiceProvider) registerCommands(app foundation.Application) {
+func (console *ServiceProvider) registerCommands(app foundation.Application) {
 	artisanFacade := app.MakeArtisan()
 	if artisanFacade == nil {
 		color.Warningln("Artisan Facade is not initialized. Skipping command registration.")

--- a/console/service_provider.go
+++ b/console/service_provider.go
@@ -11,7 +11,7 @@ import (
 type ServiceProvider struct {
 }
 
-func (r *ServiceProvider) Register(app foundation.Application) {
+func (receiver *ServiceProvider) Register(app foundation.Application) {
 	app.Singleton(contracts.BindingConsole, func(app foundation.Application) (any, error) {
 		name := "artisan"
 		usage := "Goravel Framework"
@@ -20,11 +20,11 @@ func (r *ServiceProvider) Register(app foundation.Application) {
 	})
 }
 
-func (r *ServiceProvider) Boot(app foundation.Application) {
-	r.registerCommands(app)
+func (receiver *ServiceProvider) Boot(app foundation.Application) {
+	receiver.registerCommands(app)
 }
 
-func (r *ServiceProvider) registerCommands(app foundation.Application) {
+func (receiver *ServiceProvider) registerCommands(app foundation.Application) {
 	artisanFacade := app.MakeArtisan()
 	if artisanFacade == nil {
 		color.Warningln("Artisan Facade is not initialized. Skipping command registration.")

--- a/console/service_provider.go
+++ b/console/service_provider.go
@@ -1,6 +1,7 @@
 package console
 
 import (
+	"github.com/goravel/framework/console/console"
 	"github.com/goravel/framework/contracts"
 	consolecontract "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
@@ -10,7 +11,7 @@ import (
 type ServiceProvider struct {
 }
 
-func (console *ServiceProvider) Register(app foundation.Application) {
+func (r *ServiceProvider) Register(app foundation.Application) {
 	app.Singleton(contracts.BindingConsole, func(app foundation.Application) (any, error) {
 		name := "artisan"
 		usage := "Goravel Framework"
@@ -19,11 +20,11 @@ func (console *ServiceProvider) Register(app foundation.Application) {
 	})
 }
 
-func (console *ServiceProvider) Boot(app foundation.Application) {
-	console.registerCommands(app)
+func (r *ServiceProvider) Boot(app foundation.Application) {
+	r.registerCommands(app)
 }
 
-func (console *ServiceProvider) registerCommands(app foundation.Application) {
+func (r *ServiceProvider) registerCommands(app foundation.Application) {
 	artisanFacade := app.MakeArtisan()
 	if artisanFacade == nil {
 		color.Warningln("Artisan Facade is not initialized. Skipping command registration.")

--- a/contracts/binding.go
+++ b/contracts/binding.go
@@ -1,4 +1,4 @@
-package config
+package contracts
 
 const (
 	BindingConsole     = "goravel.console"

--- a/contracts/binding.go
+++ b/contracts/binding.go
@@ -1,6 +1,7 @@
 package contracts
 
 const (
+	BindingConfig      = "goravel.config"
 	BindingConsole     = "goravel.console"
 	BindingAuth        = "goravel.auth"
 	BindingGate        = "goravel.gate"

--- a/crypt/service_provider.go
+++ b/crypt/service_provider.go
@@ -1,7 +1,7 @@
 package crypt
 
 import (
-	contracts "github.com/goravel/framework/contracts"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )

--- a/crypt/service_provider.go
+++ b/crypt/service_provider.go
@@ -1,17 +1,16 @@
 package crypt
 
 import (
+	frameworkconfig "github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
-
-const Binding = "goravel.crypt"
 
 type ServiceProvider struct {
 }
 
 func (crypt *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingCrypt, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleCrypt)

--- a/crypt/service_provider.go
+++ b/crypt/service_provider.go
@@ -1,7 +1,7 @@
 package crypt
 
 import (
-	frameworkconfig "github.com/goravel/framework/config"
+	contracts "github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
@@ -10,7 +10,7 @@ type ServiceProvider struct {
 }
 
 func (crypt *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(frameworkconfig.BindingCrypt, func(app foundation.Application) (any, error) {
+	app.Singleton(contracts.BindingCrypt, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleCrypt)

--- a/database/orm/orm.go
+++ b/database/orm/orm.go
@@ -6,14 +6,13 @@ import (
 	"fmt"
 	"sync"
 
+	frameworkconfig "github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/config"
 	contractsorm "github.com/goravel/framework/contracts/database/orm"
 	"github.com/goravel/framework/contracts/log"
 	"github.com/goravel/framework/database/factory"
 	"github.com/goravel/framework/database/gorm"
 )
-
-const BindingOrm = "goravel.orm"
 
 type Orm struct {
 	ctx             context.Context
@@ -127,7 +126,7 @@ func (r *Orm) SetQuery(query contractsorm.Query) {
 }
 
 func (r *Orm) Refresh() {
-	r.refresh(BindingOrm)
+	r.refresh(frameworkconfig.BindingOrm)
 }
 
 func (r *Orm) Transaction(txFunc func(tx contractsorm.Query) error) error {

--- a/database/orm/orm.go
+++ b/database/orm/orm.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"sync"
 
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/config"
 	contractsorm "github.com/goravel/framework/contracts/database/orm"
 	contractshttp "github.com/goravel/framework/contracts/http"
@@ -127,7 +127,7 @@ func (r *Orm) SetQuery(query contractsorm.Query) {
 }
 
 func (r *Orm) Refresh() {
-	r.refresh(frameworkconfig.BindingOrm)
+	r.refresh(contracts.BindingOrm)
 }
 
 func (r *Orm) Transaction(txFunc func(tx contractsorm.Query) error) error {

--- a/database/schema/schema.go
+++ b/database/schema/schema.go
@@ -15,8 +15,6 @@ import (
 	"github.com/goravel/framework/errors"
 )
 
-const BindingSchema = "goravel.schema"
-
 var _ contractsschema.Schema = (*Schema)(nil)
 
 type Schema struct {

--- a/database/seeder/seeder.go
+++ b/database/seeder/seeder.go
@@ -5,8 +5,6 @@ import (
 	"github.com/goravel/framework/support/color"
 )
 
-const BindingSeeder = "goravel.seeder"
-
 var _ seeder.Facade = (*SeederFacade)(nil)
 
 type SeederFacade struct {

--- a/database/service_provider.go
+++ b/database/service_provider.go
@@ -3,7 +3,7 @@ package database
 import (
 	"context"
 
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	contractsconsole "github.com/goravel/framework/contracts/console"
 	contractsmigration "github.com/goravel/framework/contracts/database/migration"
 	"github.com/goravel/framework/contracts/foundation"
@@ -21,7 +21,7 @@ type ServiceProvider struct {
 }
 
 func (r *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(frameworkconfig.BindingOrm, func(app foundation.Application) (any, error) {
+	app.Singleton(contracts.BindingOrm, func(app foundation.Application) (any, error) {
 		ctx := context.Background()
 		config := app.MakeConfig()
 		if config == nil {
@@ -47,7 +47,7 @@ func (r *ServiceProvider) Register(app foundation.Application) {
 
 		return orm, nil
 	})
-	app.Singleton(frameworkconfig.BindingSchema, func(app foundation.Application) (any, error) {
+	app.Singleton(contracts.BindingSchema, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleSchema)
@@ -66,7 +66,7 @@ func (r *ServiceProvider) Register(app foundation.Application) {
 
 		return databaseschema.NewSchema(config, log, orm, nil), nil
 	})
-	app.Singleton(frameworkconfig.BindingSeeder, func(app foundation.Application) (any, error) {
+	app.Singleton(contracts.BindingSeeder, func(app foundation.Application) (any, error) {
 		return databaseseeder.NewSeederFacade(), nil
 	})
 }

--- a/database/service_provider.go
+++ b/database/service_provider.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 
+	frameworkconfig "github.com/goravel/framework/config"
 	contractsconsole "github.com/goravel/framework/contracts/console"
 	contractsmigration "github.com/goravel/framework/contracts/database/migration"
 	"github.com/goravel/framework/contracts/foundation"
@@ -20,7 +21,7 @@ type ServiceProvider struct {
 }
 
 func (r *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(databaseorm.BindingOrm, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingOrm, func(app foundation.Application) (any, error) {
 		ctx := context.Background()
 		config := app.MakeConfig()
 		if config == nil {
@@ -46,7 +47,7 @@ func (r *ServiceProvider) Register(app foundation.Application) {
 
 		return orm, nil
 	})
-	app.Singleton(databaseschema.BindingSchema, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingSchema, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleSchema)
@@ -65,7 +66,7 @@ func (r *ServiceProvider) Register(app foundation.Application) {
 
 		return databaseschema.NewSchema(config, log, orm, nil), nil
 	})
-	app.Singleton(databaseseeder.BindingSeeder, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingSeeder, func(app foundation.Application) (any, error) {
 		return databaseseeder.NewSeederFacade(), nil
 	})
 }

--- a/event/service_provider.go
+++ b/event/service_provider.go
@@ -1,19 +1,18 @@
 package event
 
 import (
+	"github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 	eventConsole "github.com/goravel/framework/event/console"
 )
 
-const Binding = "goravel.event"
-
 type ServiceProvider struct {
 }
 
 func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(config.BindingEvent, func(app foundation.Application) (any, error) {
 		queueFacade := app.MakeQueue()
 		if queueFacade == nil {
 			return nil, errors.QueueFacadeNotSet.SetModule(errors.ModuleEvent)

--- a/event/service_provider.go
+++ b/event/service_provider.go
@@ -1,7 +1,7 @@
 package event
 
 import (
-	"github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
@@ -11,8 +11,8 @@ import (
 type ServiceProvider struct {
 }
 
-func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(config.BindingEvent, func(app foundation.Application) (any, error) {
+func (event *ServiceProvider) Register(app foundation.Application) {
+	app.Singleton(contracts.BindingEvent, func(app foundation.Application) (any, error) {
 		queueFacade := app.MakeQueue()
 		if queueFacade == nil {
 			return nil, errors.QueueFacadeNotSet.SetModule(errors.ModuleEvent)
@@ -22,11 +22,11 @@ func (receiver *ServiceProvider) Register(app foundation.Application) {
 	})
 }
 
-func (receiver *ServiceProvider) Boot(app foundation.Application) {
-	receiver.registerCommands(app)
+func (event *ServiceProvider) Boot(app foundation.Application) {
+	event.registerCommands(app)
 }
 
-func (receiver *ServiceProvider) registerCommands(app foundation.Application) {
+func (event *ServiceProvider) registerCommands(app foundation.Application) {
 	app.Commands([]console.Command{
 		&eventConsole.EventMakeCommand{},
 		&eventConsole.ListenerMakeCommand{},

--- a/filesystem/service_provider.go
+++ b/filesystem/service_provider.go
@@ -1,7 +1,7 @@
 package filesystem
 
 import (
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	configcontract "github.com/goravel/framework/contracts/config"
 	filesystemcontract "github.com/goravel/framework/contracts/filesystem"
 	"github.com/goravel/framework/contracts/foundation"
@@ -16,8 +16,8 @@ var (
 type ServiceProvider struct {
 }
 
-func (database *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(frameworkconfig.BindingFilesystem, func(app foundation.Application) (any, error) {
+func (filesystem *ServiceProvider) Register(app foundation.Application) {
+	app.Singleton(contracts.BindingFilesystem, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleFilesystem)
@@ -27,7 +27,7 @@ func (database *ServiceProvider) Register(app foundation.Application) {
 	})
 }
 
-func (database *ServiceProvider) Boot(app foundation.Application) {
+func (filesystem *ServiceProvider) Boot(app foundation.Application) {
 	ConfigFacade = app.MakeConfig()
 	StorageFacade = app.MakeStorage()
 }

--- a/filesystem/service_provider.go
+++ b/filesystem/service_provider.go
@@ -1,13 +1,12 @@
 package filesystem
 
 import (
+	frameworkconfig "github.com/goravel/framework/config"
 	configcontract "github.com/goravel/framework/contracts/config"
 	filesystemcontract "github.com/goravel/framework/contracts/filesystem"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
-
-const Binding = "goravel.filesystem"
 
 var (
 	ConfigFacade  configcontract.Config
@@ -18,7 +17,7 @@ type ServiceProvider struct {
 }
 
 func (database *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingFilesystem, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleFilesystem)

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/crypt"
 	"github.com/goravel/framework/database"
-	"github.com/goravel/framework/database/orm"
 	"github.com/goravel/framework/event"
 	"github.com/goravel/framework/filesystem"
 	"github.com/goravel/framework/foundation/json"
@@ -157,10 +156,10 @@ func (s *ApplicationTestSuite) TestMakeAuth() {
 	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
-	s.app.Singleton(cache.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(frameworkconfig.BindingCache, func(app foundation.Application) (any, error) {
 		return &mockscache.Cache{}, nil
 	})
-	s.app.Singleton(orm.BindingOrm, func(app foundation.Application) (any, error) {
+	s.app.Singleton(frameworkconfig.BindingOrm, func(app foundation.Application) (any, error) {
 		return &mocksorm.Orm{}, nil
 	})
 
@@ -179,7 +178,7 @@ func (s *ApplicationTestSuite) TestMakeCache() {
 	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
-	s.app.Singleton(frameworklog.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
 		return &mockslog.Log{}, nil
 	})
 
@@ -212,7 +211,7 @@ func (s *ApplicationTestSuite) TestMakeCrypt() {
 }
 
 func (s *ApplicationTestSuite) TestMakeEvent() {
-	s.app.Singleton(queue.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(frameworkconfig.BindingQueue, func(app foundation.Application) (any, error) {
 		return &mocksqueue.Queue{}, nil
 	})
 
@@ -266,7 +265,7 @@ func (s *ApplicationTestSuite) TestMakeLang() {
 	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
-	s.app.Singleton(frameworklog.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
 		return &mockslog.Log{}, nil
 	})
 
@@ -297,7 +296,7 @@ func (s *ApplicationTestSuite) TestMakeMail() {
 	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
 		return &mocksconfig.Config{}, nil
 	})
-	s.app.Singleton(queue.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(frameworkconfig.BindingQueue, func(app foundation.Application) (any, error) {
 		return &mocksqueue.Queue{}, nil
 	})
 
@@ -345,7 +344,7 @@ func (s *ApplicationTestSuite) TestMakeOrm() {
 		return mockConfig, nil
 	})
 
-	s.app.Singleton(frameworklog.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
 		return &mockslog.Log{}, nil
 	})
 
@@ -360,7 +359,7 @@ func (s *ApplicationTestSuite) TestMakeQueue() {
 		return &mocksconfig.Config{}, nil
 	})
 
-	s.app.Singleton(frameworklog.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
 		return &mockslog.Log{}, nil
 	})
 
@@ -398,13 +397,13 @@ func (s *ApplicationTestSuite) TestMakeSchedule() {
 	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
-	s.app.Singleton(console.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(frameworkconfig.BindingConsole, func(app foundation.Application) (any, error) {
 		return &mocksconsole.Artisan{}, nil
 	})
-	s.app.Singleton(frameworklog.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
 		return &mockslog.Log{}, nil
 	})
-	s.app.Singleton(cache.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(frameworkconfig.BindingCache, func(app foundation.Application) (any, error) {
 		return &mockscache.Cache{}, nil
 	})
 

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goravel/framework/cache"
 	frameworkconfig "github.com/goravel/framework/config"
 	"github.com/goravel/framework/console"
+	"github.com/goravel/framework/contracts"
 	contractsdatabase "github.com/goravel/framework/contracts/database"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/crypt"
@@ -156,10 +157,10 @@ func (s *ApplicationTestSuite) TestMakeAuth() {
 	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
-	s.app.Singleton(frameworkconfig.BindingCache, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingCache, func(app foundation.Application) (any, error) {
 		return &mockscache.Cache{}, nil
 	})
-	s.app.Singleton(frameworkconfig.BindingOrm, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingOrm, func(app foundation.Application) (any, error) {
 		return &mocksorm.Orm{}, nil
 	})
 
@@ -178,7 +179,7 @@ func (s *ApplicationTestSuite) TestMakeCache() {
 	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
-	s.app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingLog, func(app foundation.Application) (any, error) {
 		return &mockslog.Log{}, nil
 	})
 
@@ -211,7 +212,7 @@ func (s *ApplicationTestSuite) TestMakeCrypt() {
 }
 
 func (s *ApplicationTestSuite) TestMakeEvent() {
-	s.app.Singleton(frameworkconfig.BindingQueue, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingQueue, func(app foundation.Application) (any, error) {
 		return &mocksqueue.Queue{}, nil
 	})
 
@@ -265,7 +266,7 @@ func (s *ApplicationTestSuite) TestMakeLang() {
 	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
-	s.app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingLog, func(app foundation.Application) (any, error) {
 		return &mockslog.Log{}, nil
 	})
 
@@ -296,7 +297,7 @@ func (s *ApplicationTestSuite) TestMakeMail() {
 	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
 		return &mocksconfig.Config{}, nil
 	})
-	s.app.Singleton(frameworkconfig.BindingQueue, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingQueue, func(app foundation.Application) (any, error) {
 		return &mocksqueue.Queue{}, nil
 	})
 
@@ -344,7 +345,7 @@ func (s *ApplicationTestSuite) TestMakeOrm() {
 		return mockConfig, nil
 	})
 
-	s.app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingLog, func(app foundation.Application) (any, error) {
 		return &mockslog.Log{}, nil
 	})
 
@@ -359,7 +360,7 @@ func (s *ApplicationTestSuite) TestMakeQueue() {
 		return &mocksconfig.Config{}, nil
 	})
 
-	s.app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingLog, func(app foundation.Application) (any, error) {
 		return &mockslog.Log{}, nil
 	})
 
@@ -397,13 +398,13 @@ func (s *ApplicationTestSuite) TestMakeSchedule() {
 	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
-	s.app.Singleton(frameworkconfig.BindingConsole, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConsole, func(app foundation.Application) (any, error) {
 		return &mocksconsole.Artisan{}, nil
 	})
-	s.app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingLog, func(app foundation.Application) (any, error) {
 		return &mockslog.Log{}, nil
 	})
-	s.app.Singleton(frameworkconfig.BindingCache, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingCache, func(app foundation.Application) (any, error) {
 		return &mockscache.Cache{}, nil
 	})
 

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -88,7 +88,7 @@ func (s *ApplicationTestSuite) TestLangPath() {
 	mockConfig := mocksconfig.NewConfig(s.T())
 	mockConfig.EXPECT().GetString("app.lang_path", "lang").Return("test").Once()
 
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 
@@ -154,7 +154,7 @@ func (s *ApplicationTestSuite) TestMakeAuth() {
 	mockConfig := mocksconfig.NewConfig(s.T())
 	mockConfig.EXPECT().GetString("auth.defaults.guard").Return("user").Once()
 
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 	s.app.Singleton(contracts.BindingCache, func(app foundation.Application) (any, error) {
@@ -176,7 +176,7 @@ func (s *ApplicationTestSuite) TestMakeCache() {
 	mockConfig.EXPECT().GetString("cache.stores.memory.driver").Return("memory").Once()
 	mockConfig.EXPECT().GetString("cache.prefix").Return("goravel").Once()
 
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 	s.app.Singleton(contracts.BindingLog, func(app foundation.Application) (any, error) {
@@ -200,7 +200,7 @@ func (s *ApplicationTestSuite) TestMakeCrypt() {
 	mockConfig := mocksconfig.NewConfig(s.T())
 	mockConfig.EXPECT().GetString("app.key").Return("12345678901234567890123456789012").Once()
 
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 	s.app.SetJson(json.NewJson())
@@ -230,7 +230,7 @@ func (s *ApplicationTestSuite) TestMakeGate() {
 }
 
 func (s *ApplicationTestSuite) TestMakeGrpc() {
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return &mocksconfig.Config{}, nil
 	})
 
@@ -247,7 +247,7 @@ func (s *ApplicationTestSuite) TestMakeHash() {
 	mockConfig.EXPECT().GetInt("hashing.argon2id.memory", 65536).Return(65536).Once()
 	mockConfig.EXPECT().GetInt("hashing.argon2id.threads", 1).Return(1).Once()
 
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 
@@ -263,7 +263,7 @@ func (s *ApplicationTestSuite) TestMakeLang() {
 	mockConfig.EXPECT().GetString("app.fallback_locale").Return("en").Once()
 	mockConfig.EXPECT().GetString("app.lang_path", "lang").Return("lang").Once()
 
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 	s.app.Singleton(contracts.BindingLog, func(app foundation.Application) (any, error) {
@@ -279,7 +279,7 @@ func (s *ApplicationTestSuite) TestMakeLang() {
 
 func (s *ApplicationTestSuite) TestMakeLog() {
 	mockConfig := mocksconfig.NewConfig(s.T())
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 
@@ -294,7 +294,7 @@ func (s *ApplicationTestSuite) TestMakeLog() {
 }
 
 func (s *ApplicationTestSuite) TestMakeMail() {
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return &mocksconfig.Config{}, nil
 	})
 	s.app.Singleton(contracts.BindingQueue, func(app foundation.Application) (any, error) {
@@ -341,7 +341,7 @@ func (s *ApplicationTestSuite) TestMakeOrm() {
 	mockConfig.EXPECT().GetInt("database.pool.conn_max_idletime", 3600).Return(3600).Once()
 	mockConfig.EXPECT().GetInt("database.pool.conn_max_lifetime", 3600).Return(3600).Once()
 
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 
@@ -356,7 +356,7 @@ func (s *ApplicationTestSuite) TestMakeOrm() {
 }
 
 func (s *ApplicationTestSuite) TestMakeQueue() {
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return &mocksconfig.Config{}, nil
 	})
 
@@ -380,7 +380,7 @@ func (s *ApplicationTestSuite) TestMakeRateLimiter() {
 func (s *ApplicationTestSuite) TestMakeRoute() {
 	mockConfig := mocksconfig.NewConfig(s.T())
 
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 
@@ -395,7 +395,7 @@ func (s *ApplicationTestSuite) TestMakeSchedule() {
 	mockConfig := mocksconfig.NewConfig(s.T())
 	mockConfig.EXPECT().GetBool("app.debug").Return(false).Once()
 
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 	s.app.Singleton(contracts.BindingConsole, func(app foundation.Application) (any, error) {
@@ -420,7 +420,7 @@ func (s *ApplicationTestSuite) TestMakeSession() {
 	mockConfig.EXPECT().GetInt("session.gc_interval", 30).Return(30).Once()
 	mockConfig.EXPECT().GetString("session.files").Return("storage/framework/sessions").Once()
 
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 	s.app.SetJson(json.NewJson())
@@ -440,7 +440,7 @@ func (s *ApplicationTestSuite) TestMakeStorage() {
 	mockConfig.EXPECT().GetString("filesystems.disks.local.root").Return("").Once()
 	mockConfig.EXPECT().GetString("filesystems.disks.local.url").Return("").Once()
 
-	s.app.Singleton(frameworkconfig.Binding, func(app foundation.Application) (any, error) {
+	s.app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
 		return mockConfig, nil
 	})
 

--- a/foundation/container.go
+++ b/foundation/container.go
@@ -5,10 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/goravel/framework/auth"
-	"github.com/goravel/framework/cache"
 	"github.com/goravel/framework/config"
-	"github.com/goravel/framework/console"
 	contractsauth "github.com/goravel/framework/contracts/auth"
 	contractsaccess "github.com/goravel/framework/contracts/auth/access"
 	contractscache "github.com/goravel/framework/contracts/cache"
@@ -33,25 +30,7 @@ import (
 	contractstesting "github.com/goravel/framework/contracts/testing"
 	contractstranslation "github.com/goravel/framework/contracts/translation"
 	contractsvalidation "github.com/goravel/framework/contracts/validation"
-	"github.com/goravel/framework/crypt"
-	"github.com/goravel/framework/database/orm"
-	"github.com/goravel/framework/database/schema"
-	"github.com/goravel/framework/database/seeder"
-	"github.com/goravel/framework/event"
-	"github.com/goravel/framework/filesystem"
-	"github.com/goravel/framework/grpc"
-	"github.com/goravel/framework/hash"
-	"github.com/goravel/framework/http"
-	frameworklog "github.com/goravel/framework/log"
-	"github.com/goravel/framework/mail"
-	"github.com/goravel/framework/queue"
-	"github.com/goravel/framework/route"
-	"github.com/goravel/framework/schedule"
-	"github.com/goravel/framework/session"
 	"github.com/goravel/framework/support/color"
-	"github.com/goravel/framework/testing"
-	"github.com/goravel/framework/translation"
-	"github.com/goravel/framework/validation"
 )
 
 type instance struct {
@@ -85,7 +64,7 @@ func (c *Container) Make(key any) (any, error) {
 }
 
 func (c *Container) MakeArtisan() contractsconsole.Artisan {
-	instance, err := c.Make(console.Binding)
+	instance, err := c.Make(config.BindingConsole)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -95,7 +74,7 @@ func (c *Container) MakeArtisan() contractsconsole.Artisan {
 }
 
 func (c *Container) MakeAuth(ctx contractshttp.Context) contractsauth.Auth {
-	instance, err := c.MakeWith(auth.BindingAuth, map[string]any{
+	instance, err := c.MakeWith(config.BindingAuth, map[string]any{
 		"ctx": ctx,
 	})
 	if err != nil {
@@ -110,7 +89,7 @@ func (c *Container) MakeAuth(ctx contractshttp.Context) contractsauth.Auth {
 }
 
 func (c *Container) MakeCache() contractscache.Cache {
-	instance, err := c.Make(cache.Binding)
+	instance, err := c.Make(config.BindingCache)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -130,7 +109,7 @@ func (c *Container) MakeConfig() contractsconfig.Config {
 }
 
 func (c *Container) MakeCrypt() contractscrypt.Crypt {
-	instance, err := c.Make(crypt.Binding)
+	instance, err := c.Make(config.BindingCrypt)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -140,7 +119,7 @@ func (c *Container) MakeCrypt() contractscrypt.Crypt {
 }
 
 func (c *Container) MakeEvent() contractsevent.Instance {
-	instance, err := c.Make(event.Binding)
+	instance, err := c.Make(config.BindingEvent)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -150,7 +129,7 @@ func (c *Container) MakeEvent() contractsevent.Instance {
 }
 
 func (c *Container) MakeGate() contractsaccess.Gate {
-	instance, err := c.Make(auth.BindingGate)
+	instance, err := c.Make(config.BindingGate)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -160,7 +139,7 @@ func (c *Container) MakeGate() contractsaccess.Gate {
 }
 
 func (c *Container) MakeGrpc() contractsgrpc.Grpc {
-	instance, err := c.Make(grpc.Binding)
+	instance, err := c.Make(config.BindingGrpc)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -170,7 +149,7 @@ func (c *Container) MakeGrpc() contractsgrpc.Grpc {
 }
 
 func (c *Container) MakeHash() contractshash.Hash {
-	instance, err := c.Make(hash.Binding)
+	instance, err := c.Make(config.BindingHash)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -180,7 +159,7 @@ func (c *Container) MakeHash() contractshash.Hash {
 }
 
 func (c *Container) MakeLang(ctx context.Context) contractstranslation.Translator {
-	instance, err := c.MakeWith(translation.Binding, map[string]any{
+	instance, err := c.MakeWith(config.BindingTranslation, map[string]any{
 		"ctx": ctx,
 	})
 	if err != nil {
@@ -192,7 +171,7 @@ func (c *Container) MakeLang(ctx context.Context) contractstranslation.Translato
 }
 
 func (c *Container) MakeLog() contractslog.Log {
-	instance, err := c.Make(frameworklog.Binding)
+	instance, err := c.Make(config.BindingLog)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -202,7 +181,7 @@ func (c *Container) MakeLog() contractslog.Log {
 }
 
 func (c *Container) MakeMail() contractsmail.Mail {
-	instance, err := c.Make(mail.Binding)
+	instance, err := c.Make(config.BindingMail)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -212,7 +191,7 @@ func (c *Container) MakeMail() contractsmail.Mail {
 }
 
 func (c *Container) MakeOrm() contractsorm.Orm {
-	instance, err := c.Make(orm.BindingOrm)
+	instance, err := c.Make(config.BindingOrm)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -225,7 +204,7 @@ func (c *Container) MakeOrm() contractsorm.Orm {
 }
 
 func (c *Container) MakeQueue() contractsqueue.Queue {
-	instance, err := c.Make(queue.Binding)
+	instance, err := c.Make(config.BindingQueue)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -235,7 +214,7 @@ func (c *Container) MakeQueue() contractsqueue.Queue {
 }
 
 func (c *Container) MakeRateLimiter() contractshttp.RateLimiter {
-	instance, err := c.Make(http.BindingRateLimiter)
+	instance, err := c.Make(config.BindingRateLimiter)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -245,7 +224,7 @@ func (c *Container) MakeRateLimiter() contractshttp.RateLimiter {
 }
 
 func (c *Container) MakeRoute() contractsroute.Route {
-	instance, err := c.Make(route.Binding)
+	instance, err := c.Make(config.BindingRoute)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -255,7 +234,7 @@ func (c *Container) MakeRoute() contractsroute.Route {
 }
 
 func (c *Container) MakeSchedule() contractsschedule.Schedule {
-	instance, err := c.Make(schedule.Binding)
+	instance, err := c.Make(config.BindingSchedule)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -265,7 +244,7 @@ func (c *Container) MakeSchedule() contractsschedule.Schedule {
 }
 
 func (c *Container) MakeSchema() contractsmigration.Schema {
-	instance, err := c.Make(schema.BindingSchema)
+	instance, err := c.Make(config.BindingSchema)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -278,7 +257,7 @@ func (c *Container) MakeSchema() contractsmigration.Schema {
 }
 
 func (c *Container) MakeSession() contractsession.Manager {
-	instance, err := c.Make(session.Binding)
+	instance, err := c.Make(config.BindingSession)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -288,7 +267,7 @@ func (c *Container) MakeSession() contractsession.Manager {
 }
 
 func (c *Container) MakeStorage() contractsfilesystem.Storage {
-	instance, err := c.Make(filesystem.Binding)
+	instance, err := c.Make(config.BindingFilesystem)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -298,7 +277,7 @@ func (c *Container) MakeStorage() contractsfilesystem.Storage {
 }
 
 func (c *Container) MakeTesting() contractstesting.Testing {
-	instance, err := c.Make(testing.Binding)
+	instance, err := c.Make(config.BindingTesting)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -308,7 +287,7 @@ func (c *Container) MakeTesting() contractstesting.Testing {
 }
 
 func (c *Container) MakeValidation() contractsvalidation.Validation {
-	instance, err := c.Make(validation.Binding)
+	instance, err := c.Make(config.BindingValidation)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -318,7 +297,7 @@ func (c *Container) MakeValidation() contractsvalidation.Validation {
 }
 
 func (c *Container) MakeView() contractshttp.View {
-	instance, err := c.Make(http.BindingView)
+	instance, err := c.Make(config.BindingView)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -328,7 +307,7 @@ func (c *Container) MakeView() contractshttp.View {
 }
 
 func (c *Container) MakeSeeder() contractsseerder.Facade {
-	instance, err := c.Make(seeder.BindingSeeder)
+	instance, err := c.Make(config.BindingSeeder)
 
 	if err != nil {
 		color.Errorln(err)

--- a/foundation/container.go
+++ b/foundation/container.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts"
 	contractsauth "github.com/goravel/framework/contracts/auth"
 	contractsaccess "github.com/goravel/framework/contracts/auth/access"
@@ -100,7 +99,7 @@ func (c *Container) MakeCache() contractscache.Cache {
 }
 
 func (c *Container) MakeConfig() contractsconfig.Config {
-	instance, err := c.Make(config.Binding)
+	instance, err := c.Make(contracts.BindingConfig)
 	if err != nil {
 		color.Errorln(err)
 		return nil

--- a/foundation/container.go
+++ b/foundation/container.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	contractsauth "github.com/goravel/framework/contracts/auth"
 	contractsaccess "github.com/goravel/framework/contracts/auth/access"
 	contractscache "github.com/goravel/framework/contracts/cache"
@@ -64,7 +65,7 @@ func (c *Container) Make(key any) (any, error) {
 }
 
 func (c *Container) MakeArtisan() contractsconsole.Artisan {
-	instance, err := c.Make(config.BindingConsole)
+	instance, err := c.Make(contracts.BindingConsole)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -74,7 +75,7 @@ func (c *Container) MakeArtisan() contractsconsole.Artisan {
 }
 
 func (c *Container) MakeAuth(ctx contractshttp.Context) contractsauth.Auth {
-	instance, err := c.MakeWith(config.BindingAuth, map[string]any{
+	instance, err := c.MakeWith(contracts.BindingAuth, map[string]any{
 		"ctx": ctx,
 	})
 	if err != nil {
@@ -89,7 +90,7 @@ func (c *Container) MakeAuth(ctx contractshttp.Context) contractsauth.Auth {
 }
 
 func (c *Container) MakeCache() contractscache.Cache {
-	instance, err := c.Make(config.BindingCache)
+	instance, err := c.Make(contracts.BindingCache)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -109,7 +110,7 @@ func (c *Container) MakeConfig() contractsconfig.Config {
 }
 
 func (c *Container) MakeCrypt() contractscrypt.Crypt {
-	instance, err := c.Make(config.BindingCrypt)
+	instance, err := c.Make(contracts.BindingCrypt)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -119,7 +120,7 @@ func (c *Container) MakeCrypt() contractscrypt.Crypt {
 }
 
 func (c *Container) MakeEvent() contractsevent.Instance {
-	instance, err := c.Make(config.BindingEvent)
+	instance, err := c.Make(contracts.BindingEvent)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -129,7 +130,7 @@ func (c *Container) MakeEvent() contractsevent.Instance {
 }
 
 func (c *Container) MakeGate() contractsaccess.Gate {
-	instance, err := c.Make(config.BindingGate)
+	instance, err := c.Make(contracts.BindingGate)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -139,7 +140,7 @@ func (c *Container) MakeGate() contractsaccess.Gate {
 }
 
 func (c *Container) MakeGrpc() contractsgrpc.Grpc {
-	instance, err := c.Make(config.BindingGrpc)
+	instance, err := c.Make(contracts.BindingGrpc)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -149,7 +150,7 @@ func (c *Container) MakeGrpc() contractsgrpc.Grpc {
 }
 
 func (c *Container) MakeHash() contractshash.Hash {
-	instance, err := c.Make(config.BindingHash)
+	instance, err := c.Make(contracts.BindingHash)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -159,7 +160,7 @@ func (c *Container) MakeHash() contractshash.Hash {
 }
 
 func (c *Container) MakeLang(ctx context.Context) contractstranslation.Translator {
-	instance, err := c.MakeWith(config.BindingTranslation, map[string]any{
+	instance, err := c.MakeWith(contracts.BindingTranslation, map[string]any{
 		"ctx": ctx,
 	})
 	if err != nil {
@@ -171,7 +172,7 @@ func (c *Container) MakeLang(ctx context.Context) contractstranslation.Translato
 }
 
 func (c *Container) MakeLog() contractslog.Log {
-	instance, err := c.Make(config.BindingLog)
+	instance, err := c.Make(contracts.BindingLog)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -181,7 +182,7 @@ func (c *Container) MakeLog() contractslog.Log {
 }
 
 func (c *Container) MakeMail() contractsmail.Mail {
-	instance, err := c.Make(config.BindingMail)
+	instance, err := c.Make(contracts.BindingMail)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -191,7 +192,7 @@ func (c *Container) MakeMail() contractsmail.Mail {
 }
 
 func (c *Container) MakeOrm() contractsorm.Orm {
-	instance, err := c.Make(config.BindingOrm)
+	instance, err := c.Make(contracts.BindingOrm)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -204,7 +205,7 @@ func (c *Container) MakeOrm() contractsorm.Orm {
 }
 
 func (c *Container) MakeQueue() contractsqueue.Queue {
-	instance, err := c.Make(config.BindingQueue)
+	instance, err := c.Make(contracts.BindingQueue)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -214,7 +215,7 @@ func (c *Container) MakeQueue() contractsqueue.Queue {
 }
 
 func (c *Container) MakeRateLimiter() contractshttp.RateLimiter {
-	instance, err := c.Make(config.BindingRateLimiter)
+	instance, err := c.Make(contracts.BindingRateLimiter)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -224,7 +225,7 @@ func (c *Container) MakeRateLimiter() contractshttp.RateLimiter {
 }
 
 func (c *Container) MakeRoute() contractsroute.Route {
-	instance, err := c.Make(config.BindingRoute)
+	instance, err := c.Make(contracts.BindingRoute)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -234,7 +235,7 @@ func (c *Container) MakeRoute() contractsroute.Route {
 }
 
 func (c *Container) MakeSchedule() contractsschedule.Schedule {
-	instance, err := c.Make(config.BindingSchedule)
+	instance, err := c.Make(contracts.BindingSchedule)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -244,7 +245,7 @@ func (c *Container) MakeSchedule() contractsschedule.Schedule {
 }
 
 func (c *Container) MakeSchema() contractsmigration.Schema {
-	instance, err := c.Make(config.BindingSchema)
+	instance, err := c.Make(contracts.BindingSchema)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -257,7 +258,7 @@ func (c *Container) MakeSchema() contractsmigration.Schema {
 }
 
 func (c *Container) MakeSession() contractsession.Manager {
-	instance, err := c.Make(config.BindingSession)
+	instance, err := c.Make(contracts.BindingSession)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -267,7 +268,7 @@ func (c *Container) MakeSession() contractsession.Manager {
 }
 
 func (c *Container) MakeStorage() contractsfilesystem.Storage {
-	instance, err := c.Make(config.BindingFilesystem)
+	instance, err := c.Make(contracts.BindingFilesystem)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -277,7 +278,7 @@ func (c *Container) MakeStorage() contractsfilesystem.Storage {
 }
 
 func (c *Container) MakeTesting() contractstesting.Testing {
-	instance, err := c.Make(config.BindingTesting)
+	instance, err := c.Make(contracts.BindingTesting)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -287,7 +288,7 @@ func (c *Container) MakeTesting() contractstesting.Testing {
 }
 
 func (c *Container) MakeValidation() contractsvalidation.Validation {
-	instance, err := c.Make(config.BindingValidation)
+	instance, err := c.Make(contracts.BindingValidation)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -297,7 +298,7 @@ func (c *Container) MakeValidation() contractsvalidation.Validation {
 }
 
 func (c *Container) MakeView() contractshttp.View {
-	instance, err := c.Make(config.BindingView)
+	instance, err := c.Make(contracts.BindingView)
 	if err != nil {
 		color.Errorln(err)
 		return nil
@@ -307,7 +308,7 @@ func (c *Container) MakeView() contractshttp.View {
 }
 
 func (c *Container) MakeSeeder() contractsseerder.Facade {
-	instance, err := c.Make(config.BindingSeeder)
+	instance, err := c.Make(contracts.BindingSeeder)
 
 	if err != nil {
 		color.Errorln(err)

--- a/grpc/service_provider.go
+++ b/grpc/service_provider.go
@@ -1,17 +1,16 @@
 package grpc
 
 import (
+	frameworkconfig "github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
-
-const Binding = "goravel.grpc"
 
 type ServiceProvider struct {
 }
 
 func (route *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingGrpc, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleGrpc)

--- a/grpc/service_provider.go
+++ b/grpc/service_provider.go
@@ -1,7 +1,7 @@
 package grpc
 
 import (
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
@@ -9,8 +9,8 @@ import (
 type ServiceProvider struct {
 }
 
-func (route *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(frameworkconfig.BindingGrpc, func(app foundation.Application) (any, error) {
+func (grpc *ServiceProvider) Register(app foundation.Application) {
+	app.Singleton(contracts.BindingGrpc, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleGrpc)
@@ -20,5 +20,5 @@ func (route *ServiceProvider) Register(app foundation.Application) {
 	})
 }
 
-func (route *ServiceProvider) Boot(app foundation.Application) {
+func (grpc *ServiceProvider) Boot(app foundation.Application) {
 }

--- a/hash/service_provider.go
+++ b/hash/service_provider.go
@@ -1,17 +1,16 @@
 package hash
 
 import (
+	frameworkconfig "github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
-
-const Binding = "goravel.hash"
 
 type ServiceProvider struct {
 }
 
 func (hash *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingHash, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleHash)

--- a/hash/service_provider.go
+++ b/hash/service_provider.go
@@ -1,7 +1,7 @@
 package hash
 
 import (
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
@@ -10,7 +10,7 @@ type ServiceProvider struct {
 }
 
 func (hash *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(frameworkconfig.BindingHash, func(app foundation.Application) (any, error) {
+	app.Singleton(contracts.BindingHash, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleHash)

--- a/http/service_provider.go
+++ b/http/service_provider.go
@@ -1,16 +1,12 @@
 package http
 
 import (
+	"github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/cache"
 	consolecontract "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/http/console"
-)
-
-const (
-	BindingRateLimiter = "goravel.rate_limiter"
-	BindingView        = "goravel.view"
 )
 
 type ServiceProvider struct{}
@@ -21,10 +17,10 @@ var (
 )
 
 func (http *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(BindingRateLimiter, func(app foundation.Application) (any, error) {
+	app.Singleton(config.BindingRateLimiter, func(app foundation.Application) (any, error) {
 		return NewRateLimiter(), nil
 	})
-	app.Singleton(BindingView, func(app foundation.Application) (any, error) {
+	app.Singleton(config.BindingView, func(app foundation.Application) (any, error) {
 		return NewView(), nil
 	})
 }

--- a/http/service_provider.go
+++ b/http/service_provider.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/cache"
 	consolecontract "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
@@ -17,10 +17,10 @@ var (
 )
 
 func (http *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(config.BindingRateLimiter, func(app foundation.Application) (any, error) {
+	app.Singleton(contracts.BindingRateLimiter, func(app foundation.Application) (any, error) {
 		return NewRateLimiter(), nil
 	})
-	app.Singleton(config.BindingView, func(app foundation.Application) (any, error) {
+	app.Singleton(contracts.BindingView, func(app foundation.Application) (any, error) {
 		return NewView(), nil
 	})
 }

--- a/log/service_provider.go
+++ b/log/service_provider.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
@@ -10,7 +10,7 @@ type ServiceProvider struct {
 }
 
 func (log *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
+	app.Singleton(contracts.BindingLog, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleLog)

--- a/log/service_provider.go
+++ b/log/service_provider.go
@@ -1,17 +1,16 @@
 package log
 
 import (
+	frameworkconfig "github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
-
-const Binding = "goravel.log"
 
 type ServiceProvider struct {
 }
 
 func (log *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingLog, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleLog)

--- a/mail/service_provider.go
+++ b/mail/service_provider.go
@@ -1,7 +1,7 @@
 package mail
 
 import (
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	consolecontract "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/contracts/queue"
@@ -13,8 +13,8 @@ import (
 type ServiceProvider struct {
 }
 
-func (route *ServiceProvider) Register(app foundation.Application) {
-	app.Bind(frameworkconfig.BindingMail, func(app foundation.Application) (any, error) {
+func (mail *ServiceProvider) Register(app foundation.Application) {
+	app.Bind(contracts.BindingMail, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleMail)
@@ -28,15 +28,15 @@ func (route *ServiceProvider) Register(app foundation.Application) {
 	})
 }
 
-func (route *ServiceProvider) Boot(app foundation.Application) {
+func (mail *ServiceProvider) Boot(app foundation.Application) {
 	app.Commands([]consolecontract.Command{
 		console.NewMailMakeCommand(),
 	})
 
-	route.registerJobs(app)
+	mail.registerJobs(app)
 }
 
-func (route *ServiceProvider) registerJobs(app foundation.Application) {
+func (mail *ServiceProvider) registerJobs(app foundation.Application) {
 	queueFacade := app.MakeQueue()
 	if queueFacade == nil {
 		color.Warningln("Queue Facade is not initialized. Skipping job registration.")

--- a/mail/service_provider.go
+++ b/mail/service_provider.go
@@ -1,6 +1,7 @@
 package mail
 
 import (
+	frameworkconfig "github.com/goravel/framework/config"
 	consolecontract "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/contracts/queue"
@@ -9,13 +10,11 @@ import (
 	"github.com/goravel/framework/support/color"
 )
 
-const Binding = "goravel.mail"
-
 type ServiceProvider struct {
 }
 
 func (route *ServiceProvider) Register(app foundation.Application) {
-	app.Bind(Binding, func(app foundation.Application) (any, error) {
+	app.Bind(frameworkconfig.BindingMail, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleMail)

--- a/queue/service_provider.go
+++ b/queue/service_provider.go
@@ -1,7 +1,7 @@
 package queue
 
 import (
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
@@ -11,8 +11,8 @@ import (
 type ServiceProvider struct {
 }
 
-func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(frameworkconfig.BindingQueue, func(app foundation.Application) (any, error) {
+func (queue *ServiceProvider) Register(app foundation.Application) {
+	app.Singleton(contracts.BindingQueue, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleQueue)
@@ -27,7 +27,7 @@ func (receiver *ServiceProvider) Register(app foundation.Application) {
 	})
 }
 
-func (receiver *ServiceProvider) Boot(app foundation.Application) {
+func (queue *ServiceProvider) Boot(app foundation.Application) {
 	app.Commands([]console.Command{
 		&queueConsole.JobMakeCommand{},
 	})

--- a/queue/service_provider.go
+++ b/queue/service_provider.go
@@ -1,19 +1,18 @@
 package queue
 
 import (
+	frameworkconfig "github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 	queueConsole "github.com/goravel/framework/queue/console"
 )
 
-const Binding = "goravel.queue"
-
 type ServiceProvider struct {
 }
 
 func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingQueue, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleQueue)

--- a/route/service_provider.go
+++ b/route/service_provider.go
@@ -1,17 +1,16 @@
 package route
 
 import (
+	frameworkconfig "github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
-
-const Binding = "goravel.route"
 
 type ServiceProvider struct {
 }
 
 func (route *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingRoute, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleRoute)

--- a/route/service_provider.go
+++ b/route/service_provider.go
@@ -1,7 +1,7 @@
 package route
 
 import (
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
@@ -10,7 +10,7 @@ type ServiceProvider struct {
 }
 
 func (route *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(frameworkconfig.BindingRoute, func(app foundation.Application) (any, error) {
+	app.Singleton(contracts.BindingRoute, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleRoute)

--- a/schedule/service_provider.go
+++ b/schedule/service_provider.go
@@ -1,17 +1,16 @@
 package schedule
 
 import (
+	frameworkconfig "github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
-
-const Binding = "goravel.schedule"
 
 type ServiceProvider struct {
 }
 
 func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingSchedule, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleSchedule)

--- a/schedule/service_provider.go
+++ b/schedule/service_provider.go
@@ -1,7 +1,7 @@
 package schedule
 
 import (
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
@@ -9,8 +9,8 @@ import (
 type ServiceProvider struct {
 }
 
-func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(frameworkconfig.BindingSchedule, func(app foundation.Application) (any, error) {
+func (schedule *ServiceProvider) Register(app foundation.Application) {
+	app.Singleton(contracts.BindingSchedule, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleSchedule)
@@ -35,6 +35,6 @@ func (receiver *ServiceProvider) Register(app foundation.Application) {
 	})
 }
 
-func (receiver *ServiceProvider) Boot(app foundation.Application) {
+func (schedule *ServiceProvider) Boot(app foundation.Application) {
 
 }

--- a/session/service_provider.go
+++ b/session/service_provider.go
@@ -1,7 +1,7 @@
 package session
 
 import (
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/contracts/session"
@@ -16,8 +16,8 @@ var (
 type ServiceProvider struct {
 }
 
-func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(frameworkconfig.BindingSession, func(app foundation.Application) (any, error) {
+func (session *ServiceProvider) Register(app foundation.Application) {
+	app.Singleton(contracts.BindingSession, func(app foundation.Application) (any, error) {
 		c := app.MakeConfig()
 		if c == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleSession)
@@ -32,7 +32,7 @@ func (receiver *ServiceProvider) Register(app foundation.Application) {
 	})
 }
 
-func (receiver *ServiceProvider) Boot(app foundation.Application) {
+func (session *ServiceProvider) Boot(app foundation.Application) {
 	SessionFacade = app.MakeSession()
 	ConfigFacade = app.MakeConfig()
 }

--- a/session/service_provider.go
+++ b/session/service_provider.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	frameworkconfig "github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/contracts/session"
@@ -12,13 +13,11 @@ var (
 	ConfigFacade  config.Config
 )
 
-const Binding = "goravel.session"
-
 type ServiceProvider struct {
 }
 
 func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(frameworkconfig.BindingSession, func(app foundation.Application) (any, error) {
 		c := app.MakeConfig()
 		if c == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleSession)

--- a/testing/service_provider.go
+++ b/testing/service_provider.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"github.com/goravel/framework/config"
 	contractsconsole "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	contractsroute "github.com/goravel/framework/contracts/route"
@@ -8,8 +9,6 @@ import (
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support/color"
 )
-
-const Binding = "goravel.testing"
 
 var (
 	json          foundation.Json
@@ -22,7 +21,7 @@ type ServiceProvider struct {
 }
 
 func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(config.BindingTesting, func(app foundation.Application) (any, error) {
 		return NewApplication(app), nil
 	})
 }

--- a/testing/service_provider.go
+++ b/testing/service_provider.go
@@ -1,7 +1,7 @@
 package testing
 
 import (
-	"github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	contractsconsole "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	contractsroute "github.com/goravel/framework/contracts/route"
@@ -20,13 +20,13 @@ var (
 type ServiceProvider struct {
 }
 
-func (receiver *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(config.BindingTesting, func(app foundation.Application) (any, error) {
+func (testing *ServiceProvider) Register(app foundation.Application) {
+	app.Singleton(contracts.BindingTesting, func(app foundation.Application) (any, error) {
 		return NewApplication(app), nil
 	})
 }
 
-func (receiver *ServiceProvider) Boot(app foundation.Application) {
+func (testing *ServiceProvider) Boot(app foundation.Application) {
 	artisanFacade = app.MakeArtisan()
 	if artisanFacade == nil {
 		color.Errorln(errors.ArtisanFacadeNotSet.SetModule(errors.ModuleTesting))

--- a/translation/service_provider.go
+++ b/translation/service_provider.go
@@ -3,7 +3,7 @@ package translation
 import (
 	"context"
 
-	frameworkconfig "github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
@@ -12,7 +12,7 @@ type ServiceProvider struct {
 }
 
 func (translation *ServiceProvider) Register(app foundation.Application) {
-	app.BindWith(frameworkconfig.BindingTranslation, func(app foundation.Application, parameters map[string]any) (any, error) {
+	app.BindWith(contracts.BindingTranslation, func(app foundation.Application, parameters map[string]any) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleLang)

--- a/translation/service_provider.go
+++ b/translation/service_provider.go
@@ -3,17 +3,16 @@ package translation
 import (
 	"context"
 
+	frameworkconfig "github.com/goravel/framework/config"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
 )
-
-const Binding = "goravel.translation"
 
 type ServiceProvider struct {
 }
 
 func (translation *ServiceProvider) Register(app foundation.Application) {
-	app.BindWith(Binding, func(app foundation.Application, parameters map[string]any) (any, error) {
+	app.BindWith(frameworkconfig.BindingTranslation, func(app foundation.Application, parameters map[string]any) (any, error) {
 		config := app.MakeConfig()
 		if config == nil {
 			return nil, errors.ConfigFacadeNotSet.SetModule(errors.ModuleLang)

--- a/validation/service_provider.go
+++ b/validation/service_provider.go
@@ -1,7 +1,7 @@
 package validation
 
 import (
-	"github.com/goravel/framework/config"
+	"github.com/goravel/framework/contracts"
 	consolecontract "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/validation/console"
@@ -10,13 +10,13 @@ import (
 type ServiceProvider struct {
 }
 
-func (database *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(config.BindingValidation, func(app foundation.Application) (any, error) {
+func (validation *ServiceProvider) Register(app foundation.Application) {
+	app.Singleton(contracts.BindingValidation, func(app foundation.Application) (any, error) {
 		return NewValidation(), nil
 	})
 }
 
-func (database *ServiceProvider) Boot(app foundation.Application) {
+func (validation *ServiceProvider) Boot(app foundation.Application) {
 	app.Commands([]consolecontract.Command{
 		&console.RuleMakeCommand{},
 		&console.FilterMakeCommand{},

--- a/validation/service_provider.go
+++ b/validation/service_provider.go
@@ -1,18 +1,17 @@
 package validation
 
 import (
+	"github.com/goravel/framework/config"
 	consolecontract "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/validation/console"
 )
 
-const Binding = "goravel.validation"
-
 type ServiceProvider struct {
 }
 
 func (database *ServiceProvider) Register(app foundation.Application) {
-	app.Singleton(Binding, func(app foundation.Application) (any, error) {
+	app.Singleton(config.BindingValidation, func(app foundation.Application) (any, error) {
 		return NewValidation(), nil
 	})
 }


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/?

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->
Normal binding for internal packages will include the package even we never registered it in app because of Make func in container which make the output file larger, so we need a diff. way to bind these packages and keep Make functions in container

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->


fresh goravl contains all service providers
```bash
➜  goravel git:(v1.15.x) ✗ go build -o goravel main.go    
➜  goravel git:(v1.15.x) ✗ ll
total 152304
-rw-r--r--@  1 ahmed3mar  staff   550B Feb  7 10:01 Dockerfile
-rw-r--r--@  1 ahmed3mar  staff   1.0K Feb  7 10:01 LICENSE
-rw-r--r--@  1 ahmed3mar  staff   9.2K Feb  7 10:01 README.md
-rw-r--r--@  1 ahmed3mar  staff   9.0K Feb  7 10:01 README_zh.md
drwxr-xr-x@  7 ahmed3mar  staff   224B Feb  7 10:01 app
drwxr-xr-x@  3 ahmed3mar  staff    96B Feb  7 10:01 bootstrap
drwxr-xr-x@ 16 ahmed3mar  staff   512B Feb  7 10:01 config
drwxr-xr-x@  5 ahmed3mar  staff   160B Feb  7 10:01 database
-rw-r--r--@  1 ahmed3mar  staff   114B Feb  7 10:01 docker-compose.yml
-rw-r--r--@  1 ahmed3mar  staff   9.9K Feb  8 02:57 go.mod
-rw-r--r--@  1 ahmed3mar  staff   111K Feb  8 02:57 go.sum
-rwxr-xr-x@  1 ahmed3mar  staff    74M Feb  8 12:35 goravel           # <--- 74MB
-rw-r--r--@  1 ahmed3mar  staff   707B Feb  7 10:01 main.go
drwxr-xr-x   5 ahmed3mar  staff   160B Feb  7 11:45 packages
drwxr-xr-x@  3 ahmed3mar  staff    96B Feb  7 10:01 public
drwxr-xr-x@  3 ahmed3mar  staff    96B Feb  7 10:01 resources
drwxr-xr-x@  5 ahmed3mar  staff   160B Feb  7 10:01 routes
drwxr-xr-x@  4 ahmed3mar  staff   128B Feb  7 10:01 storage
drwxr-xr-x@  4 ahmed3mar  staff   128B Feb  7 10:01 tests
```

with flags `-s -w`

```bash
go build -ldflags="-s -w" -o goravel main.go
-rwxr-xr-x@  1 ahmed3mar  staff    53M Feb  8 12:37 goravel           # <--- 53M
```

but if we need to use goravel for example only with log, console, http, route and gin only and our project doesn't need for database or queue system or others

normal
```bash
go build -ldflags="-s -w" -o goravel main.go
-rwxr-xr-x@  1 ahmed3mar  staff    39M Feb  8 12:40 goravel          # <--- 39M
```

with move binding to external not inside same package
```bash
go build -ldflags="-s -w" -o goravel main.go
-rwxr-xr-x@  1 ahmed3mar  staff    22M Feb  8 12:40 goravel         # <--- 22M
```

the size of output file is decreased from 39MB to 22MB


## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
