### PR TITLE
feat(orm): add NullableTimestamps and NullableSoftDeletes with pointe…

### DIFF
--- a/database/factory/factory_test.go
+++ b/database/factory/factory_test.go
@@ -13,17 +13,17 @@ import (
 )
 
 type BaseModel struct {
-	ID uint `gorm:"primaryKey" json:"id"`
+	ID uint `gorm:"primaryKey" json:"id" db:"id"`
 	NullableTimestamps
 }
 
 type NullableSoftDeletes struct {
-	DeletedAt *gormio.DeletedAt `gorm:"column:deleted_at" json:"deleted_at"`
+	DeletedAt *gormio.DeletedAt `gorm:"column:deleted_at" json:"deleted_at" db:"deleted_at"`
 }
 
 type NullableTimestamps struct {
-	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at"`
-	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`
+	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at" db:"created_at"`
+	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at" db:"updated_at"`
 }
 
 type User struct {

--- a/database/factory/factory_test.go
+++ b/database/factory/factory_test.go
@@ -12,23 +12,23 @@ import (
 	"github.com/goravel/framework/support/carbon"
 )
 
-type Model struct {
+type BaseModel struct {
 	ID uint `gorm:"primaryKey" json:"id"`
-	Timestamps
+	NullableTimestamps
 }
 
-type SoftDeletes struct {
-	DeletedAt gormio.DeletedAt `gorm:"column:deleted_at" json:"deleted_at"`
+type NullableSoftDeletes struct {
+	DeletedAt *gormio.DeletedAt `gorm:"column:deleted_at" json:"deleted_at"`
 }
 
-type Timestamps struct {
-	CreatedAt carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at"`
-	UpdatedAt carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`
+type NullableTimestamps struct {
+	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at"`
+	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`
 }
 
 type User struct {
-	Model
-	SoftDeletes
+	BaseModel
+	NullableSoftDeletes
 	Name   string
 	Avatar string
 }
@@ -52,7 +52,7 @@ func (u *UserFactory) Definition() map[string]any {
 }
 
 type House struct {
-	Model
+	BaseModel
 	Name          string
 	HouseableID   uint
 	HouseableType string

--- a/database/gorm/event_test.go
+++ b/database/gorm/event_test.go
@@ -12,17 +12,13 @@ import (
 )
 
 type BaseModel struct {
-	ID uint `gorm:"primaryKey" json:"id"`
+	ID uint `gorm:"primaryKey" json:"id" db:"id"`
 	NullableTimestamps
 }
 
-type NullableSoftDeletes struct {
-	DeletedAt *gorm.DeletedAt `gorm:"column:deleted_at" json:"deleted_at"`
-}
-
 type NullableTimestamps struct {
-	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at"`
-	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`
+	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at" db:"created_at"`
+	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at" db:"updated_at"`
 }
 
 type TestEventModel struct {

--- a/database/orm/model.go
+++ b/database/orm/model.go
@@ -27,15 +27,15 @@ type Timestamps struct {
 }
 
 type BaseModel struct {
-	ID uint `gorm:"primaryKey" json:"id"`
+	ID uint `gorm:"primaryKey" json:"id" db:"id"`
 	NullableTimestamps
 }
 
 type NullableSoftDeletes struct {
-	DeletedAt *gorm.DeletedAt `gorm:"column:deleted_at" json:"deleted_at"`
+	DeletedAt *gorm.DeletedAt `gorm:"column:deleted_at" json:"deleted_at" db:"deleted_at"`
 }
 
 type NullableTimestamps struct {
-	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at"`
-	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`
+	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at" db:"created_at"`
+	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at" db:"updated_at"`
 }

--- a/database/orm/model.go
+++ b/database/orm/model.go
@@ -9,16 +9,33 @@ import (
 
 const Associations = clause.Associations
 
+// Deprecated: use BaseModel instead
 type Model struct {
 	ID uint `gorm:"primaryKey" json:"id"`
 	Timestamps
 }
 
+// Deprecated: use NullableSoftDeletes instead
 type SoftDeletes struct {
 	DeletedAt gorm.DeletedAt `gorm:"column:deleted_at" json:"deleted_at"`
 }
 
+// Deprecated: use NullableTimestamps instead
 type Timestamps struct {
 	CreatedAt carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at"`
 	UpdatedAt carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`
+}
+
+type BaseModel struct {
+	ID uint `gorm:"primaryKey" json:"id"`
+	NullableTimestamps
+}
+
+type NullableSoftDeletes struct {
+	DeletedAt *gorm.DeletedAt `gorm:"column:deleted_at" json:"deleted_at"`
+}
+
+type NullableTimestamps struct {
+	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at"`
+	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`
 }

--- a/support/database/database_test.go
+++ b/support/database/database_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/goravel/framework/support/carbon"
 )
 
-type Model struct {
+type BaseModel struct {
 	ID uint `gorm:"primaryKey" json:"id"`
-	Timestamps
+	NullableTimestamps
 }
 
-type Timestamps struct {
-	CreatedAt carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at"`
-	UpdatedAt carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`
+type NullableTimestamps struct {
+	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at"`
+	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`
 }
 
 type TestStruct struct {
@@ -62,7 +62,7 @@ func TestGetID(t *testing.T) {
 			description: "return value with Model",
 			setup: func(description string) {
 				type User struct {
-					Model
+					BaseModel
 					Name   string
 					Avatar string
 				}
@@ -99,7 +99,7 @@ func TestGetID(t *testing.T) {
 			description: "return value with Model",
 			setup: func(description string) {
 				type User struct {
-					Model
+					BaseModel
 					Name   string
 					Avatar string
 				}

--- a/tests/db_test.go
+++ b/tests/db_test.go
@@ -133,18 +133,18 @@ func (s *DBTestSuite) TestCursor() {
 		s.Run(driver, func() {
 			query.DB().Table("products").Insert([]Product{
 				{
-					Name: "cursor_product1", Weight: convert.Pointer(100), Model: Model{
-						Timestamps: Timestamps{
-							CreatedAt: s.now,
-							UpdatedAt: s.now,
+					Name: "cursor_product1", Weight: convert.Pointer(100), BaseModel: BaseModel{
+						NullableTimestamps: NullableTimestamps{
+							CreatedAt: &s.now,
+							UpdatedAt: &s.now,
 						},
 					},
 				},
 				{
-					Name: "cursor_product2", Weight: convert.Pointer(200), Model: Model{
-						Timestamps: Timestamps{
-							CreatedAt: s.now,
-							UpdatedAt: s.now,
+					Name: "cursor_product2", Weight: convert.Pointer(200), BaseModel: BaseModel{
+						NullableTimestamps: NullableTimestamps{
+							CreatedAt: &s.now,
+							UpdatedAt: &s.now,
 						},
 					},
 				},
@@ -425,10 +425,10 @@ func (s *DBTestSuite) TestInsert_First_Get() {
 			s.Run("single struct", func() {
 				result, err := query.DB().Table("products").Insert(Product{
 					Name: "single struct",
-					Model: Model{
-						Timestamps: Timestamps{
-							CreatedAt: s.now,
-							UpdatedAt: s.now,
+					BaseModel: BaseModel{
+						NullableTimestamps: NullableTimestamps{
+							CreatedAt: &s.now,
+							UpdatedAt: &s.now,
 						},
 					},
 				})
@@ -450,10 +450,10 @@ func (s *DBTestSuite) TestInsert_First_Get() {
 				result, err := query.DB().Table("products").Insert([]Product{
 					{
 						Name: "multiple structs1",
-						Model: Model{
-							Timestamps: Timestamps{
-								CreatedAt: s.now,
-								UpdatedAt: s.now,
+						BaseModel: BaseModel{
+							NullableTimestamps: NullableTimestamps{
+								CreatedAt: &s.now,
+								UpdatedAt: &s.now,
 							},
 						},
 					},
@@ -1053,10 +1053,10 @@ func (s *DBTestSuite) TestUpdate_Delete() {
 			result, err := query.DB().Table("products").Insert([]Product{
 				{
 					Name: "update structs1",
-					Model: Model{
-						Timestamps: Timestamps{
-							CreatedAt: s.now,
-							UpdatedAt: s.now,
+					BaseModel: BaseModel{
+						NullableTimestamps: NullableTimestamps{
+							CreatedAt: &s.now,
+							UpdatedAt: &s.now,
 						},
 					},
 				},
@@ -1204,10 +1204,10 @@ func (s *DBTestSuite) TestWhere() {
 		s.Run(driver, func() {
 			query.DB().Table("products").Insert(Product{
 				Name: "where model",
-				Model: Model{
-					Timestamps: Timestamps{
-						CreatedAt: s.now,
-						UpdatedAt: s.now,
+				BaseModel: BaseModel{
+					NullableTimestamps: NullableTimestamps{
+						CreatedAt: &s.now,
+						UpdatedAt: &s.now,
 					},
 				},
 			})

--- a/tests/db_test.go
+++ b/tests/db_test.go
@@ -168,12 +168,12 @@ func (s *DBTestSuite) TestCursor() {
 				s.Equal(2, len(products))
 				s.Equal("cursor_product1", products[0].Name)
 				s.Equal(100, *products[0].Weight)
-				s.Equal(s.now, products[0].CreatedAt)
-				s.Equal(s.now, products[0].UpdatedAt)
+				s.Equal(&s.now, products[0].CreatedAt)
+				s.Equal(&s.now, products[0].UpdatedAt)
 				s.Equal("cursor_product2", products[1].Name)
 				s.Equal(200, *products[1].Weight)
-				s.Equal(s.now, products[1].CreatedAt)
-				s.Equal(s.now, products[1].UpdatedAt)
+				s.Equal(&s.now, products[1].CreatedAt)
+				s.Equal(&s.now, products[1].UpdatedAt)
 			})
 
 			s.Run("Bind Map", func() {
@@ -441,9 +441,11 @@ func (s *DBTestSuite) TestInsert_First_Get() {
 				s.NoError(err)
 				s.True(product.ID > 0)
 				s.Equal("single struct", product.Name)
-				s.Equal(s.now, product.CreatedAt)
-				s.Equal(s.now, product.UpdatedAt)
-				s.False(product.DeletedAt.Valid)
+				s.NotNil(product.CreatedAt)
+				s.Equal(&s.now, product.CreatedAt)
+				s.NotNil(product.UpdatedAt)
+				s.Equal(&s.now, product.UpdatedAt)
+				s.Nil(product.DeletedAt)
 			})
 
 			s.Run("multiple structs", func() {
@@ -485,9 +487,9 @@ func (s *DBTestSuite) TestInsert_First_Get() {
 				err = query.DB().Table("products").Where("name", "single map").Where("deleted_at", nil).First(&product)
 				s.NoError(err)
 				s.Equal("single map", product.Name)
-				s.Equal(s.now, product.CreatedAt)
-				s.Equal(s.now, product.UpdatedAt)
-				s.False(product.DeletedAt.Valid)
+				s.Equal(&s.now, product.CreatedAt)
+				s.Equal(&s.now, product.UpdatedAt)
+				s.Nil(product.DeletedAt)
 			})
 
 			s.Run("multiple map", func() {

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/pterm/pterm v0.12.80 // indirect
-	github.com/redis/go-redis/v9 v9.7.1 // indirect
+	github.com/redis/go-redis/v9 v9.7.3 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/samber/lo v1.49.1 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -191,6 +191,7 @@ github.com/pterm/pterm v0.12.80 h1:mM55B+GnKUnLMUSqhdINe4s6tOuVQIetQ3my8JGyAIg=
 github.com/pterm/pterm v0.12.80/go.mod h1:c6DeF9bSnOSeFPZlfs4ZRAFcf5SCoTwvwQ5xaKGQlHo=
 github.com/redis/go-redis/v9 v9.7.1 h1:4LhKRCIduqXqtvCUlaq9c8bdHOkICjDMrr1+Zb3osAc=
 github.com/redis/go-redis/v9 v9.7.1/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
+github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
 github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -191,6 +191,7 @@ github.com/pterm/pterm v0.12.80 h1:mM55B+GnKUnLMUSqhdINe4s6tOuVQIetQ3my8JGyAIg=
 github.com/pterm/pterm v0.12.80/go.mod h1:c6DeF9bSnOSeFPZlfs4ZRAFcf5SCoTwvwQ5xaKGQlHo=
 github.com/redis/go-redis/v9 v9.7.1 h1:4LhKRCIduqXqtvCUlaq9c8bdHOkICjDMrr1+Zb3osAc=
 github.com/redis/go-redis/v9 v9.7.1/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
+github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/tests/models.go
+++ b/tests/models.go
@@ -17,17 +17,17 @@ type contextKey int
 const testContextKey contextKey = 0
 
 type BaseModel struct {
-	ID uint `gorm:"primaryKey" json:"id"`
+	ID uint `gorm:"primaryKey" json:"id" db:"id"`
 	NullableTimestamps
 }
 
 type NullableSoftDeletes struct {
-	DeletedAt *gorm.DeletedAt `gorm:"column:deleted_at" json:"deleted_at"`
+	DeletedAt *gorm.DeletedAt `gorm:"column:deleted_at" json:"deleted_at " db:"deleted_at"`
 }
 
 type NullableTimestamps struct {
-	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at"`
-	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`
+	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at" db:"created_at"`
+	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at" db:"updated_at"`
 }
 
 type User struct {

--- a/tests/models.go
+++ b/tests/models.go
@@ -16,23 +16,23 @@ type contextKey int
 
 const testContextKey contextKey = 0
 
-type Model struct {
+type BaseModel struct {
 	ID uint `gorm:"primaryKey" json:"id"`
-	Timestamps
+	NullableTimestamps
 }
 
-type SoftDeletes struct {
-	DeletedAt gorm.DeletedAt `gorm:"column:deleted_at" json:"deleted_at" db:"deleted_at"`
+type NullableSoftDeletes struct {
+	DeletedAt *gorm.DeletedAt `gorm:"column:deleted_at" json:"deleted_at"`
 }
 
-type Timestamps struct {
-	CreatedAt carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at" db:"created_at"`
-	UpdatedAt carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at" db:"updated_at"`
+type NullableTimestamps struct {
+	CreatedAt *carbon.DateTime `gorm:"autoCreateTime;column:created_at" json:"created_at"`
+	UpdatedAt *carbon.DateTime `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`
 }
 
 type User struct {
-	Model
-	SoftDeletes
+	BaseModel
+	NullableSoftDeletes
 	Name    string
 	Bio     *string
 	Avatar  string
@@ -379,14 +379,14 @@ func (r *UserFactory) Definition() map[string]any {
 }
 
 type Role struct {
-	Model
+	BaseModel
 	Name   string
 	Avatar string
 	Users  []*User `gorm:"many2many:role_user"`
 }
 
 type Address struct {
-	Model
+	BaseModel
 	UserID   uint
 	Name     string
 	Province string
@@ -394,7 +394,7 @@ type Address struct {
 }
 
 type Book struct {
-	Model
+	BaseModel
 	UserID uint
 	Name   string
 	User   *User
@@ -402,7 +402,7 @@ type Book struct {
 }
 
 type Author struct {
-	Model
+	BaseModel
 	BookID uint   `db:"book_id"`
 	Name   string `db:"name"`
 }
@@ -426,7 +426,7 @@ func (r *AuthorFactory) Definition() map[string]any {
 }
 
 type House struct {
-	Model
+	BaseModel
 	Name          string
 	HouseableID   uint
 	HouseableType string
@@ -437,15 +437,15 @@ func (r *House) Factory() string {
 }
 
 type Phone struct {
-	Model
+	BaseModel
 	Name          string
 	PhoneableID   uint
 	PhoneableType string
 }
 
 type Product struct {
-	Model
-	SoftDeletes
+	BaseModel
+	NullableSoftDeletes
 	Name   string `db:"name"`
 	Weight *int   `db:"weight"`
 	Height *int   `db:"height"`
@@ -456,8 +456,8 @@ func (r *Product) Connection() string {
 }
 
 type Review struct {
-	Model
-	SoftDeletes
+	BaseModel
+	NullableSoftDeletes
 	Body string
 }
 
@@ -466,8 +466,8 @@ func (r *Review) Connection() string {
 }
 
 type People struct {
-	Model
-	SoftDeletes
+	BaseModel
+	NullableSoftDeletes
 	Body string
 }
 
@@ -476,8 +476,8 @@ func (r *People) Connection() string {
 }
 
 type Person struct {
-	Model
-	SoftDeletes
+	BaseModel
+	NullableSoftDeletes
 	Name string
 }
 
@@ -486,8 +486,8 @@ func (r *Person) Connection() string {
 }
 
 type Box struct {
-	Model
-	SoftDeletes
+	BaseModel
+	NullableSoftDeletes
 	Name string
 }
 
@@ -496,7 +496,7 @@ func (r *Box) Connection() string {
 }
 
 type Schema struct {
-	Model
+	BaseModel
 	Name string
 }
 

--- a/tests/models.go
+++ b/tests/models.go
@@ -22,7 +22,7 @@ type BaseModel struct {
 }
 
 type NullableSoftDeletes struct {
-	DeletedAt *gorm.DeletedAt `gorm:"column:deleted_at" json:"deleted_at " db:"deleted_at"`
+	DeletedAt *gorm.DeletedAt `gorm:"column:deleted_at" json:"deleted_at" db:"deleted_at"`
 }
 
 type NullableTimestamps struct {


### PR DESCRIPTION
Closes https://github.com/goravel/goravel/issues/642

This PR introduces new struct definitions `NullableTimestamps` and `NullableSoftDeletes` which use pointer fields for `CreatedAt`, `UpdatedAt`, and `DeletedAt`. These new types improve compatibility with `facades.DB`, which requires fields to be pointers to handle nullability properly.

- Added `NullableTimestamps` and `NullableSoftDeletes` structs
- Created `NullableModel` as an alternative to `Model`
- Marked `Timestamps` and `SoftDeletes` as deprecated
- Updated `structToMap` to handle pointer fields and nil values correctly
- Adjusted tests to handle pointer comparisons with `carbon.DateTime`

This change is backwards compatible and does not affect existing usage with `facades.Orm`.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [X] Added test cases for my code
