### PR TITLE
fix: Problem with submodels id string

### DIFF
--- a/support/database/database.go
+++ b/support/database/database.go
@@ -13,10 +13,6 @@ func GetID(dest any) any {
 	t := reflect.TypeOf(dest)
 	v := reflect.ValueOf(dest)
 
-	if t.Kind() == reflect.Pointer {
-		return GetIDByReflect(t.Elem(), v.Elem())
-	}
-
 	return GetIDByReflect(t, v)
 }
 

--- a/support/database/database.go
+++ b/support/database/database.go
@@ -36,20 +36,7 @@ func GetIDByReflect(t reflect.Type, v reflect.Value) any {
 			return id
 		}
 		if v.Field(i).Type().Kind() == reflect.Struct {
-			structField := v.Field(i).Type()
-			for j := 0; j < structField.NumField(); j++ {
-				if !structField.Field(j).IsExported() {
-					continue
-				}
-				if strings.Contains(structField.Field(j).Tag.Get("gorm"), "primaryKey") {
-					id := v.Field(i).Field(j).Interface()
-					if cast.ToString(id) == "" || cast.ToInt(id) == 0 {
-						return nil
-					}
-
-					return id
-				}
-			}
+			return GetIDByReflect(v.Field(i).Type(), v.Field(i))
 		}
 	}
 

--- a/support/database/database.go
+++ b/support/database/database.go
@@ -35,7 +35,7 @@ func GetIDByReflect(t reflect.Type, v reflect.Value) any {
 
 			return id
 		}
-		if v.Field(i).Type().Kind() == reflect.Struct {
+		if v.Field(i).Type().Kind() == reflect.Struct && t.Field(i).Anonymous {
 			return GetIDByReflect(v.Field(i).Type(), v.Field(i))
 		}
 	}

--- a/support/database/database_test.go
+++ b/support/database/database_test.go
@@ -190,6 +190,48 @@ func TestGetIDByReflect(t *testing.T) {
 				assert.Nil(t, result)
 			},
 		},
+		{
+			description: "TestStruct.ID type Submodel Id String",
+			setup: func(description string) {
+				id := "testId"
+				type User struct {
+					TestStructString
+					Name string
+				}
+
+				ts := User{Name: "name"}
+				ts.ID = "testId"
+				v := reflect.ValueOf(ts)
+				tpe := reflect.TypeOf(ts)
+
+				result := GetIDByReflect(tpe, v)
+
+				assert.Equal(t, id, result)
+			},
+		},
+		{
+			description: "TestStruct.ID type SubSubmodel Id String",
+			setup: func(description string) {
+				id := "testId"
+				type UserFirst struct {
+					TestStructString
+					Name string
+				}
+				type UserSecond struct {
+					UserFirst
+					Avatar string
+				}
+
+				ts := UserSecond{}
+				ts.ID = "testId"
+				v := reflect.ValueOf(ts)
+				tpe := reflect.TypeOf(ts)
+
+				result := GetIDByReflect(tpe, v)
+
+				assert.Equal(t, id, result)
+			},
+		},
 	}
 	for _, test := range tests {
 		test.setup(test.description)

--- a/support/database/database_test.go
+++ b/support/database/database_test.go
@@ -200,7 +200,7 @@ func TestGetIDByReflect(t *testing.T) {
 				}
 
 				ts := User{Name: "name"}
-				ts.ID = "testId"
+				ts.ID = id
 				v := reflect.ValueOf(ts)
 				tpe := reflect.TypeOf(ts)
 
@@ -223,7 +223,7 @@ func TestGetIDByReflect(t *testing.T) {
 				}
 
 				ts := UserSecond{}
-				ts.ID = "testId"
+				ts.ID = id
 				v := reflect.ValueOf(ts)
 				tpe := reflect.TypeOf(ts)
 


### PR DESCRIPTION
## 📑 Description

I found an error while working with the model.
link problem with the GetIDByReflect method. This method does not properly handle submodel with id string. 
Also, this method does not process variants with double nesting.

The problem is here, not in nested fields it works correctly
```
cast.ToString(id) == "" || cast.ToInt(id) == 0
```
The problem with such models

```
type User struct {
   TestStructString
   Name string
}

ts := User{Name: "name"}
ts.ID = "testId"
```

And with nested models

```
type UserFirst struct {
	TestStructString
	Name string
}
type UserSecond struct {
	UserFirst
	Avatar string
}

ts := UserSecond{}
ts.ID = "testId"
```

And I also refactored this method a little
