### PR TITLE
feat: [#571] migrator supports After and First column modifiers

### DIFF
--- a/contracts/database/schema/blueprint.go
+++ b/contracts/database/schema/blueprint.go
@@ -17,7 +17,7 @@ type Blueprint interface {
 	Char(column string, length ...int) ColumnDefinition
 	// Column Create a new custom type column on the table.
 	Column(column string, ttype string) ColumnDefinition
-	// Comment Add a comment to the table.
+	// Comment Add a comment to the table. (MySQL / PostgreSQL)
 	Comment(value string)
 	// Create Indicate that the table needs to be created.
 	Create()

--- a/contracts/database/schema/column.go
+++ b/contracts/database/schema/column.go
@@ -1,14 +1,20 @@
 package schema
 
 type ColumnDefinition interface {
+	// After Place the column "after" another column (MySQL only)
+	After(column string) ColumnDefinition
 	// AutoIncrement set the column as auto increment
 	AutoIncrement() ColumnDefinition
-	// Change the column
+	// Change the column (MySQL / PostgreSQL / SQL Server)
 	Change() ColumnDefinition
-	// Comment sets the comment value
+	// Comment sets the comment value (MySQL / PostgreSQL)
 	Comment(comment string) ColumnDefinition
 	// Default set the default value
 	Default(def any) ColumnDefinition
+	// First Place the column "first" in the table (MySQL only)
+	First() ColumnDefinition
+	// GetAfter returns the after value
+	GetAfter() string
 	// GetAllowed returns the allowed value
 	GetAllowed() []any
 	// GetAutoIncrement returns the autoIncrement value
@@ -41,6 +47,8 @@ type ColumnDefinition interface {
 	GetUseCurrentOnUpdate() bool
 	// IsChange returns true if the column has changed
 	IsChange() bool
+	// IsFirst returns true if the column is first
+	IsFirst() bool
 	// IsSetComment returns true if the comment value is set
 	IsSetComment() bool
 	// OnUpdate sets the column to use the value on update (Mysql only)
@@ -51,7 +59,7 @@ type ColumnDefinition interface {
 	Total(total int) ColumnDefinition
 	// Nullable allow NULL values to be inserted into the column
 	Nullable() ColumnDefinition
-	// Unsigned set the column as unsigned
+	// Unsigned set the column as unsigned (Mysql only)
 	Unsigned() ColumnDefinition
 	// UseCurrent set the column to use the current timestamp
 	UseCurrent() ColumnDefinition

--- a/database/schema/column.go
+++ b/database/schema/column.go
@@ -6,11 +6,13 @@ import (
 )
 
 type ColumnDefinition struct {
+	after              string
 	allowed            []any
 	autoIncrement      *bool
 	change             bool
 	comment            *string
 	def                any
+	first              bool
 	length             *int
 	name               *string
 	nullable           *bool
@@ -29,6 +31,12 @@ func NewColumnDefinition(name string, ttype string) schema.ColumnDefinition {
 		name:  &name,
 		ttype: convert.Pointer(ttype),
 	}
+}
+
+func (r *ColumnDefinition) After(column string) schema.ColumnDefinition {
+	r.after = column
+
+	return r
 }
 
 func (r *ColumnDefinition) AutoIncrement() schema.ColumnDefinition {
@@ -53,6 +61,16 @@ func (r *ColumnDefinition) Default(def any) schema.ColumnDefinition {
 	r.def = def
 
 	return r
+}
+
+func (r *ColumnDefinition) First() schema.ColumnDefinition {
+	r.first = true
+
+	return r
+}
+
+func (r *ColumnDefinition) GetAfter() string {
+	return r.after
 }
 
 func (r *ColumnDefinition) GetAllowed() []any {
@@ -165,6 +183,10 @@ func (r *ColumnDefinition) GetUseCurrentOnUpdate() bool {
 
 func (r *ColumnDefinition) IsChange() bool {
 	return r.change
+}
+
+func (r *ColumnDefinition) IsFirst() bool {
+	return r.first
 }
 
 func (r *ColumnDefinition) IsSetComment() bool {

--- a/mocks/database/schema/ColumnDefinition.go
+++ b/mocks/database/schema/ColumnDefinition.go
@@ -20,6 +20,54 @@ func (_m *ColumnDefinition) EXPECT() *ColumnDefinition_Expecter {
 	return &ColumnDefinition_Expecter{mock: &_m.Mock}
 }
 
+// After provides a mock function with given fields: column
+func (_m *ColumnDefinition) After(column string) schema.ColumnDefinition {
+	ret := _m.Called(column)
+
+	if len(ret) == 0 {
+		panic("no return value specified for After")
+	}
+
+	var r0 schema.ColumnDefinition
+	if rf, ok := ret.Get(0).(func(string) schema.ColumnDefinition); ok {
+		r0 = rf(column)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(schema.ColumnDefinition)
+		}
+	}
+
+	return r0
+}
+
+// ColumnDefinition_After_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'After'
+type ColumnDefinition_After_Call struct {
+	*mock.Call
+}
+
+// After is a helper method to define mock.On call
+//   - column string
+func (_e *ColumnDefinition_Expecter) After(column interface{}) *ColumnDefinition_After_Call {
+	return &ColumnDefinition_After_Call{Call: _e.mock.On("After", column)}
+}
+
+func (_c *ColumnDefinition_After_Call) Run(run func(column string)) *ColumnDefinition_After_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *ColumnDefinition_After_Call) Return(_a0 schema.ColumnDefinition) *ColumnDefinition_After_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ColumnDefinition_After_Call) RunAndReturn(run func(string) schema.ColumnDefinition) *ColumnDefinition_After_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // AutoIncrement provides a mock function with no fields
 func (_m *ColumnDefinition) AutoIncrement() schema.ColumnDefinition {
 	ret := _m.Called()
@@ -206,6 +254,98 @@ func (_c *ColumnDefinition_Default_Call) Return(_a0 schema.ColumnDefinition) *Co
 }
 
 func (_c *ColumnDefinition_Default_Call) RunAndReturn(run func(interface{}) schema.ColumnDefinition) *ColumnDefinition_Default_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// First provides a mock function with no fields
+func (_m *ColumnDefinition) First() schema.ColumnDefinition {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for First")
+	}
+
+	var r0 schema.ColumnDefinition
+	if rf, ok := ret.Get(0).(func() schema.ColumnDefinition); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(schema.ColumnDefinition)
+		}
+	}
+
+	return r0
+}
+
+// ColumnDefinition_First_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'First'
+type ColumnDefinition_First_Call struct {
+	*mock.Call
+}
+
+// First is a helper method to define mock.On call
+func (_e *ColumnDefinition_Expecter) First() *ColumnDefinition_First_Call {
+	return &ColumnDefinition_First_Call{Call: _e.mock.On("First")}
+}
+
+func (_c *ColumnDefinition_First_Call) Run(run func()) *ColumnDefinition_First_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ColumnDefinition_First_Call) Return(_a0 schema.ColumnDefinition) *ColumnDefinition_First_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ColumnDefinition_First_Call) RunAndReturn(run func() schema.ColumnDefinition) *ColumnDefinition_First_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetAfter provides a mock function with no fields
+func (_m *ColumnDefinition) GetAfter() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAfter")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// ColumnDefinition_GetAfter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAfter'
+type ColumnDefinition_GetAfter_Call struct {
+	*mock.Call
+}
+
+// GetAfter is a helper method to define mock.On call
+func (_e *ColumnDefinition_Expecter) GetAfter() *ColumnDefinition_GetAfter_Call {
+	return &ColumnDefinition_GetAfter_Call{Call: _e.mock.On("GetAfter")}
+}
+
+func (_c *ColumnDefinition_GetAfter_Call) Run(run func()) *ColumnDefinition_GetAfter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ColumnDefinition_GetAfter_Call) Return(_a0 string) *ColumnDefinition_GetAfter_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ColumnDefinition_GetAfter_Call) RunAndReturn(run func() string) *ColumnDefinition_GetAfter_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -932,6 +1072,51 @@ func (_c *ColumnDefinition_IsChange_Call) Return(_a0 bool) *ColumnDefinition_IsC
 }
 
 func (_c *ColumnDefinition_IsChange_Call) RunAndReturn(run func() bool) *ColumnDefinition_IsChange_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// IsFirst provides a mock function with no fields
