### PR TITLE
refactor: rename environment file related variables and split `constant.go` file

### DIFF
--- a/auth/console/jwt_secret_command.go
+++ b/auth/console/jwt_secret_command.go
@@ -76,14 +76,14 @@ func (r *JwtSecretCommand) setSecretInEnvironmentFile(key string) error {
 
 // writeNewEnvironmentFileWith Write a new environment file with the given key.
 func (r *JwtSecretCommand) writeNewEnvironmentFileWith(key string) error {
-	content, err := os.ReadFile(support.EnvPath)
+	content, err := os.ReadFile(support.EnvFilePath)
 	if err != nil {
 		return err
 	}
 
 	newContent := strings.Replace(string(content), "JWT_SECRET="+r.config.GetString("jwt.secret"), "JWT_SECRET="+key, 1)
 
-	err = os.WriteFile(support.EnvPath, []byte(newContent), 0644)
+	err = os.WriteFile(support.EnvFilePath, []byte(newContent), 0644)
 	if err != nil {
 		return err
 	}

--- a/auth/console/jwt_secret_command_test.go
+++ b/auth/console/jwt_secret_command_test.go
@@ -20,21 +20,21 @@ func TestJwtSecretCommand(t *testing.T) {
 	mockContext := mocksconsole.NewContext(t)
 	mockContext.EXPECT().Success("Jwt Secret set successfully").Once()
 
-	assert.False(t, file.Exists(support.EnvPath))
-	err := file.PutContent(support.EnvPath, "JWT_SECRET=\n")
+	assert.False(t, file.Exists(support.EnvFilePath))
+	err := file.PutContent(support.EnvFilePath, "JWT_SECRET=\n")
 	assert.NoError(t, err)
 
 	assert.NoError(t, jwtSecretCommand.Handle(mockContext))
 
-	assert.True(t, file.Exists(support.EnvPath))
-	env, err := os.ReadFile(support.EnvPath)
+	assert.True(t, file.Exists(support.EnvFilePath))
+	env, err := os.ReadFile(support.EnvFilePath)
 	assert.NoError(t, err)
 	assert.True(t, len(env) > 10)
-	assert.NoError(t, file.Remove(support.EnvPath))
+	assert.NoError(t, file.Remove(support.EnvFilePath))
 }
 
 func TestJwtSecretCommandWithCustomEnvFile(t *testing.T) {
-	support.EnvPath = "config.conf"
+	support.EnvFilePath = "config.conf"
 
 	mockConfig := mocksconfig.NewConfig(t)
 	mockConfig.EXPECT().GetString("jwt.secret").Return("").Twice()
@@ -55,5 +55,5 @@ func TestJwtSecretCommandWithCustomEnvFile(t *testing.T) {
 	assert.True(t, len(env) > 10)
 	assert.NoError(t, file.Remove("config.conf"))
 
-	support.EnvPath = ".env"
+	support.EnvFilePath = ".env"
 }

--- a/config/application.go
+++ b/config/application.go
@@ -20,14 +20,14 @@ type Application struct {
 	vip *viper.Viper
 }
 
-func NewApplication(envPath string) *Application {
+func NewApplication(EnvFilePath string) *Application {
 	app := &Application{}
 	app.vip = viper.New()
 	app.vip.AutomaticEnv()
 
-	if file.Exists(envPath) {
+	if file.Exists(EnvFilePath) {
 		app.vip.SetConfigType("env")
-		app.vip.SetConfigFile(envPath)
+		app.vip.SetConfigFile(EnvFilePath)
 
 		if err := app.vip.ReadInConfig(); err != nil {
 			color.Errorln("Invalid Config error: " + err.Error())
@@ -36,7 +36,7 @@ func NewApplication(envPath string) *Application {
 	}
 
 	appKey := app.Env("APP_KEY")
-	if !support.DontVerifyEnvFileExists {
+	if !support.EnvFileVerifyExists {
 		if appKey == nil {
 			color.Errorln("Please initialize APP_KEY first.")
 			color.Default().Println("Create a .env file and run command: go run . artisan key:generate")

--- a/config/application.go
+++ b/config/application.go
@@ -20,14 +20,14 @@ type Application struct {
 	vip *viper.Viper
 }
 
-func NewApplication(EnvFilePath string) *Application {
+func NewApplication(envFilePath string) *Application {
 	app := &Application{}
 	app.vip = viper.New()
 	app.vip.AutomaticEnv()
 
-	if file.Exists(EnvFilePath) {
+	if file.Exists(envFilePath) {
 		app.vip.SetConfigType("env")
-		app.vip.SetConfigFile(EnvFilePath)
+		app.vip.SetConfigFile(envFilePath)
 
 		if err := app.vip.ReadInConfig(); err != nil {
 			color.Errorln("Invalid Config error: " + err.Error())

--- a/config/application.go
+++ b/config/application.go
@@ -36,7 +36,7 @@ func NewApplication(envFilePath string) *Application {
 	}
 
 	appKey := app.Env("APP_KEY")
-	if !support.EnvFileVerifyExists {
+	if !support.DontVerifyEnvFileExists {
 		if appKey == nil {
 			color.Errorln("Please initialize APP_KEY first.")
 			color.Default().Println("Create a .env file and run command: go run . artisan key:generate")

--- a/config/application_test.go
+++ b/config/application_test.go
@@ -19,7 +19,7 @@ type ApplicationTestSuite struct {
 }
 
 func TestApplicationTestSuite(t *testing.T) {
-	assert.Nil(t, file.PutContent(support.EnvPath, `
+	assert.Nil(t, file.PutContent(support.EnvFilePath, `
 APP_KEY=12345678901234567890123456789012
 APP_DEBUG=true
 DB_PORT=3306
@@ -42,11 +42,11 @@ FLOAT_VALUE=6.28
 	assert.Nil(t, temp.Close())
 
 	suite.Run(t, &ApplicationTestSuite{
-		config:       NewApplication(support.EnvPath),
+		config:       NewApplication(support.EnvFilePath),
 		customConfig: NewApplication(temp.Name()),
 	})
 
-	assert.Nil(t, file.Remove(support.EnvPath))
+	assert.Nil(t, file.Remove(support.EnvFilePath))
 }
 
 func (s *ApplicationTestSuite) SetupTest() {
@@ -183,7 +183,7 @@ func TestOsVariables(t *testing.T) {
 	assert.Nil(t, os.Setenv("APP_PORT", "3306"))
 	assert.Nil(t, os.Setenv("APP_DEBUG", "true"))
 
-	config := NewApplication(support.EnvPath)
+	config := NewApplication(support.EnvFilePath)
 
 	assert.Equal(t, "12345678901234567890123456789013", config.GetString("APP_KEY"))
 	assert.Equal(t, "goravel", config.GetString("APP_NAME"))

--- a/config/service_provider.go
+++ b/config/service_provider.go
@@ -11,7 +11,7 @@ type ServiceProvider struct {
 
 func (r *ServiceProvider) Register(app foundation.Application) {
 	app.Singleton(contracts.BindingConfig, func(app foundation.Application) (any, error) {
-		return NewApplication(support.EnvPath), nil
+		return NewApplication(support.EnvFilePath), nil
 	})
 }
 

--- a/console/console/key_generate_command.go
+++ b/console/console/key_generate_command.go
@@ -77,14 +77,14 @@ func (r *KeyGenerateCommand) generateRandomKey() string {
 
 // writeNewEnvironmentFileWith Write a new environment file with the given key.
 func (r *KeyGenerateCommand) writeNewEnvironmentFileWith(key string) error {
-	content, err := os.ReadFile(support.EnvPath)
+	content, err := os.ReadFile(support.EnvFilePath)
 	if err != nil {
 		return err
 	}
 
 	newContent := strings.Replace(string(content), "APP_KEY="+r.config.GetString("app.key"), "APP_KEY="+key, 1)
 
-	err = os.WriteFile(support.EnvPath, []byte(newContent), 0644)
+	err = os.WriteFile(support.EnvFilePath, []byte(newContent), 0644)
 	if err != nil {
 		return err
 	}

--- a/console/console/key_generate_command_test.go
+++ b/console/console/key_generate_command_test.go
@@ -26,17 +26,17 @@ func TestKeyGenerateCommand(t *testing.T) {
 		return strings.Contains(s, "open .env:")
 	})).Once()
 
-	assert.False(t, file.Exists(support.EnvPath))
+	assert.False(t, file.Exists(support.EnvFilePath))
 
 	assert.Nil(t, keyGenerateCommand.Handle(mockContext))
 
-	err := file.PutContent(support.EnvPath, "APP_KEY=12345\n")
+	err := file.PutContent(support.EnvFilePath, "APP_KEY=12345\n")
 	assert.Nil(t, err)
 
 	mockContext.EXPECT().Success("Application key set successfully").Once()
 	assert.Nil(t, keyGenerateCommand.Handle(mockContext))
-	assert.True(t, file.Exists(support.EnvPath))
-	env, err := os.ReadFile(support.EnvPath)
+	assert.True(t, file.Exists(support.EnvFilePath))
+	env, err := os.ReadFile(support.EnvFilePath)
 	assert.Nil(t, err)
 	assert.True(t, len(env) > 10)
 
@@ -50,14 +50,14 @@ func TestKeyGenerateCommand(t *testing.T) {
 	mockContext.EXPECT().Error(assert.AnError.Error()).Once()
 	assert.Nil(t, keyGenerateCommand.Handle(mockContext))
 
-	env, err = os.ReadFile(support.EnvPath)
+	env, err = os.ReadFile(support.EnvFilePath)
 	assert.Nil(t, err)
 	assert.True(t, len(env) > 10)
-	assert.Nil(t, file.Remove(support.EnvPath))
+	assert.Nil(t, file.Remove(support.EnvFilePath))
 }
 
 func TestKeyGenerateCommandWithCustomEnvFile(t *testing.T) {
-	support.EnvPath = "config.conf"
+	support.EnvFilePath = "config.conf"
 
 	mockConfig := mocksconfig.NewConfig(t)
 	mockConfig.EXPECT().GetString("app.env").Return("local").Twice()
@@ -93,5 +93,5 @@ func TestKeyGenerateCommandWithCustomEnvFile(t *testing.T) {
 	assert.True(t, len(env) > 10)
 	assert.Nil(t, file.Remove("config.conf"))
 
-	support.EnvPath = ".env"
+	support.EnvFilePath = ".env"
 }

--- a/crypt/aes.go
+++ b/crypt/aes.go
@@ -24,7 +24,7 @@ func NewAES(config config.Config, json foundation.Json) (*AES, error) {
 	key := config.GetString("app.key")
 
 	// Don't use AES in artisan when the key is empty.
-	if support.Env == support.EnvArtisan && len(key) == 0 {
+	if support.RuntimeMode == support.EnvArtisan && len(key) == 0 {
 		return nil, errors.CryptAppKeyNotSet
 	}
 

--- a/crypt/aes.go
+++ b/crypt/aes.go
@@ -24,7 +24,7 @@ func NewAES(config config.Config, json foundation.Json) (*AES, error) {
 	key := config.GetString("app.key")
 
 	// Don't use AES in artisan when the key is empty.
-	if support.RuntimeMode == support.EnvArtisan && len(key) == 0 {
+	if support.RuntimeMode == support.RuntimeArtisan && len(key) == 0 {
 		return nil, errors.CryptAppKeyNotSet
 	}
 

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -278,7 +278,7 @@ func setEnv() {
 			if arg == "artisan" {
 				support.RuntimeMode = support.EnvArtisan
 			}
-			support.EnvFileVerifyExists = slices.Contains(support.EnvFileVerifyWhitelist, arg)
+			support.DontVerifyEnvFileExists = slices.Contains(support.DontVerifyEnvFileWhitelist, arg)
 		}
 	}
 

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -315,34 +315,34 @@ func setRootPath() {
 }
 
 func getEnvFilePath() string {
-	EnvFilePath := ".env"
+	envFilePath := ".env"
 	args := os.Args
 	for index, arg := range args {
 		if strings.HasPrefix(arg, "--env=") {
 			if path := strings.TrimPrefix(arg, "--env="); path != "" {
-				EnvFilePath = path
+				envFilePath = path
 				break
 			}
 		}
 		if strings.HasPrefix(arg, "-env=") {
 			if path := strings.TrimPrefix(arg, "-env="); path != "" {
-				EnvFilePath = path
+				envFilePath = path
 				break
 			}
 		}
 		if strings.HasPrefix(arg, "-e=") {
 			if path := strings.TrimPrefix(arg, "-e="); path != "" {
-				EnvFilePath = path
+				envFilePath = path
 				break
 			}
 		}
 		if arg == "--env" || arg == "-env" || arg == "-e" {
 			if len(args) >= index+1 && !strings.HasPrefix(args[index+1], "-") {
-				EnvFilePath = args[index+1]
+				envFilePath = args[index+1]
 				break
 			}
 		}
 	}
 
-	return EnvFilePath
+	return envFilePath
 }

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -23,7 +23,7 @@ var (
 	App foundation.Application
 )
 
-var _ = flag.String("env", support.EnvPath, "custom .env path")
+var _ = flag.String("env", support.EnvFilePath, "custom .env path")
 
 func init() {
 	setEnv()
@@ -278,11 +278,11 @@ func setEnv() {
 			if arg == "artisan" {
 				support.Env = support.EnvArtisan
 			}
-			support.DontVerifyEnvFileExists = slices.Contains(support.DontVerifyEnvFileWhitelist, arg)
+			support.EnvFileVerifyExists = slices.Contains(support.EnvFileVerifyWhitelist, arg)
 		}
 	}
 
-	env := getEnvPath()
+	env := getEnvFilePath()
 	if support.Env == support.EnvTest {
 		var (
 			relativePath string
@@ -307,42 +307,42 @@ func setEnv() {
 		}
 	}
 
-	support.EnvPath = env
+	support.EnvFilePath = env
 }
 
 func setRootPath() {
 	support.RootPath = env.CurrentAbsolutePath()
 }
 
-func getEnvPath() string {
-	envPath := ".env"
+func getEnvFilePath() string {
+	EnvFilePath := ".env"
 	args := os.Args
 	for index, arg := range args {
 		if strings.HasPrefix(arg, "--env=") {
 			if path := strings.TrimPrefix(arg, "--env="); path != "" {
-				envPath = path
+				EnvFilePath = path
 				break
 			}
 		}
 		if strings.HasPrefix(arg, "-env=") {
 			if path := strings.TrimPrefix(arg, "-env="); path != "" {
-				envPath = path
+				EnvFilePath = path
 				break
 			}
 		}
 		if strings.HasPrefix(arg, "-e=") {
 			if path := strings.TrimPrefix(arg, "-e="); path != "" {
-				envPath = path
+				EnvFilePath = path
 				break
 			}
 		}
 		if arg == "--env" || arg == "-env" || arg == "-e" {
 			if len(args) >= index+1 && !strings.HasPrefix(args[index+1], "-") {
-				envPath = args[index+1]
+				EnvFilePath = args[index+1]
 				break
 			}
 		}
 	}
 
-	return envPath
+	return EnvFilePath
 }

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -271,23 +271,23 @@ func (app *Application) setTimezone() {
 func setEnv() {
 	args := os.Args
 	if strings.HasSuffix(os.Args[0], ".test") || strings.HasSuffix(os.Args[0], ".test.exe") {
-		support.Env = support.EnvTest
+		support.RuntimeMode = support.EnvTest
 	}
 	if len(args) >= 2 {
 		for _, arg := range args[1:] {
 			if arg == "artisan" {
-				support.Env = support.EnvArtisan
+				support.RuntimeMode = support.EnvArtisan
 			}
 			support.EnvFileVerifyExists = slices.Contains(support.EnvFileVerifyWhitelist, arg)
 		}
 	}
 
-	env := getEnvFilePath()
-	if support.Env == support.EnvTest {
+	envPath := getEnvFilePath()
+	if support.RuntimeMode == support.EnvTest {
 		var (
 			relativePath string
 			envExist     bool
-			testEnv      = env
+			testEnv      = envPath
 		)
 
 		for i := 0; i < 50; i++ {
@@ -302,12 +302,12 @@ func setEnv() {
 		}
 
 		if envExist {
-			env = testEnv
+			envPath = testEnv
 			support.RelativePath = relativePath
 		}
 	}
 
-	support.EnvFilePath = env
+	support.EnvFilePath = envPath
 }
 
 func setRootPath() {

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -271,19 +271,19 @@ func (app *Application) setTimezone() {
 func setEnv() {
 	args := os.Args
 	if strings.HasSuffix(os.Args[0], ".test") || strings.HasSuffix(os.Args[0], ".test.exe") {
-		support.RuntimeMode = support.EnvTest
+		support.RuntimeMode = support.RuntimeTest
 	}
 	if len(args) >= 2 {
 		for _, arg := range args[1:] {
 			if arg == "artisan" {
-				support.RuntimeMode = support.EnvArtisan
+				support.RuntimeMode = support.RuntimeArtisan
 			}
 			support.DontVerifyEnvFileExists = slices.Contains(support.DontVerifyEnvFileWhitelist, arg)
 		}
 	}
 
 	envFilePath := getEnvFilePath()
-	if support.RuntimeMode == support.EnvTest {
+	if support.RuntimeMode == support.RuntimeTest {
 		var (
 			relativePath string
 			envExist     bool

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -282,12 +282,12 @@ func setEnv() {
 		}
 	}
 
-	envPath := getEnvFilePath()
+	envFilePath := getEnvFilePath()
 	if support.RuntimeMode == support.EnvTest {
 		var (
 			relativePath string
 			envExist     bool
-			testEnv      = envPath
+			testEnv      = envFilePath
 		)
 
 		for i := 0; i < 50; i++ {
@@ -302,12 +302,12 @@ func setEnv() {
 		}
 
 		if envExist {
-			envPath = testEnv
+			envFilePath = testEnv
 			support.RelativePath = relativePath
 		}
 	}
 
-	support.EnvFilePath = envPath
+	support.EnvFilePath = envFilePath
 }
 
 func setRootPath() {

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -45,11 +45,11 @@ type ApplicationTestSuite struct {
 }
 
 func TestApplicationTestSuite(t *testing.T) {
-	assert.Nil(t, file.PutContent(support.EnvPath, "APP_KEY=12345678901234567890123456789012"))
+	assert.Nil(t, file.PutContent(support.EnvFilePath, "APP_KEY=12345678901234567890123456789012"))
 
 	suite.Run(t, new(ApplicationTestSuite))
 
-	assert.Nil(t, file.Remove(support.EnvPath))
+	assert.Nil(t, file.Remove(support.EnvFilePath))
 }
 
 func (s *ApplicationTestSuite) SetupTest() {

--- a/foundation/console/env_decrypt_command.go
+++ b/foundation/console/env_decrypt_command.go
@@ -55,7 +55,7 @@ func (r *EnvDecryptCommand) Extend() command.Extend {
 // Handle Execute the console command.
 func (r *EnvDecryptCommand) Handle(ctx console.Context) error {
 	key := convert.Default(ctx.Option("key"), os.Getenv("GORAVEL_ENV_ENCRYPTION_KEY"))
-	name := convert.Default(ctx.Option("name"), support.EnvEncryptPath)
+	name := convert.Default(ctx.Option("name"), support.EnvFileEncryptPath)
 	if key == "" {
 		ctx.Error("A decryption key is required.")
 		return nil
@@ -67,7 +67,7 @@ func (r *EnvDecryptCommand) Handle(ctx console.Context) error {
 		return nil
 	}
 
-	if file.Exists(support.EnvPath) {
+	if file.Exists(support.EnvFilePath) {
 		answer, _ := ctx.Confirm("Environment file already exists, are you sure to overwrite?")
 		if !answer {
 			return nil
@@ -80,7 +80,7 @@ func (r *EnvDecryptCommand) Handle(ctx console.Context) error {
 		return nil
 	}
 
-	err = os.WriteFile(support.EnvPath, plaintext, 0644)
+	err = os.WriteFile(support.EnvFilePath, plaintext, 0644)
 	if err != nil {
 		ctx.Error(fmt.Sprintf("Writer error: %v", err))
 		return nil

--- a/foundation/console/env_decrypt_command_test.go
+++ b/foundation/console/env_decrypt_command_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/goravel/framework/support/file"
 )
 
-const EnvDecryptInvalidKey = "xxxx"
-const EnvDecryptValidKey = "BgcELROHL8sAV568T7Fiki7krjLHOkUc"
-const EnvDecryptPlaintext = "APP_KEY=12345"
-const EnvDecryptCiphertext = "QmdjRUxST0hMOHNBVjU2OKtnzDsyCUjWjNdNa2OVn5w="
+const EnvFileDecryptInvalidKey = "xxxx"
+const EnvFileDecryptValidKey = "BgcELROHL8sAV568T7Fiki7krjLHOkUc"
+const EnvFileDecryptPlaintext = "APP_KEY=12345"
+const EnvFileDecryptCiphertext = "QmdjRUxST0hMOHNBVjU2OKtnzDsyCUjWjNdNa2OVn5w="
 
 type EnvDecryptCommandTestSuite struct {
 	suite.Suite
@@ -84,94 +84,94 @@ func (s *EnvDecryptCommandTestSuite) TestHandle() {
 
 	s.Run("empty key", func() {
 		mockContext.EXPECT().Option("key").Return("").Once()
-		mockContext.EXPECT().Option("name").Return(support.EnvEncryptPath).Once()
+		mockContext.EXPECT().Option("name").Return(support.EnvFileEncryptPath).Once()
 		mockContext.EXPECT().Error("A decryption key is required.").Once()
 		s.Nil(cmd.Handle(mockContext))
 	})
 
 	s.Run("invalid key", func() {
-		s.Nil(file.PutContent(support.EnvEncryptPath, EnvDecryptCiphertext))
+		s.Nil(file.PutContent(support.EnvFileEncryptPath, EnvFileDecryptCiphertext))
 		defer func() {
-			s.Nil(file.Remove(support.EnvEncryptPath))
+			s.Nil(file.Remove(support.EnvFileEncryptPath))
 		}()
 
-		mockContext.EXPECT().Option("key").Return(EnvDecryptInvalidKey).Once()
-		mockContext.EXPECT().Option("name").Return(support.EnvEncryptPath).Once()
+		mockContext.EXPECT().Option("key").Return(EnvFileDecryptInvalidKey).Once()
+		mockContext.EXPECT().Option("name").Return(support.EnvFileEncryptPath).Once()
 		mockContext.EXPECT().Error("Decrypt error: crypto/aes: invalid key size 4").Once()
 
 		s.Nil(cmd.Handle(mockContext))
 	})
 
-	s.Run(fmt.Sprintf("%s is not found", support.EnvEncryptPath), func() {
-		mockContext.EXPECT().Option("key").Return(EnvDecryptValidKey).Once()
-		mockContext.EXPECT().Option("name").Return(support.EnvEncryptPath).Once()
+	s.Run(fmt.Sprintf("%s is not found", support.EnvFileEncryptPath), func() {
+		mockContext.EXPECT().Option("key").Return(EnvFileDecryptValidKey).Once()
+		mockContext.EXPECT().Option("name").Return(support.EnvFileEncryptPath).Once()
 		mockContext.EXPECT().Error("Encrypted environment file not found.").Once()
 		s.Nil(cmd.Handle(mockContext))
 	})
 
-	s.Run(fmt.Sprintf("%s exists and confirm failed", support.EnvPath), func() {
-		s.Nil(file.PutContent(support.EnvEncryptPath, EnvDecryptCiphertext))
-		s.Nil(file.PutContent(support.EnvPath, EnvDecryptPlaintext))
+	s.Run(fmt.Sprintf("%s exists and confirm failed", support.EnvFilePath), func() {
+		s.Nil(file.PutContent(support.EnvFileEncryptPath, EnvFileDecryptCiphertext))
+		s.Nil(file.PutContent(support.EnvFilePath, EnvFileDecryptPlaintext))
 		defer func() {
-			s.Nil(file.Remove(support.EnvEncryptPath))
-			s.Nil(file.Remove(support.EnvPath))
+			s.Nil(file.Remove(support.EnvFileEncryptPath))
+			s.Nil(file.Remove(support.EnvFilePath))
 		}()
 
-		mockContext.EXPECT().Option("key").Return(EnvDecryptValidKey).Once()
-		mockContext.EXPECT().Option("name").Return(support.EnvEncryptPath).Once()
+		mockContext.EXPECT().Option("key").Return(EnvFileDecryptValidKey).Once()
+		mockContext.EXPECT().Option("name").Return(support.EnvFileEncryptPath).Once()
 		mockContext.EXPECT().Confirm("Environment file already exists, are you sure to overwrite?").Return(false, nil).Once()
 		s.Nil(cmd.Handle(mockContext))
 	})
 
-	s.Run(fmt.Sprintf("success when %s exists", support.EnvPath), func() {
-		s.Nil(file.PutContent(support.EnvEncryptPath, EnvDecryptCiphertext))
-		s.Nil(file.PutContent(support.EnvPath, EnvDecryptPlaintext))
+	s.Run(fmt.Sprintf("success when %s exists", support.EnvFilePath), func() {
+		s.Nil(file.PutContent(support.EnvFileEncryptPath, EnvFileDecryptCiphertext))
+		s.Nil(file.PutContent(support.EnvFilePath, EnvFileDecryptPlaintext))
 		defer func() {
-			s.Nil(file.Remove(support.EnvPath))
-			s.Nil(file.Remove(support.EnvEncryptPath))
+			s.Nil(file.Remove(support.EnvFilePath))
+			s.Nil(file.Remove(support.EnvFileEncryptPath))
 		}()
 
-		mockContext.EXPECT().Option("key").Return(EnvDecryptValidKey).Once()
-		mockContext.EXPECT().Option("name").Return(support.EnvEncryptPath).Once()
+		mockContext.EXPECT().Option("key").Return(EnvFileDecryptValidKey).Once()
+		mockContext.EXPECT().Option("name").Return(support.EnvFileEncryptPath).Once()
 		mockContext.EXPECT().Confirm("Environment file already exists, are you sure to overwrite?").Return(true, nil).Once()
 		mockContext.EXPECT().Success("Encrypted environment successfully decrypted.").Once()
 
 		s.Nil(cmd.Handle(mockContext))
-		s.True(file.Exists(support.EnvPath))
-		content, err := file.GetContent(support.EnvPath)
+		s.True(file.Exists(support.EnvFilePath))
+		content, err := file.GetContent(support.EnvFilePath)
 		s.Nil(err)
-		s.Equal(EnvDecryptPlaintext, content)
+		s.Equal(EnvFileDecryptPlaintext, content)
 	})
 
-	s.Run(fmt.Sprintf("success when %s not exists", support.EnvPath), func() {
-		s.Nil(file.PutContent(support.EnvEncryptPath, EnvDecryptCiphertext))
+	s.Run(fmt.Sprintf("success when %s not exists", support.EnvFilePath), func() {
+		s.Nil(file.PutContent(support.EnvFileEncryptPath, EnvFileDecryptCiphertext))
 		defer func() {
-			s.Nil(file.Remove(support.EnvEncryptPath))
-			s.Nil(file.Remove(support.EnvPath))
+			s.Nil(file.Remove(support.EnvFileEncryptPath))
+			s.Nil(file.Remove(support.EnvFilePath))
 		}()
 
-		mockContext.EXPECT().Option("key").Return(EnvDecryptValidKey).Once()
-		mockContext.EXPECT().Option("name").Return(support.EnvEncryptPath).Once()
+		mockContext.EXPECT().Option("key").Return(EnvFileDecryptValidKey).Once()
+		mockContext.EXPECT().Option("name").Return(support.EnvFileEncryptPath).Once()
 		mockContext.EXPECT().Success("Encrypted environment successfully decrypted.").Once()
 
 		s.Nil(cmd.Handle(mockContext))
-		s.True(file.Exists(support.EnvPath))
-		content, err := file.GetContent(support.EnvPath)
+		s.True(file.Exists(support.EnvFilePath))
+		content, err := file.GetContent(support.EnvFilePath)
 		s.Nil(err)
-		s.Equal(EnvDecryptPlaintext, content)
+		s.Equal(EnvFileDecryptPlaintext, content)
 	})
 }
 
 func (s *EnvDecryptCommandTestSuite) TestDecrypt() {
 	s.Run("valid key", func() {
-		decrypted, err := NewEnvDecryptCommand().decrypt([]byte(EnvDecryptCiphertext), []byte(EnvDecryptValidKey))
+		decrypted, err := NewEnvDecryptCommand().decrypt([]byte(EnvFileDecryptCiphertext), []byte(EnvFileDecryptValidKey))
 		s.Nil(err)
-		s.Equal(EnvDecryptPlaintext, string(decrypted))
+		s.Equal(EnvFileDecryptPlaintext, string(decrypted))
 		s.Nil(err)
 	})
 
 	s.Run("invalid key", func() {
-		_, err := NewEnvDecryptCommand().decrypt([]byte(EnvDecryptCiphertext), []byte(EnvDecryptInvalidKey))
+		_, err := NewEnvDecryptCommand().decrypt([]byte(EnvFileDecryptCiphertext), []byte(EnvFileDecryptInvalidKey))
 		s.Error(err)
 	})
 }

--- a/foundation/console/env_encrypt_command.go
+++ b/foundation/console/env_encrypt_command.go
@@ -57,8 +57,8 @@ func (r *EnvEncryptCommand) Extend() command.Extend {
 // Handle Execute the console command.
 func (r *EnvEncryptCommand) Handle(ctx console.Context) error {
 	key := convert.Default(ctx.Option("key"), str.Random(32))
-	name := convert.Default(ctx.Option("name"), support.EnvEncryptPath)
-	plaintext, err := os.ReadFile(support.EnvPath)
+	name := convert.Default(ctx.Option("name"), support.EnvFileEncryptPath)
+	plaintext, err := os.ReadFile(support.EnvFilePath)
 	if err != nil {
 		ctx.Error("Environment file not found.")
 		return nil
@@ -85,7 +85,7 @@ func (r *EnvEncryptCommand) Handle(ctx console.Context) error {
 
 	ctx.Success("Environment successfully encrypted.")
 	ctx.TwoColumnDetail("Key", key)
-	ctx.TwoColumnDetail("Cipher", support.EnvEncryptCipher)
+	ctx.TwoColumnDetail("Cipher", support.EnvFileEncryptCipher)
 	ctx.TwoColumnDetail("Encrypted file", name)
 
 	return nil

--- a/foundation/console/env_encrypt_command_test.go
+++ b/foundation/console/env_encrypt_command_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/goravel/framework/support/file"
 )
 
-const EnvEncryptInvalidKey = "xxxx"
-const EnvEncryptValidKey = "BgcELROHL8sAV568T7Fiki7krjLHOkUc"
-const EnvEncryptPlaintext = "APP_KEY=12345"
-const EnvEncryptCiphertext = "QmdjRUxST0hMOHNBVjU2OKtnzDsyCUjWjNdNa2OVn5w="
+const EnvFileEncryptInvalidKey = "xxxx"
+const EnvFileEncryptValidKey = "BgcELROHL8sAV568T7Fiki7krjLHOkUc"
+const EnvFileEncryptPlaintext = "APP_KEY=12345"
+const EnvFileEncryptCiphertext = "QmdjRUxST0hMOHNBVjU2OKtnzDsyCUjWjNdNa2OVn5w="
 
 type EnvEncryptCommandTestSuite struct {
 	suite.Suite
@@ -77,95 +77,95 @@ func (s *EnvEncryptCommandTestSuite) TestHandle() {
 	cmd := NewEnvEncryptCommand()
 	mockContext := mocksconsole.NewContext(s.T())
 
-	s.Run(fmt.Sprintf("%s not exists", support.EnvPath), func() {
-		mockContext.EXPECT().Option("key").Return(EnvEncryptValidKey).Once()
-		mockContext.EXPECT().Option("name").Return(support.EnvEncryptPath).Once()
+	s.Run(fmt.Sprintf("%s not exists", support.EnvFilePath), func() {
+		mockContext.EXPECT().Option("key").Return(EnvFileEncryptValidKey).Once()
+		mockContext.EXPECT().Option("name").Return(support.EnvFileEncryptPath).Once()
 		mockContext.EXPECT().Error("Environment file not found.").Once()
 
 		s.Nil(cmd.Handle(mockContext))
 	})
 
-	s.Run(fmt.Sprintf("%s exists and confirm failed", support.EnvEncryptPath), func() {
-		s.Nil(file.PutContent(support.EnvPath, EnvEncryptPlaintext))
-		s.Nil(file.PutContent(support.EnvEncryptPath, EnvEncryptCiphertext))
+	s.Run(fmt.Sprintf("%s exists and confirm failed", support.EnvFileEncryptPath), func() {
+		s.Nil(file.PutContent(support.EnvFilePath, EnvFileEncryptPlaintext))
+		s.Nil(file.PutContent(support.EnvFileEncryptPath, EnvFileEncryptCiphertext))
 		defer func() {
-			s.Nil(file.Remove(support.EnvPath))
-			s.Nil(file.Remove(support.EnvEncryptPath))
+			s.Nil(file.Remove(support.EnvFilePath))
+			s.Nil(file.Remove(support.EnvFileEncryptPath))
 		}()
 
-		mockContext.EXPECT().Option("key").Return(EnvEncryptValidKey).Once()
-		mockContext.EXPECT().Option("name").Return(support.EnvEncryptPath).Once()
+		mockContext.EXPECT().Option("key").Return(EnvFileEncryptValidKey).Once()
+		mockContext.EXPECT().Option("name").Return(support.EnvFileEncryptPath).Once()
 		mockContext.EXPECT().Confirm("Encrypted environment file already exists, are you sure to overwrite?").Return(false, nil).Once()
 
 		s.Nil(cmd.Handle(mockContext))
 	})
 
 	s.Run("invalid key", func() {
-		s.Nil(file.PutContent(support.EnvPath, EnvEncryptPlaintext))
+		s.Nil(file.PutContent(support.EnvFilePath, EnvFileEncryptPlaintext))
 		defer func() {
-			s.Nil(file.Remove(support.EnvPath))
+			s.Nil(file.Remove(support.EnvFilePath))
 		}()
 
-		mockContext.EXPECT().Option("key").Return(EnvEncryptInvalidKey).Once()
-		mockContext.EXPECT().Option("name").Return(support.EnvEncryptPath).Once()
+		mockContext.EXPECT().Option("key").Return(EnvFileEncryptInvalidKey).Once()
+		mockContext.EXPECT().Option("name").Return(support.EnvFileEncryptPath).Once()
 		mockContext.EXPECT().Error("Encrypt error: crypto/aes: invalid key size 4").Once()
 
 		s.Nil(cmd.Handle(mockContext))
 	})
 
-	s.Run(fmt.Sprintf("success when %s exists", support.EnvEncryptPath), func() {
-		s.Nil(file.PutContent(support.EnvPath, EnvEncryptPlaintext))
-		s.Nil(file.PutContent(support.EnvEncryptPath, EnvEncryptCiphertext))
+	s.Run(fmt.Sprintf("success when %s exists", support.EnvFileEncryptPath), func() {
+		s.Nil(file.PutContent(support.EnvFilePath, EnvFileEncryptPlaintext))
+		s.Nil(file.PutContent(support.EnvFileEncryptPath, EnvFileEncryptCiphertext))
 		defer func() {
-			s.Nil(file.Remove(support.EnvPath))
-			s.Nil(file.Remove(support.EnvEncryptPath))
+			s.Nil(file.Remove(support.EnvFilePath))
+			s.Nil(file.Remove(support.EnvFileEncryptPath))
 		}()
 
-		mockContext.EXPECT().Option("key").Return(EnvEncryptValidKey).Once()
-		mockContext.EXPECT().Option("name").Return(support.EnvEncryptPath).Once()
+		mockContext.EXPECT().Option("key").Return(EnvFileEncryptValidKey).Once()
+		mockContext.EXPECT().Option("name").Return(support.EnvFileEncryptPath).Once()
 		mockContext.EXPECT().Confirm("Encrypted environment file already exists, are you sure to overwrite?").Return(true, nil).Once()
 		mockContext.EXPECT().Success("Environment successfully encrypted.").Once()
-		mockContext.EXPECT().TwoColumnDetail("Key", EnvEncryptValidKey).Once()
-		mockContext.EXPECT().TwoColumnDetail("Cipher", support.EnvEncryptCipher).Once()
+		mockContext.EXPECT().TwoColumnDetail("Key", EnvFileEncryptValidKey).Once()
+		mockContext.EXPECT().TwoColumnDetail("Cipher", support.EnvFileEncryptCipher).Once()
 		mockContext.EXPECT().TwoColumnDetail("Encrypted file", ".env.encrypted").Once()
 
 		s.Nil(cmd.Handle(mockContext))
-		content, err := file.GetContent(support.EnvEncryptPath)
+		content, err := file.GetContent(support.EnvFileEncryptPath)
 		s.Nil(err)
-		s.Equal(EnvEncryptCiphertext, content)
+		s.Equal(EnvFileEncryptCiphertext, content)
 	})
 
-	s.Run(fmt.Sprintf("success when %s not exists", support.EnvEncryptPath), func() {
-		s.Nil(file.PutContent(support.EnvPath, EnvEncryptPlaintext))
+	s.Run(fmt.Sprintf("success when %s not exists", support.EnvFileEncryptPath), func() {
+		s.Nil(file.PutContent(support.EnvFilePath, EnvFileEncryptPlaintext))
 		defer func() {
-			s.Nil(file.Remove(support.EnvPath))
-			s.Nil(file.Remove(support.EnvEncryptPath))
+			s.Nil(file.Remove(support.EnvFilePath))
+			s.Nil(file.Remove(support.EnvFileEncryptPath))
 		}()
 
-		mockContext.EXPECT().Option("key").Return(EnvEncryptValidKey).Once()
-		mockContext.EXPECT().Option("name").Return(support.EnvEncryptPath).Once()
+		mockContext.EXPECT().Option("key").Return(EnvFileEncryptValidKey).Once()
+		mockContext.EXPECT().Option("name").Return(support.EnvFileEncryptPath).Once()
 		mockContext.EXPECT().Success("Environment successfully encrypted.").Once()
-		mockContext.EXPECT().TwoColumnDetail("Key", EnvEncryptValidKey).Once()
-		mockContext.EXPECT().TwoColumnDetail("Cipher", support.EnvEncryptCipher).Once()
-		mockContext.EXPECT().TwoColumnDetail("Encrypted file", support.EnvEncryptPath).Once()
+		mockContext.EXPECT().TwoColumnDetail("Key", EnvFileEncryptValidKey).Once()
+		mockContext.EXPECT().TwoColumnDetail("Cipher", support.EnvFileEncryptCipher).Once()
+		mockContext.EXPECT().TwoColumnDetail("Encrypted file", support.EnvFileEncryptPath).Once()
 
 		s.Nil(cmd.Handle(mockContext))
-		content, err := file.GetContent(support.EnvEncryptPath)
+		content, err := file.GetContent(support.EnvFileEncryptPath)
 		s.Nil(err)
-		s.Equal(EnvEncryptCiphertext, content)
+		s.Equal(EnvFileEncryptCiphertext, content)
 	})
 }
 
 func (s *EnvEncryptCommandTestSuite) TestEncrypt() {
 	s.Run("valid key", func() {
-		ciphertext, err := NewEnvEncryptCommand().encrypt([]byte(EnvEncryptPlaintext), []byte(EnvEncryptValidKey))
+		ciphertext, err := NewEnvEncryptCommand().encrypt([]byte(EnvFileEncryptPlaintext), []byte(EnvFileEncryptValidKey))
 		base64Data := base64.StdEncoding.EncodeToString(ciphertext)
-		s.Equal(EnvEncryptCiphertext, base64Data)
+		s.Equal(EnvFileEncryptCiphertext, base64Data)
 		s.Nil(err)
 	})
 
 	s.Run("invalid key", func() {
-		_, err := NewEnvEncryptCommand().encrypt([]byte(EnvEncryptPlaintext), []byte(EnvEncryptInvalidKey))
+		_, err := NewEnvEncryptCommand().encrypt([]byte(EnvFileEncryptPlaintext), []byte(EnvFileEncryptInvalidKey))
 		s.Error(err)
 	})
 }

--- a/mail/application_test.go
+++ b/mail/application_test.go
@@ -26,7 +26,7 @@ type ApplicationTestSuite struct {
 }
 
 func TestApplicationTestSuite(t *testing.T) {
-	if !file.Exists(support.EnvPath) && os.Getenv("MAIL_HOST") == "" {
+	if !file.Exists(support.EnvFilePath) && os.Getenv("MAIL_HOST") == "" {
 		color.Errorln("No mail tests run, need create .env based on .env.example, then initialize it")
 		return
 	}
@@ -165,9 +165,9 @@ func mockConfig(mailPort int) *configmock.Config {
 	mockConfig.On("GetString", "queue.failed.database").Return("database")
 	mockConfig.On("GetString", "queue.failed.table").Return("failed_jobs")
 
-	if file.Exists(support.EnvPath) {
+	if file.Exists(support.EnvFilePath) {
 		vip := viper.New()
-		vip.SetConfigName(support.EnvPath)
+		vip.SetConfigName(support.EnvFilePath)
 		vip.SetConfigType("env")
 		vip.AddConfigPath(".")
 		_ = vip.ReadInConfig()

--- a/support/constant.go
+++ b/support/constant.go
@@ -3,6 +3,6 @@ package support
 const (
 	Version = "v1.15.3"
 
-	EnvArtisan = "artisan"
-	EnvTest    = "test"
+	RuntimeArtisan = "artisan"
+	RuntimeTest    = "test"
 )

--- a/support/constant.go
+++ b/support/constant.go
@@ -3,19 +3,6 @@ package support
 const Version string = "v1.15.3"
 
 const (
-	EnvRuntime = "runtime"
 	EnvArtisan = "artisan"
 	EnvTest    = "test"
-)
-
-var (
-	RelativePath = ""
-	RootPath     = ""
-
-	Env                    = EnvRuntime
-	EnvFilePath            = ".env"
-	EnvFileEncryptPath     = ".env.encrypted"
-	EnvFileEncryptCipher   = "AES-256-CBC"
-	EnvFileVerifyExists    = false
-	EnvFileVerifyWhitelist = []string{"key:generate", "env:decrypt"}
 )

--- a/support/constant.go
+++ b/support/constant.go
@@ -1,8 +1,8 @@
 package support
 
-const Version string = "v1.15.3"
-
 const (
+	Version = "v1.15.3"
+
 	EnvArtisan = "artisan"
 	EnvTest    = "test"
 )

--- a/support/constant.go
+++ b/support/constant.go
@@ -9,12 +9,13 @@ const (
 )
 
 var (
-	Env                        = EnvRuntime
-	EnvPath                    = ".env"
-	EnvEncryptPath             = ".env.encrypted"
-	EnvEncryptCipher           = "AES-256-CBC"
-	RelativePath               = ""
-	RootPath                   = ""
-	DontVerifyEnvFileExists    = false
-	DontVerifyEnvFileWhitelist = []string{"key:generate", "env:decrypt"}
+	RelativePath = ""
+	RootPath     = ""
+
+	Env                    = EnvRuntime
+	EnvFilePath            = ".env"
+	EnvFileEncryptPath     = ".env.encrypted"
+	EnvFileEncryptCipher   = "AES-256-CBC"
+	EnvFileVerifyExists    = false
+	EnvFileVerifyWhitelist = []string{"key:generate", "env:decrypt"}
 )

--- a/support/file/file_test.go
+++ b/support/file/file_test.go
@@ -16,7 +16,7 @@ func TestClientOriginalExtension(t *testing.T) {
 }
 
 func TestContain(t *testing.T) {
-	assert.True(t, Contain("../constant.go", "const Version"))
+	assert.True(t, Contain("../constant.go", "Version"))
 }
 
 func TestCreate(t *testing.T) {
@@ -72,7 +72,7 @@ func TestGetContent(t *testing.T) {
 	content, err = GetContent("../constant.go")
 	assert.Nil(t, err)
 	assert.NotNil(t, content)
-	assert.Contains(t, content, "const Version")
+	assert.Contains(t, content, "Version")
 }
 
 func TestPutContent(t *testing.T) {

--- a/support/variable.go
+++ b/support/variable.go
@@ -1,0 +1,14 @@
+package support
+
+var (
+	RelativePath = ""
+	RootPath     = ""
+
+	RuntimeMode = ""
+
+	EnvFilePath            = ".env"
+	EnvFileEncryptPath     = ".env.encrypted"
+	EnvFileEncryptCipher   = "AES-256-CBC"
+	EnvFileVerifyExists    = false
+	EnvFileVerifyWhitelist = []string{"key:generate", "env:decrypt"}
+)

--- a/support/variable.go
+++ b/support/variable.go
@@ -6,9 +6,10 @@ var (
 
 	RuntimeMode = ""
 
-	EnvFilePath            = ".env"
-	EnvFileEncryptPath     = ".env.encrypted"
-	EnvFileEncryptCipher   = "AES-256-CBC"
-	EnvFileVerifyExists    = false
-	EnvFileVerifyWhitelist = []string{"key:generate", "env:decrypt"}
+	EnvFilePath          = ".env"
+	EnvFileEncryptPath   = ".env.encrypted"
+	EnvFileEncryptCipher = "AES-256-CBC"
+
+	DontVerifyEnvFileExists    = false
+	DontVerifyEnvFileWhitelist = []string{"key:generate", "env:decrypt"}
 )


### PR DESCRIPTION
## 📑 Description

- split `constant.go` file into `constant.go` and `variable.go`
- rename `support.Env` to `support.RuntimeMode`,
- rename `support.EnvPath` to `support.EnvFilePath`,
- rename `support.EnvEncryptPath` to `support.EnvFileEncryptPath`
- rename `support.EnvEncryptCipher` to `support.EnvFileEncryptCipher`

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Streamlined environment configuration handling and naming conventions to ensure consistent file operations across commands.
  
- **Chores**
  - Removed outdated configuration options and consolidated global settings for environment management.
  - Introduced new variables for environment file paths and encryption settings.

- **Tests**
  - Updated test cases and constants to align with the revised configuration, ensuring accurate and consistent validation.
  - Simplified assertions in test functions to reflect updated content format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
