### PR TITLE
chore: [#880] Make --no-ansi a global option

### DIFF
--- a/console/application.go
+++ b/console/application.go
@@ -34,6 +34,7 @@ func NewApplication(name, usage, usageText, version string, useArtisan bool) con
 	instance.Name = name
 	instance.Usage = usage
 	instance.UsageText = usageText
+	instance.HelpName = name + " [global options]"
 	instance.Version = version
 	instance.CommandNotFound = commandNotFound
 	instance.OnUsageError = onUsageError
@@ -56,7 +57,7 @@ func (r *Application) Register(commands []console.Command) {
 			},
 			Category:     item.Extend().Category,
 			ArgsUsage:    item.Extend().ArgsUsage,
-			Flags:        append(flagsToCliFlags(item.Extend().Flags), noANSIFlag),
+			Flags:        flagsToCliFlags(item.Extend().Flags),
 			OnUsageError: onUsageError,
 		}
 		r.instance.Commands = append(r.instance.Commands, &cliCommand)

--- a/console/cli_helper.go
+++ b/console/cli_helper.go
@@ -34,7 +34,7 @@ var (
 {{ yellow "Usage:" }}
    {{if .UsageText}}{{wrap (colorize .UsageText) 3}}{{end}}{{if .VisibleFlags}}
 
-{{ yellow "Options:" }}{{template "flagTemplate" .}}{{end}}{{if .VisibleCommands}}
+{{ yellow "Global options:" }}{{template "flagTemplate" .}}{{end}}{{if .VisibleCommands}}
 
 {{ yellow "Available commands:" }}{{template "commandTemplate" .}}{{end}}
 `

--- a/console/cli_helper_test.go
+++ b/console/cli_helper_test.go
@@ -106,7 +106,7 @@ func TestShowCommandHelp_HelpPrinterCustom(t *testing.T) {
 				`Usage:
    test
 
-Options:
+Global options:
    -h, --help       Show help
        --no-ansi    Force disable ANSI output
    -v, --version    Print the version`,

--- a/console/cli_helper_test.go
+++ b/console/cli_helper_test.go
@@ -27,7 +27,7 @@ func TestShowCommandHelp_HelpPrinterCustom(t *testing.T) {
 			name: "print app help",
 			containsOutput: []string{
 				color.Yellow().Sprint("Usage:"),
-				color.Yellow().Sprint("Options:"),
+				color.Yellow().Sprint("Global options:"),
 				color.Yellow().Sprint("Available commands:"),
 				color.Yellow().Sprint("test"),
 				color.Green().Sprint("test:foo"),


### PR DESCRIPTION
## 📑 Description

The Artisan usage format is `artisan [global options] command [options] [arguments...]`, so it makes more sense for `--no-ansi `to be a global option.

![freeze](https://github.com/user-attachments/assets/ed85e742-e5bc-4216-84d5-045423bcdf4c)


Closes https://github.com/goravel/goravel/issues/?

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced CLI help output now displays a "Global options:" label for clearer usage guidance.
- **New Features**
	- Refined command flag handling streamlines behavior for terminal output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