+func (_m *ColumnDefinition) IsFirst() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsFirst")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// ColumnDefinition_IsFirst_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsFirst'
+type ColumnDefinition_IsFirst_Call struct {
+	*mock.Call
+}
+
+// IsFirst is a helper method to define mock.On call
+func (_e *ColumnDefinition_Expecter) IsFirst() *ColumnDefinition_IsFirst_Call {
+	return &ColumnDefinition_IsFirst_Call{Call: _e.mock.On("IsFirst")}
+}
+
+func (_c *ColumnDefinition_IsFirst_Call) Run(run func()) *ColumnDefinition_IsFirst_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *ColumnDefinition_IsFirst_Call) Return(_a0 bool) *ColumnDefinition_IsFirst_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ColumnDefinition_IsFirst_Call) RunAndReturn(run func() bool) *ColumnDefinition_IsFirst_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## 📑 Description
Go migrator supports `After` and `First` column modifiers. (MySQL only)

```go
func (r *M20250210084318AddColumnToTestTableCommentTable) Up() error {
	return facades.Schema().Table("test_table_comment", func(table schema.Blueprint) {
		table.String("after_column").After("first_column")
		table.String("add_to_head").First()
	})
}
```

Closes https://github.com/goravel/goravel/issues/571

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled enhanced schema design by allowing columns to be positioned either at the start or after a specified column.
  - Introduced new methods for managing column ordering and retrieving positional information.

- **Documentation**
  - Improved clarity on database compatibility, ensuring users understand which database systems support the new table comment and column ordering capabilities.
  - Updated comments to specify compatibility with MySQL, PostgreSQL, and SQL Server for relevant methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
