### PR TITLE
feat: [#592] Add --no-ansi flag to disable color output in Artisan co…

### DIFF
--- a/console/application.go
+++ b/console/application.go
@@ -12,6 +12,16 @@ import (
 	"github.com/goravel/framework/support/env"
 )
 
+var (
+	noANSI     bool
+	noANSIFlag = &cli.BoolFlag{
+		Name:               "no-ansi",
+		Destination:        &noANSI,
+		DisableDefaultText: true,
+		Usage:              "Force disable ANSI output",
+	}
+)
+
 type Application struct {
 	instance   *cli.App
 	useArtisan bool
@@ -86,7 +96,7 @@ func (r *Application) CallAndExit(command string) {
 // Run a command. Args come from os.Args.
 func (r *Application) Run(args []string, exitIfArtisan bool) error {
 	if noANSI || env.IsNoANSI() {
-		color.DisableColor()
+		color.Disable()
 	}
 
 	artisanIndex := -1

--- a/console/cli_helper.go
+++ b/console/cli_helper.go
@@ -69,16 +69,6 @@ var colorsFuncMap = template.FuncMap{
 	"yellow":  color.Yellow().Sprint,
 }
 
-var (
-	noANSI     bool
-	noANSIFlag = &cli.BoolFlag{
-		Name:               "no-ansi",
-		Destination:        &noANSI,
-		DisableDefaultText: true,
-		Usage:              "Force disable ANSI output",
-	}
-)
-
 func capitalize(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -286,7 +276,7 @@ func printHelpCustom(out io.Writer, templ string, data interface{}, _ map[string
 	}
 
 	if noANSI || env.IsNoANSI() {
-		color.DisableColor()
+		color.Disable()
 	}
 	err := t.Execute(w, data)
 	if err != nil {

--- a/console/cli_helper.go
+++ b/console/cli_helper.go
@@ -14,6 +14,7 @@ import (
 	"github.com/xrash/smetrics"
 
 	"github.com/goravel/framework/support/color"
+	"github.com/goravel/framework/support/env"
 )
 
 func init() {
@@ -26,15 +27,9 @@ func init() {
 
 const maxLineLength = 10000
 
-var usageTemplate = `{{if .UsageText}}{{wrap (colorize .UsageText) 3}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [options]{{end}}{{if .ArgsUsage}}{{.ArgsUsage}}{{else}}{{if .Args}} [arguments...]{{end}}{{end}}{{end}}`
-var commandTemplate = `{{ $cv := offsetCommands .VisibleCommands 5}}{{range .VisibleCategories}}{{if .Name}}
- {{yellow .Name}}:{{end}}{{range .VisibleCommands}}
-  {{$s := join .Names ", "}}{{green $s}}{{ $sp := subtract $cv (offset $s 3) }}{{ indent $sp ""}}{{wrap (colorize .Usage) $cv}}{{end}}{{end}}`
-
-var flagTemplate = `{{ $cv := offsetFlags .VisibleFlags 5}}{{range  .VisibleFlags}}
-   {{$s := getFlagName .}}{{green $s}}{{ $sp := subtract $cv (offset $s 1) }}{{ indent $sp ""}}{{$us := (capitalize .Usage)}}{{wrap (colorize $us) $cv}}{{$df := getFlagDefaultText . }}{{if $df}} {{yellow $df}}{{end}}{{end}}`
-
-var appHelpTemplate = `{{$v := offset .Usage 6}}{{wrap (colorize .Usage) 3}}{{if .Version}} {{green (wrap .Version $v)}}{{end}}
+// Template for the help message.
+var (
+	appHelpTemplate = `{{$v := offset .Usage 6}}{{wrap (colorize .Usage) 3}}{{if .Version}} {{green (wrap .Version $v)}}{{end}}
 
 {{ yellow "Usage:" }}
    {{if .UsageText}}{{wrap (colorize .UsageText) 3}}{{end}}{{if .VisibleFlags}}
@@ -44,7 +39,7 @@ var appHelpTemplate = `{{$v := offset .Usage 6}}{{wrap (colorize .Usage) 3}}{{if
 {{ yellow "Available commands:" }}{{template "commandTemplate" .}}{{end}}
 `
 
-var commandHelpTemplate = `{{ yellow "Description:" }}
+	commandHelpTemplate = `{{ yellow "Description:" }}
    {{ (colorize .Usage) }}
 
 {{ yellow "Usage:" }}
@@ -52,122 +47,37 @@ var commandHelpTemplate = `{{ yellow "Description:" }}
 
 {{ yellow "Options:" }}{{template "flagTemplate" .}}{{end}}
 `
+	commandTemplate = `{{ $cv := offsetCommands .VisibleCommands 5}}{{range .VisibleCategories}}{{if .Name}}
+ {{yellow .Name}}:{{end}}{{range (sortCommands .VisibleCommands)}}
+  {{$s := join .Names ", "}}{{green $s}}{{ $sp := subtract $cv (offset $s 3) }}{{ indent $sp ""}}{{wrap (colorize .Usage) $cv}}{{end}}{{end}}`
+	flagTemplate = `{{ $cv := offsetFlags .VisibleFlags 5}}{{range  (sortFlags .VisibleFlags)}}
+   {{$s := getFlagName .}}{{green $s}}{{ $sp := subtract $cv (offset $s 1) }}{{ indent $sp ""}}{{$us := (capitalize .Usage)}}{{wrap (colorize $us) $cv}}{{$df := getFlagDefaultText . }}{{if $df}} {{yellow $df}}{{end}}{{end}}`
+	usageTemplate = `{{if .UsageText}}{{wrap (colorize .UsageText) 3}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [options]{{end}}{{if .ArgsUsage}}{{.ArgsUsage}}{{else}}{{if .Args}} [arguments...]{{end}}{{end}}{{end}}`
+)
 
+// colorsFuncMap is a map of functions for coloring text.
 var colorsFuncMap = template.FuncMap{
-	"green":   color.Green().Sprint,
-	"red":     color.Red().Sprint,
-	"blue":    color.Blue().Sprint,
-	"yellow":  color.Yellow().Sprint,
-	"cyan":    color.Cyan().Sprint,
-	"white":   color.White().Sprint,
-	"gray":    color.Gray().Sprint,
-	"default": color.Default().Sprint,
 	"black":   color.Black().Sprint,
+	"blue":    color.Blue().Sprint,
+	"cyan":    color.Cyan().Sprint,
+	"default": color.Default().Sprint,
+	"gray":    color.Gray().Sprint,
+	"green":   color.Green().Sprint,
 	"magenta": color.Magenta().Sprint,
+	"red":     color.Red().Sprint,
+	"white":   color.White().Sprint,
+	"yellow":  color.Yellow().Sprint,
 }
 
-func subtract(a, b int) int {
-	return a - b
-}
-
-func indent(spaces int, v string) string {
-	pad := strings.Repeat(" ", spaces)
-	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
-}
-
-func wrap(input string, offset int) string {
-	var ss []string
-
-	lines := strings.Split(input, "\n")
-
-	padding := strings.Repeat(" ", offset)
-
-	for i, line := range lines {
-		if line == "" {
-			ss = append(ss, line)
-		} else {
-			wrapped := wrapLine(line, offset, padding)
-			if i == 0 {
-				ss = append(ss, wrapped)
-			} else {
-				ss = append(ss, padding+wrapped)
-
-			}
-
-		}
+var (
+	noANSI     bool
+	noANSIFlag = &cli.BoolFlag{
+		Name:               "no-ansi",
+		Destination:        &noANSI,
+		DisableDefaultText: true,
+		Usage:              "Force disable ANSI output",
 	}
-
-	return strings.Join(ss, "\n")
-}
-
-func wrapLine(input string, offset int, padding string) string {
-	if maxLineLength <= offset || len(input) <= maxLineLength-offset {
-		return input
-	}
-
-	lineWidth := maxLineLength - offset
-	words := strings.Fields(input)
-	if len(words) == 0 {
-		return input
-	}
-
-	wrapped := words[0]
-	spaceLeft := lineWidth - len(wrapped)
-	for _, word := range words[1:] {
-		if len(word)+1 > spaceLeft {
-			wrapped += "\n" + padding + word
-			spaceLeft = lineWidth - len(word)
-		} else {
-			wrapped += " " + word
-			spaceLeft -= 1 + len(word)
-		}
-	}
-
-	return wrapped
-}
-
-func offset(input string, fixed int) int {
-	return len(input) + fixed
-}
-
-func offsetCommands(cmd []*cli.Command, fixed int) int {
-	var maxLen = 0
-	for i := range cmd {
-		if s := strings.Join(cmd[i].Names(), ", "); len(s) > maxLen {
-			maxLen = len(s)
-		}
-	}
-	return maxLen + fixed
-}
-
-func offsetFlags(flags []cli.Flag, fixed int) int {
-	var maxLen = 0
-	for i := range flags {
-		if s := cli.FlagNamePrefixer(flags[i].Names(), ""); len(s) > maxLen {
-			maxLen = len(s)
-		}
-	}
-	return maxLen + fixed
-}
-
-func getFlagName(flag cli.DocGenerationFlag) string {
-	names := flag.Names()
-	sort.Slice(names, func(i, j int) bool {
-		return len(names[i]) < len(names[j])
-	})
-
-	return cli.FlagNamePrefixer(names, "")
-}
-
-func getFlagDefaultText(flag cli.DocGenerationFlag) string {
-	defaultValueString := ""
-	if bf, ok := flag.(*cli.BoolFlag); !ok || !bf.DisableDefaultText {
-		if s := flag.GetDefaultText(); s != "" {
-			defaultValueString = fmt.Sprintf(`[default: %s]`, s)
-		}
-	}
-	return defaultValueString
-}
+)
 
 func capitalize(s string) string {
 	s = strings.TrimSpace(s)
@@ -181,56 +91,8 @@ func capitalize(s string) string {
 // support style tags like <fg=red>text</>
 // more details in https://gookit.github.io/color/#/?id=tag-attributes
 func colorize(text string) string {
-    return color.Default().Sprint(text)
+	return color.Default().Sprint(text)
 
-}
-
-func printVersion(ctx *cli.Context) {
-	_, _ = fmt.Fprintf(ctx.App.Writer, "%v %v\n", ctx.App.Usage, color.Green().Sprint(ctx.App.Version))
-}
-
-func printHelpCustom(out io.Writer, templ string, data interface{}, _ map[string]interface{}) {
-
-	funcMap := template.FuncMap{
-		"join":               strings.Join,
-		"subtract":           subtract,
-		"indent":             indent,
-		"trim":               strings.TrimSpace,
-		"capitalize":         capitalize,
-		"wrap":               wrap,
-		"offset":             offset,
-		"offsetCommands":     offsetCommands,
-		"offsetFlags":        offsetFlags,
-		"getFlagName":        getFlagName,
-		"getFlagDefaultText": getFlagDefaultText,
-		"colorize":           colorize,
-	}
-
-	w := tabwriter.NewWriter(out, 1, 8, 2, ' ', 0)
-	t := template.Must(template.New("help").Funcs(funcMap).Funcs(colorsFuncMap).Parse(templ))
-	templates := map[string]string{
-		"usageTemplate":   usageTemplate,
-		"commandTemplate": commandTemplate,
-		"flagTemplate":    flagTemplate,
-	}
-	for name, value := range templates {
-		if _, err := t.New(name).Parse(value); err != nil {
-			if os.Getenv("CLI_TEMPLATE_ERROR_DEBUG") != "" {
-				_, _ = fmt.Fprintf(cli.ErrWriter, "CLI TEMPLATE ERROR: %#v\n", err)
-			}
-		}
-	}
-
-	err := t.Execute(w, data)
-	if err != nil {
-		// If the writer is closed, t.Execute will fail, and there's nothing
-		// we can do to recover.
-		if os.Getenv("CLI_TEMPLATE_ERROR_DEBUG") != "" {
-			_, _ = fmt.Fprintf(cli.ErrWriter, "CLI TEMPLATE ERROR: %#v\n", err)
-		}
-		return
-	}
-	_ = w.Flush()
 }
 
 func commandNotFound(ctx *cli.Context, command string) {
@@ -253,26 +115,6 @@ func commandNotFound(ctx *cli.Context, command string) {
 	}
 	color.Errorln(msgTxt)
 	color.Gray().Println(suggestion)
-}
-
-func onUsageError(_ *cli.Context, err error, _ bool) error {
-	if flag, ok := strings.CutPrefix(err.Error(), "flag provided but not defined: -"); ok {
-		color.Red().Printfln("The '%s' option does not exist.", flag)
-		return nil
-	}
-	if flag, ok := strings.CutPrefix(err.Error(), "flag needs an argument: -"); ok {
-		color.Red().Printfln("The '%s' option requires a value.", flag)
-		return nil
-	}
-	if errMsg := err.Error(); strings.HasPrefix(errMsg, "invalid value") && strings.Contains(errMsg, "for flag -") {
-		var value, flag string
-		if _, parseErr := fmt.Sscanf(errMsg, "invalid value %q for flag -%s", &value, &flag); parseErr == nil {
-			color.Red().Printfln("Invalid value '%s' for option '%s'.", value, strings.TrimSuffix(flag, ":"))
-			return nil
-		}
-	}
-
-	return err
 }
 
 func findAlternatives(name string, collection []string) (result []string) {
@@ -335,4 +177,198 @@ func findAlternatives(name string, collection []string) (result []string) {
 		result = append(result, item.name)
 	}
 	return result
+}
+
+func getFlagDefaultText(flag cli.DocGenerationFlag) string {
+	defaultValueString := ""
+	if bf, ok := flag.(*cli.BoolFlag); !ok || !bf.DisableDefaultText {
+		if s := flag.GetDefaultText(); s != "" {
+			defaultValueString = fmt.Sprintf(`[default: %s]`, s)
+		}
+	}
+	return defaultValueString
+}
+
+func getFlagName(flag cli.DocGenerationFlag) string {
+	names := flag.Names()
+	sort.Slice(names, func(i, j int) bool {
+		return len(names[i]) < len(names[j])
+	})
+	prefixed := cli.FlagNamePrefixer(names, "")
+	// If there is no short name, add some padding to align flag name.
+	if len(names) == 1 {
+		prefixed = "    " + prefixed
+	}
+
+	return prefixed
+}
+
+func indent(spaces int, v string) string {
+	pad := strings.Repeat(" ", spaces)
+	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+}
+
+func offset(input string, fixed int) int {
+	return len(input) + fixed
+}
+
+func offsetCommands(cmd []*cli.Command, fixed int) int {
+	var maxLen = 0
+	for i := range cmd {
+		if s := strings.Join(cmd[i].Names(), ", "); len(s) > maxLen {
+			maxLen = len(s)
+		}
+	}
+	return maxLen + fixed
+}
+
+func offsetFlags(flags []cli.Flag, fixed int) int {
+	var maxLen = 0
+	for i := range flags {
+		if s := cli.FlagNamePrefixer(flags[i].Names(), ""); len(s) > maxLen {
+			maxLen = len(s)
+		}
+	}
+	return maxLen + fixed
+}
+
+func onUsageError(_ *cli.Context, err error, _ bool) error {
+	if flag, ok := strings.CutPrefix(err.Error(), "flag provided but not defined: -"); ok {
+		color.Red().Printfln("The '%s' option does not exist.", flag)
+		return nil
+	}
+	if flag, ok := strings.CutPrefix(err.Error(), "flag needs an argument: -"); ok {
+		color.Red().Printfln("The '%s' option requires a value.", flag)
+		return nil
+	}
+	if errMsg := err.Error(); strings.HasPrefix(errMsg, "invalid value") && strings.Contains(errMsg, "for flag -") {
+		var value, flag string
+		if _, parseErr := fmt.Sscanf(errMsg, "invalid value %q for flag -%s", &value, &flag); parseErr == nil {
+			color.Red().Printfln("Invalid value '%s' for option '%s'.", value, strings.TrimSuffix(flag, ":"))
+			return nil
+		}
+	}
+
+	return err
+}
+
+func printHelpCustom(out io.Writer, templ string, data interface{}, _ map[string]interface{}) {
+	funcMap := template.FuncMap{
+		"capitalize":         capitalize,
+		"colorize":           colorize,
+		"getFlagName":        getFlagName,
+		"getFlagDefaultText": getFlagDefaultText,
+		"indent":             indent,
+		"join":               strings.Join,
+		"offset":             offset,
+		"offsetCommands":     offsetCommands,
+		"offsetFlags":        offsetFlags,
+		"sortFlags":          sortFlags,
+		"sortCommands":       sortCommands,
+		"subtract":           subtract,
+		"trim":               strings.TrimSpace,
+		"wrap":               wrap,
+	}
+
+	w := tabwriter.NewWriter(out, 1, 8, 2, ' ', 0)
+	t := template.Must(template.New("help").Funcs(funcMap).Funcs(colorsFuncMap).Parse(templ))
+	templates := map[string]string{
+		"usageTemplate":   usageTemplate,
+		"commandTemplate": commandTemplate,
+		"flagTemplate":    flagTemplate,
+	}
+	for name, value := range templates {
+		if _, err := t.New(name).Parse(value); err != nil {
+			if os.Getenv("CLI_TEMPLATE_ERROR_DEBUG") != "" {
+				_, _ = fmt.Fprintf(cli.ErrWriter, "CLI TEMPLATE ERROR: %#v\n", err)
+			}
+		}
+	}
+
+	if noANSI || env.IsNoANSI() {
+		color.DisableColor()
+	}
+	err := t.Execute(w, data)
+	if err != nil {
+		// If the writer is closed, t.Execute will fail, and there's nothing
+		// we can do to recover.
+		if os.Getenv("CLI_TEMPLATE_ERROR_DEBUG") != "" {
+			_, _ = fmt.Fprintf(cli.ErrWriter, "CLI TEMPLATE ERROR: %#v\n", err)
+		}
+		return
+	}
+	_ = w.Flush()
+}
+
+func printVersion(ctx *cli.Context) {
+	_, _ = fmt.Fprintf(ctx.App.Writer, "%v %v\n", ctx.App.Usage, color.Green().Sprint(ctx.App.Version))
+}
+
+func sortCommands(commands []*cli.Command) []*cli.Command {
+	sort.Slice(commands, func(i, j int) bool {
+		return strings.Join(commands[i].Names(), ", ") < strings.Join(commands[j].Names(), ", ")
+	})
+	return commands
+}
+
+func sortFlags(flags []cli.Flag) []cli.Flag {
+	sort.Slice(flags, func(i, j int) bool {
+		return cli.FlagNamePrefixer(flags[i].Names(), "") < cli.FlagNamePrefixer(flags[j].Names(), "")
+	})
+	return flags
+}
+
+func subtract(a, b int) int {
+	return a - b
+}
+
+func wrap(input string, offset int) string {
+	var ss []string
+
+	lines := strings.Split(input, "\n")
+
+	padding := strings.Repeat(" ", offset)
+
+	for i, line := range lines {
+		if line == "" {
+			ss = append(ss, line)
+		} else {
+			wrapped := wrapLine(line, offset, padding)
+			if i == 0 {
+				ss = append(ss, wrapped)
+			} else {
+				ss = append(ss, padding+wrapped)
+
+			}
+
+		}
+	}
+
+	return strings.Join(ss, "\n")
+}
+
+func wrapLine(input string, offset int, padding string) string {
+	if maxLineLength <= offset || len(input) <= maxLineLength-offset {
+		return input
+	}
+
+	lineWidth := maxLineLength - offset
+	words := strings.Fields(input)
+	if len(words) == 0 {
+		return input
+	}
+
+	wrapped := words[0]
+	spaceLeft := lineWidth - len(wrapped)
+	for _, word := range words[1:] {
+		if len(word)+1 > spaceLeft {
+			wrapped += "\n" + padding + word
+			spaceLeft = lineWidth - len(word)
+		} else {
+			wrapped += " " + word
+			spaceLeft -= 1 + len(word)
+		}
+	}
+
+	return wrapped
 }

--- a/console/cli_helper_test.go
+++ b/console/cli_helper_test.go
@@ -98,6 +98,20 @@ func TestShowCommandHelp_HelpPrinterCustom(t *testing.T) {
 				color.Red().Sprint("Invalid value 'not-a-number' for option 'int'."),
 			},
 		},
+		{
+			name: "no ansi color",
+			call: "--no-ansi",
+			containsOutput: []string{
+				"test test",
+				`Usage:
+   test
+
+Options:
+   -h, --help       Show help
+       --no-ansi    Force disable ANSI output
+   -v, --version    Print the version`,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/console/console/build_command.go
+++ b/console/console/build_command.go
@@ -34,7 +34,6 @@ func (r *BuildCommand) Description() string {
 // Extend The console command extend.
 func (r *BuildCommand) Extend() command.Extend {
 	return command.Extend{
-		Category: "build",
 		Flags: []command.Flag{
 			&command.StringFlag{
 				Name:    "os",

--- a/contracts/console/command/command.go
+++ b/contracts/console/command/command.go
@@ -24,11 +24,12 @@ type Flag interface {
 }
 
 type BoolFlag struct {
-	Name     string
-	Aliases  []string
-	Usage    string
-	Required bool
-	Value    bool
+	Name               string
+	Aliases            []string
+	DisableDefaultText bool
+	Usage              string
+	Required           bool
+	Value              bool
 }
 
 func (receiver *BoolFlag) Type() string {

--- a/database/console/migration/migrate_command.go
+++ b/database/console/migration/migrate_command.go
@@ -29,9 +29,7 @@ func (r *MigrateCommand) Description() string {
 
 // Extend The console command extend.
 func (r *MigrateCommand) Extend() command.Extend {
-	return command.Extend{
-		Category: "migrate",
-	}
+	return command.Extend{}
 }
 
 // Handle Execute the console command.

--- a/support/color/color.go
+++ b/support/color/color.go
@@ -195,3 +195,8 @@ func CaptureOutput(f func(w io.Writer)) string {
 	outBuf.Reset()
 	return content
 }
+
+// DisableColor disables color output
+func DisableColor() {
+	pterm.DisableColor()
+}

--- a/support/color/color.go
+++ b/support/color/color.go
@@ -196,7 +196,7 @@ func CaptureOutput(f func(w io.Writer)) string {
 	return content
 }
 
-// DisableColor disables color output
-func DisableColor() {
+// Disable disables color output
+func Disable() {
 	pterm.DisableColor()
 }

--- a/support/env/env.go
+++ b/support/env/env.go
@@ -66,6 +66,17 @@ func IsLinux() bool {
 	return runtime.GOOS == "linux"
 }
 
+// IsNoANSI checks if the application is running with the --no-ansi flag.
+func IsNoANSI() bool {
+	for _, arg := range os.Args {
+		if arg == "--no-ansi" {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsTesting checks if the application is running in testing mode.
 func IsTesting() bool {
 	for _, arg := range os.Args {


### PR DESCRIPTION

## 📑 Description

This PR introduces the --no-ansi flag to Artisan commands to disable color output, which is particularly useful for CI environments where colored logs can make parsing more difficult.

In addition to this feature, several other improvements have been made:

- Sorted options and commands: The available options and commands are now sorted for better readability and consistency.

- Command categorization: The build and migrate commands have been moved from their respective categories to the main command group, as they function more like top-level commands rather than subcommands (e.g., make:xxx).

- Code formatting: The code has been formatted, and all variables and functions are now organized in alphabetical order for improved maintainability and clarity.

![before](https://github.com/user-attachments/assets/e8a51a44-0808-4145-95f5-9b7bee5683f5)
![after](https://github.com/user-attachments/assets/5a71cec1-8b7a-47d9-af1e-c2144ff14bf0)


Closes https://github.com/goravel/goravel/issues/592

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a command-line option to disable colored (ANSI) output for a more customizable terminal experience.
	- Improved help and usage displays by sorting commands and flags for clearer, more organized information.
	- Introduced new functions to manage color output and check command-line arguments for enhanced control.
- **Bug Fixes**
	- Enhanced error handling for undefined flags and flags requiring arguments in command-line usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
