### PR TITLE
chore: improve flag sorting logic in artisan commands

### DIFF
--- a/console/application.go
+++ b/console/application.go
@@ -20,6 +20,12 @@ var (
 		DisableDefaultText: true,
 		Usage:              "Force disable ANSI output",
 	}
+
+	globalFlags = []cli.Flag{
+		noANSIFlag,
+		cli.HelpFlag,
+		cli.VersionFlag,
+	}
 )
 
 type Application struct {

--- a/console/cli_helper.go
+++ b/console/cli_helper.go
@@ -302,9 +302,30 @@ func sortCommands(commands []*cli.Command) []*cli.Command {
 }
 
 func sortFlags(flags []cli.Flag) []cli.Flag {
+	// built-in flags should be at the end.
+	var (
+		builtinFlags = map[string]struct{}{
+			cli.FlagNamePrefixer(noANSIFlag.Names(), ""):      {},
+			cli.FlagNamePrefixer(cli.HelpFlag.Names(), ""):    {},
+			cli.FlagNamePrefixer(cli.VersionFlag.Names(), ""): {},
+		}
+		isBuiltinFlags = func(n string) bool {
+			_, ok := builtinFlags[n]
+			return ok
+		}
+	)
+
 	sort.Slice(flags, func(i, j int) bool {
-		return cli.FlagNamePrefixer(flags[i].Names(), "") < cli.FlagNamePrefixer(flags[j].Names(), "")
+		a, b := cli.FlagNamePrefixer(flags[i].Names(), ""), cli.FlagNamePrefixer(flags[j].Names(), "")
+		if isBuiltinFlags(a) && !isBuiltinFlags(b) {
+			return false
+		}
+		if !isBuiltinFlags(a) && isBuiltinFlags(b) {
+			return true
+		}
+		return a < b
 	})
+
 	return flags
 }
 
@@ -330,7 +351,6 @@ func wrap(input string, offset int) string {
 				ss = append(ss, padding+wrapped)
 
 			}
-
 		}
 	}
 


### PR DESCRIPTION
## 📑 Description

Ensures that built-in CLI flags are separated from user-defined flags, grouping them distinctly for better organization and clarity in the output.

#### Before:
```shell
go run . new -h
Description:
   Create a new Goravel application

Usage:
   goravel [global options] new [options] [--] <name>

Options:
       --database The database driver your application will use
       --dev      Installs the latest "development" release
   -f, --force    Forces install even if the directory already exists
   -h, --help     Show help
       --http     The HTTP driver your application will use
       --storage  The filesystem module your application will use
```

#### After:

```shell
go run . new -h
Description:
   Create a new Goravel application

Usage:
   goravel [global options] new [options] [--] <name>

Options:
       --database The database driver your application will use
       --dev      Installs the latest "development" release
   -f, --force    Forces install even if the directory already exists
       --http     The HTTP driver your application will use
       --storage  The filesystem module your application will use
   -h, --help     Show help
```

Closes https://github.com/goravel/goravel/issues/?

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved ordering of command-line options. Built-in flags are now consistently shown at the end, enhancing clarity and ease-of-use when reviewing available commands.
	- Added global flags for help and version information, providing users with more options directly through the command-line interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
