### PR TITLE
feat: Add Resource Path

### DIFF
--- a/contracts/foundation/application.go
+++ b/contracts/foundation/application.go
@@ -49,6 +49,8 @@ type Application interface {
 	DatabasePath(path ...string) string
 	// StoragePath get the path to the storage directory.
 	StoragePath(path ...string) string
+	// ResourcePath get the path to the resources directory.
+	ResourcePath(path ...string) string
 	// LangPath get the path to the language files.
 	LangPath(path ...string) string
 	// PublicPath get the path to the public directory.

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -95,6 +95,11 @@ func (app *Application) StoragePath(path ...string) string {
 	return app.absPath(path...)
 }
 
+func (app *Application) ResourcePath(path ...string) string {
+	path = append([]string{support.RelativePath, "resources"}, path...)
+	return app.absPath(path...)
+}
+
 func (app *Application) LangPath(path ...string) string {
 	defaultPath := "lang"
 	if configFacade := app.MakeConfig(); configFacade != nil {

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -81,6 +81,10 @@ func (s *ApplicationTestSuite) TestStoragePath() {
 	s.Equal(filepath.Join(support.RootPath, "storage", "goravel.go"), s.app.StoragePath("goravel.go"))
 }
 
+func (s *ApplicationTestSuite) TestResourcePath() {
+	s.Equal(filepath.Join(support.RootPath, "resources", "goravel.go"), s.app.ResourcePath("goravel.go"))
+}
+
 func (s *ApplicationTestSuite) TestLangPath() {
 	mockConfig := mocksconfig.NewConfig(s.T())
 	mockConfig.EXPECT().GetString("app.lang_path", "lang").Return("test").Once()

--- a/mocks/foundation/Application.go
+++ b/mocks/foundation/Application.go
@@ -2384,6 +2384,65 @@ func (_c *Application_StoragePath_Call) RunAndReturn(run func(...string) string)
 	return _c
 }
 
+// ResourcePath provides a mock function with given fields: path
+func (_m *Application) ResourcePath(path ...string) string {
+	_va := make([]interface{}, len(path))
+	for _i := range path {
+		_va[_i] = path[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResourcePath")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(...string) string); ok {
+		r0 = rf(path...)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// Application_ResourcePath_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResourcePath'
+type Application_ResourcePath_Call struct {
+	*mock.Call
+}
+
+// ResourcePath is a helper method to define mock.On call
+//   - path ...string
+func (_e *Application_Expecter) ResourcePath(path ...interface{}) *Application_ResourcePath_Call {
+	return &Application_ResourcePath_Call{Call: _e.mock.On("ResourcePath",
+		append([]interface{}{}, path...)...)}
+}
+
+func (_c *Application_ResourcePath_Call) Run(run func(path ...string)) *Application_ResourcePath_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]string, len(args)-0)
+		for i, a := range args[0:] {
+			if a != nil {
+				variadicArgs[i] = a.(string)
+			}
+		}
+		run(variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Application_ResourcePath_Call) Return(_a0 string) *Application_ResourcePath_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Application_ResourcePath_Call) RunAndReturn(run func(...string) string) *Application_ResourcePath_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Version provides a mock function with no fields
 func (_m *Application) Version() string {
 	ret := _m.Called()

--- a/support/path/path.go
+++ b/support/path/path.go
@@ -24,6 +24,10 @@ func Storage(paths ...string) string {
 	return facades.App().StoragePath(paths...)
 }
 
+func Resource(paths ...string) string {
+	return facades.App().ResourcePath(paths...)
+}
+
 func Lang(paths ...string) string {
 	return facades.App().LangPath(paths...)
 }


### PR DESCRIPTION
## 📑 Description

This PR aims to add the Path Helper function for the resource path which would target the `resources/*` directory.

### Usage
```golang
path.Resource("js/app.js")
```

## ✅ Checks

- [x] Added test cases for my code
