### PR TITLE
feat: enhance session manager to support custom drivers

### DIFF
--- a/session/driver/file.go
+++ b/session/driver/file.go
@@ -1,94 +1,214 @@
 package driver
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 
+	sessioncontract "github.com/goravel/framework/contracts/session"
+	"github.com/goravel/framework/facades"
 	"github.com/goravel/framework/support/carbon"
 	"github.com/goravel/framework/support/file"
 )
 
+// File implements the session.Driver interface using the filesystem.
 type File struct {
-	path    string
-	minutes int
-	mu      sync.RWMutex
+	path    string       // Directory where session files are stored
+	minutes int          // Session lifetime in minutes
+	mu      sync.RWMutex // Protects access during file operations
 }
 
-func NewFile(path string, minutes int) *File {
+func newFile(path string, minutes int) (*File, error) {
+	if path == "" {
+		return nil, fmt.Errorf("session file path cannot be empty")
+	}
+
 	return &File{
 		path:    path,
 		minutes: minutes,
+	}, nil
+}
+
+// FileDriverFactory creates an instance of the file session driver using framework config.
+// This function matches the 'func() (session.Driver, error)' signature for config 'via'.
+func FileDriverFactory() (sessioncontract.Driver, error) {
+	config := facades.Config()
+
+	lifetime := config.GetInt("session.lifetime")
+	filesPath := config.GetString("session.files")
+
+	if filesPath == "" {
+		return nil, fmt.Errorf("session.files path is not configured; required for file session driver") // Return error: driver cannot function without a path
 	}
+
+	instance, err := newFile(filesPath, lifetime)
+	if err != nil {
+		return nil, err
+	}
+	return instance, nil
 }
 
 func (f *File) Close() error {
 	return nil
 }
 
+// Destroy removes a session file by its ID.
 func (f *File) Destroy(id string) error {
-	f.mu.Lock()
+	f.mu.Lock() // Exclusive lock for delete operation
 	defer f.mu.Unlock()
 
-	return file.Remove(f.getFilePath(id))
-}
+	if f.path == "" {
 
-func (f *File) Gc(maxLifetime int) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
-	cutoffTime := carbon.Now(carbon.UTC).SubSeconds(maxLifetime)
-
-	if !file.Exists(f.path) {
-		return nil
+		return fmt.Errorf("session path not configured") // Return error
 	}
 
-	return filepath.Walk(f.path, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
+	filePath := f.getFilePath(id)
 
-		if !info.IsDir() && info.ModTime().Before(cutoffTime.StdTime()) {
-			return os.Remove(path)
-		}
+	err := file.Remove(filePath)
+	// Log errors unless the file simply didn't exist
+	if err != nil && !os.IsNotExist(err) {
 
-		return nil
-	})
-}
-
-func (f *File) Open(string, string) error {
+		return fmt.Errorf("failed to destroy session file '%s': %w", id, err)
+	}
 	return nil
 }
 
+// Gc performs garbage collection, removing expired session files.
+func (f *File) Gc(maxLifetime int) error {
+	f.mu.Lock() // Exclusive lock for GC potentially deleting many files
+	defer f.mu.Unlock()
+
+	if f.path == "" {
+
+		return fmt.Errorf("session path not configured") // Return error
+	}
+	if maxLifetime <= 0 {
+
+		return fmt.Errorf("invalid maxLifetime for GC: %d", maxLifetime)
+	}
+
+	cutoffTime := carbon.Now(carbon.UTC).SubSeconds(maxLifetime)
+
+	var filesRemoved int
+	var errorsEncountered int
+
+	err := filepath.Walk(f.path, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			// Log errors during walk (e.g., permissions) and potentially stop
+
+			errorsEncountered++
+			// Decide whether to stop walking on error. Returning the error stops.
+			// Returning nil allows it to potentially continue with other files/subdirs.
+			return nil
+		}
+
+		// Skip the root directory itself and any subdirectories immediately under it.
+		// Session files should be directly in f.path, not in subdirs.
+		if info.IsDir() {
+			if path == f.path {
+				return nil // Allow entering the root directory
+			}
+
+			return filepath.SkipDir
+		}
+
+		//Convert ModTime to utc
+		modTime := info.ModTime().UTC()
+
+		// Check modification time against cutoff for actual files
+		if modTime.Before(cutoffTime.StdTime()) {
+
+			removeErr := os.Remove(path)
+			if removeErr != nil && !os.IsNotExist(removeErr) {
+
+				errorsEncountered++
+				// Continue GC even if one file fails to delete
+			} else if removeErr == nil {
+				filesRemoved++
+			}
+		}
+		return nil // Continue walking
+	})
+
+	// Return the error from filepath.Walk if it terminated due to an issue.
+	if err != nil {
+
+		return fmt.Errorf("session GC failed for path '%s': %w", f.path, err)
+	}
+	return nil
+}
+
+// Open initializes the session driver. No action needed for file driver.
+func (f *File) Open(savePath string, sessionName string) error {
+	return nil
+}
+
+// Read retrieves session data from a file by ID. Returns empty string if not found or expired.
 func (f *File) Read(id string) (string, error) {
-	f.mu.RLock()
+	f.mu.RLock() // Read lock is sufficient
 	defer f.mu.RUnlock()
 
-	path := f.getFilePath(id)
-	if file.Exists(path) {
-		modified, err := file.LastModified(path, carbon.UTC)
+	if f.path == "" {
+
+		// Consistent behavior: return "" and no error if path is missing.
+		return "", nil
+	}
+
+	filePath := f.getFilePath(id)
+
+	// 1. Check existence first (optimization)
+	if !file.Exists(filePath) {
+		return "", nil
+	}
+
+	// 2. Check if expired (based on modification time)
+	if f.minutes > 0 {
+		modified, err := file.LastModified(filePath, carbon.UTC)
 		if err != nil {
-			return "", err
+
+			// Treat as unreadable if mod time fails
+			return "", fmt.Errorf("failed to check session expiry for '%s': %w", id, err)
 		}
-		if modified.After(carbon.Now(carbon.UTC).SubMinutes(f.minutes).StdTime()) {
-			data, err := os.ReadFile(path)
-			if err != nil {
-				return "", err
-			}
-			return string(data), nil
+
+		expiryTime := carbon.Now(carbon.UTC).SubMinutes(f.minutes)
+		if modified.Before(expiryTime.StdTime()) {
+
+			return "", nil
 		}
 	}
 
-	return "", nil
+	// 3. Read the file content
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+
+		return "", fmt.Errorf("failed to read session data for '%s': %w", id, err)
+	}
+
+	return string(data), nil
 }
 
+// Write saves session data to a file by ID.
 func (f *File) Write(id string, data string) error {
-	f.mu.Lock()
+	f.mu.Lock() // Exclusive lock for write operation
 	defer f.mu.Unlock()
 
-	return file.PutContent(f.getFilePath(id), data)
+	if f.path == "" {
+		return fmt.Errorf("cannot write session file: session path is not configured")
+	}
+
+	filePath := f.getFilePath(id)
+
+	err := file.PutContent(filePath, data)
+	if err != nil {
+		return fmt.Errorf("failed to write session data for '%s': %w", id, err)
+	}
+	return nil
 }
 
 func (f *File) getFilePath(id string) string {
 	return filepath.Join(f.path, id)
 }
+
+// Ensure File implements the Driver interface at compile time.
+var _ sessioncontract.Driver = (*File)(nil)

--- a/session/driver/file_test.go
+++ b/session/driver/file_test.go
@@ -1,12 +1,14 @@
 package driver
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
+	sessioncontract "github.com/goravel/framework/contracts/session"
 	"github.com/goravel/framework/support/carbon"
 	"github.com/goravel/framework/support/file"
+	"github.com/stretchr/testify/suite"
 )
 
 type FileTestSuite struct {
@@ -17,12 +19,28 @@ func TestFileTestSuite(t *testing.T) {
 	suite.Run(t, &FileTestSuite{})
 }
 
-func (f *FileTestSuite) BeforeTest() {
-	f.Nil(file.Remove(f.getPath()))
+func (f *FileTestSuite) BeforeTest(suiteName, testName string) {
+
+	err := file.Remove(f.getPath())
+
+	f.Require().True(err == nil || os.IsNotExist(err), "Failed to clean test directory '%s' before test: %v", f.getPath(), err)
+}
+
+func (f *FileTestSuite) AfterTest(suiteName, testName string) {
+	err := file.Remove(f.getPath())
+	f.Require().True(err == nil || os.IsNotExist(err), "Failed to clean test directory '%s' after test: %v", f.getPath(), err)
+}
+
+func (f *FileTestSuite) TestNewFile_EmptyPathError() {
+	driver, err := newFile("", f.getMinutes())
+	f.Error(err, "newFile should return error for empty path")
+	f.Nil(driver, "Driver should be nil on error")
+	f.Contains(err.Error(), "session file path cannot be empty", "Error message mismatch")
 }
 
 func (f *FileTestSuite) TestClose() {
 	driver := f.getDriver()
+	f.Require().NotNil(driver)
 	f.Nil(driver.Close())
 }
 
@@ -45,97 +63,147 @@ func (f *FileTestSuite) TestDestroy() {
 
 func (f *FileTestSuite) TestGc() {
 	driver := f.getDriver()
+	f.Require().NotNil(driver)
+	lifetimeSeconds := f.getMinutes() * 60
 
-	f.Nil(driver.Gc(300))
+	sessionIDValid := "gc_valid_session"
+	f.Nil(driver.Write(sessionIDValid, "this session should survive gc"))
 
-	f.Nil(driver.Write("foo", "bar"))
-	f.Nil(driver.Gc(300))
-	value, err := driver.Read("foo")
-	f.Nil(err)
-	f.Equal("bar", value)
+	f.Nil(driver.Gc(lifetimeSeconds))
 
-	carbon.SetTestNow(carbon.Now(carbon.UTC).AddMinutes(5).AddSecond())
-	f.Nil(driver.Gc(300))
+	valueValid, errValid := driver.Read(sessionIDValid)
+	f.Nil(errValid)
+	f.Equal("this session should survive gc", valueValid, "Valid session removed by GC")
 
-	value, err = driver.Read("foo")
-	f.Nil(err)
-	f.Equal("", value)
-	carbon.UnsetTestNow()
+	sessionIDExpired := "gc_expired_session"
+	f.Nil(driver.Write(sessionIDExpired, "this session should be removed by gc"))
+	f.True(file.Exists(filepath.Join(f.getPath(), sessionIDValid)), "Expired session file missing after GC")
 
-	// file does not exist
-	driver = NewFile("foo", 300)
-	f.Nil(driver.Gc(300))
+	carbon.SetTestNow(carbon.Now(carbon.UTC).AddMinutes(f.getMinutes()).AddMinutes(20))
+	defer carbon.UnsetTestNow()
+
+	f.Nil(driver.Gc(lifetimeSeconds))
+
+	valueExpired, errExpired := driver.Read(sessionIDExpired)
+	f.Nil(errExpired, "Read on GC'd session should not error")
+	f.Equal("", valueExpired, "Expired session not removed by GC")
+	f.False(file.Exists(filepath.Join(f.getPath(), sessionIDExpired)), "Valid session file still exists after GC")
+}
+
+func (f *FileTestSuite) TestGc_NonExistentPath() {
+	driver := f.getDriver()
+	f.Require().NotNil(driver)
+	lifetimeSeconds := f.getMinutes() * 60
+
+	err := file.Remove(f.getPath())
+	f.Require().True(err == nil || os.IsNotExist(err), "Failed to remove test directory during test setup")
+	f.False(file.Exists(f.getPath()), "Test directory should be gone before calling Gc")
+
+	gcErr := driver.Gc(lifetimeSeconds)
+	f.Nil(gcErr, "Gc should not return error for non-existent base path")
 }
 
 func (f *FileTestSuite) TestOpen() {
 	driver := f.getDriver()
+	f.Require().NotNil(driver)
 	f.Nil(driver.Open("", ""))
 }
 
 func (f *FileTestSuite) TestRead() {
 	driver := f.getDriver()
-	f.Nil(driver.Write("foo", "bar"))
+	f.Require().NotNil(driver)
+	sessionID := "read_test_session"
+	sessionData := "data to be read"
 
-	value, err := driver.Read("foo")
+	value, err := driver.Read("read_non_existent")
 	f.Nil(err)
-	f.Equal("bar", value)
+	f.Equal("", value, "Reading non-existent session should return empty string")
 
-	carbon.SetTestNow(carbon.Now(carbon.UTC).AddMinutes(f.getMinutes()).SubSecond())
-	value, err = driver.Read("foo")
+	f.Nil(driver.Write(sessionID, sessionData))
+	value, err = driver.Read(sessionID)
 	f.Nil(err)
-	f.Equal("bar", value)
+	f.Equal(sessionData, value, "Failed to read back recently written data")
+
+	carbon.SetTestNow(carbon.Now(carbon.UTC).AddMinutes(f.getMinutes()).AddSeconds(-1))
+	value, err = driver.Read(sessionID)
+	f.Nil(err)
+	f.Equal(sessionData, value, "Session expired too early")
 	carbon.UnsetTestNow()
 
-	carbon.SetTestNow(carbon.Now(carbon.UTC).AddMinutes(f.getMinutes()).AddSecond())
-	value, err = driver.Read("foo")
-	f.Nil(err)
-	f.Equal("", value)
+	carbon.SetTestNow(carbon.Now(carbon.UTC).AddMinutes(f.getMinutes()).AddSeconds(1))
+	value, err = driver.Read(sessionID)
+	f.Nil(err, "Read on expired session should not error")
+	f.Equal("", value, "Session did not expire correctly")
 	carbon.UnsetTestNow()
 }
 
 func (f *FileTestSuite) TestWrite() {
 	driver := f.getDriver()
-	f.Nil(driver.Write("foo", "bar"))
-	value, err := driver.Read("foo")
-	f.Nil(err)
-	f.Equal("bar", value)
+	f.Require().NotNil(driver)
+	sessionID := "write_test_session"
 
-	f.Nil(driver.Write("foo", "qux"))
-	value, err = driver.Read("foo")
+	f.Nil(driver.Write(sessionID, "initial data"))
+	value, err := driver.Read(sessionID)
 	f.Nil(err)
-	f.Equal("qux", value)
+	f.Equal("initial data", value)
 
-	f.Nil(file.Remove(f.getPath()))
+	f.True(file.Exists(filepath.Join(f.getPath(), sessionID)))
+
+	f.Nil(driver.Write(sessionID, "overwritten data"))
+	value, err = driver.Read(sessionID)
+	f.Nil(err)
+	f.Equal("overwritten data", value)
 }
 
 func BenchmarkFile_ReadWrite(b *testing.B) {
+
 	f := new(FileTestSuite)
 	f.SetT(&testing.T{})
+	f.BeforeTest("", "")
 
 	driver := f.getDriver()
-	f.Nil(driver.Write("foo", "bar"))
+	require := f.Require()
+	require.NotNil(driver)
+
+	sessionID := "bench_session_id"
+	sessionData := "benchmark data"
+
+	err := driver.Write(sessionID, sessionData)
+	require.Nil(err)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		f.Nil(driver.Write("foo", "bar"))
 
-		value, err := driver.Read("foo")
-		f.Nil(err)
-		f.Equal("bar", value)
+		errWrite := driver.Write(sessionID, sessionData)
+		if errWrite != nil {
+			b.Fatalf("Write failed during benchmark: %v", errWrite)
+		}
+
+		value, errRead := driver.Read(sessionID)
+		if errRead != nil {
+			b.Fatalf("Read failed during benchmark: %v", errRead)
+		}
+		if value != sessionData {
+			b.Fatalf("Read returned incorrect data during benchmark: got %s, want %s", value, sessionData)
+		}
 	}
 	b.StopTimer()
 
-	f.BeforeTest()
 }
 
-func (f *FileTestSuite) getDriver() *File {
-	return NewFile(f.getPath(), f.getMinutes())
+func (f *FileTestSuite) getDriver() sessioncontract.Driver {
+	driver, err := newFile(f.getPath(), f.getMinutes())
+
+	f.Require().NoError(err, "Failed to create file driver for test")
+	f.Require().NotNil(driver, "Created driver is nil")
+	return driver
 }
 
 func (f *FileTestSuite) getPath() string {
-	return "test"
+
+	return "storage/framework/sessions_test"
 }
 
 func (f *FileTestSuite) getMinutes() int {
-	return 10
+	return 5
 }

--- a/session/manager.go
+++ b/session/manager.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -8,29 +9,139 @@ import (
 	"github.com/goravel/framework/contracts/foundation"
 	sessioncontract "github.com/goravel/framework/contracts/session"
 	"github.com/goravel/framework/errors"
-	"github.com/goravel/framework/session/driver"
 	"github.com/goravel/framework/support/color"
 )
 
 type Manager struct {
 	config      config.Config
 	drivers     map[string]sessioncontract.Driver
+	factories   map[string]func() sessioncontract.Driver
 	json        foundation.Json
 	sessionPool sync.Pool
+	mu          sync.RWMutex
 }
 
 func NewManager(config config.Config, json foundation.Json) *Manager {
 	manager := &Manager{
-		config:  config,
-		drivers: make(map[string]sessioncontract.Driver),
-		json:    json,
+		config:    config,
+		drivers:   make(map[string]sessioncontract.Driver),
+		factories: make(map[string]func() sessioncontract.Driver),
+		json:      json,
 		sessionPool: sync.Pool{New: func() any {
 			return NewSession("", nil, json)
 		},
 		},
 	}
-	manager.extendDefaultDrivers()
+	// Reads config ONLY to find drivers.
+	manager.registerConfiguredDrivers()
 	return manager
+}
+
+// Driver retrieves the session driver factory by name and instantiates if needed.
+func (m *Manager) Driver(name ...string) (sessioncontract.Driver, error) {
+	driverName := m.getDefaultDriver()
+	if len(name) > 0 && name[0] != "" {
+		driverName = name[0]
+	}
+
+	if driverName == "" {
+		return nil, errors.SessionDriverIsNotSet
+	}
+
+	// Check instance cache first
+	m.mu.RLock()
+	driverInstance, instanceExists := m.drivers[driverName]
+	m.mu.RUnlock()
+	if instanceExists {
+		return driverInstance, nil
+	}
+
+	// Resolve factory
+	m.mu.RLock()
+	factory, factoryExists := m.factories[driverName]
+	m.mu.RUnlock()
+
+	if !factoryExists {
+		return nil, errors.SessionDriverNotSupported.Args(driverName)
+	}
+
+	// Instantiate using factory (with lock)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Double-check instance existence after acquiring lock
+	driverInstance, instanceExists = m.drivers[driverName]
+	if instanceExists {
+		return driverInstance, nil
+	}
+
+	driverInstance = factory()
+	if driverInstance == nil {
+		return nil, errors.New(fmt.Sprintf("Session driver %s factory returned nil", driverName))
+	}
+
+	m.drivers[driverName] = driverInstance
+	m.startGcTimer(driverInstance) // Start GC for the new instance
+
+	return driverInstance, nil
+}
+
+// Extend registers a factory function for a given driver name.
+func (m *Manager) Extend(driver string, factory func() sessioncontract.Driver) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.factories[driver]; exists {
+		return errors.SessionDriverAlreadyExists.Args(driver)
+	}
+	m.factories[driver] = factory
+	return nil
+}
+
+// registerConfiguredDrivers ONLY reads from config.
+func (m *Manager) registerConfiguredDrivers() {
+	configuredDrivers := m.config.Get("session.drivers", map[string]any{})
+	driversMap, ok := configuredDrivers.(map[string]any)
+	if !ok {
+		return
+	}
+	for name, driverConfigAny := range driversMap {
+		driverConfig, ok := driverConfigAny.(map[string]any)
+		if !ok {
+
+			continue
+		}
+
+		viaFactoryAny, exists := driverConfig["via"]
+		if !exists {
+
+			continue
+		}
+
+		// Factory from config: func() (sessioncontract.Driver, error)
+		viaFactoryWithError, ok := viaFactoryAny.(func() (sessioncontract.Driver, error))
+		if !ok {
+
+			continue
+		}
+
+		// Wrapper for Extend signature: func() sessioncontract.Driver
+		factoryWrapper := func() sessioncontract.Driver {
+			driverInstance, err := viaFactoryWithError()
+			if err != nil {
+
+				return nil
+			}
+			if driverInstance == nil {
+
+				return nil
+			}
+			return driverInstance
+		}
+
+		// Register using Extend. Errors logged internally by Extend.
+		_ = m.Extend(name, factoryWrapper)
+	}
 }
 
 func (m *Manager) BuildSession(handler sessioncontract.Driver, sessionID ...string) (sessioncontract.Session, error) {
@@ -51,34 +162,6 @@ func (m *Manager) BuildSession(handler sessioncontract.Driver, sessionID ...stri
 	return session, nil
 }
 
-func (m *Manager) Driver(name ...string) (sessioncontract.Driver, error) {
-	var driverName string
-	if len(name) > 0 {
-		driverName = name[0]
-	} else {
-		driverName = m.getDefaultDriver()
-	}
-
-	if driverName == "" {
-		return nil, errors.SessionDriverIsNotSet
-	}
-
-	if m.drivers[driverName] == nil {
-		return nil, errors.SessionDriverNotSupported.Args(driverName)
-	}
-
-	return m.drivers[driverName], nil
-}
-
-func (m *Manager) Extend(driver string, handler func() sessioncontract.Driver) error {
-	if m.drivers[driver] != nil {
-		return errors.SessionDriverAlreadyExists.Args(driver)
-	}
-	m.drivers[driver] = handler()
-	m.startGcTimer(m.drivers[driver])
-	return nil
-}
-
 func (m *Manager) ReleaseSession(session sessioncontract.Session) {
 	session.Flush().
 		SetDriver(nil).
@@ -92,24 +175,14 @@ func (m *Manager) acquireSession() sessioncontract.Session {
 	return session
 }
 
+// getDefaultDriver reads the default driver name from config.
 func (m *Manager) getDefaultDriver() string {
 	return m.config.GetString("session.driver")
 }
 
-func (m *Manager) extendDefaultDrivers() {
-	if err := m.Extend("file", m.createFileDriver); err != nil {
-		panic(errors.SessionDriverExtensionFailed.SetModule(errors.ModuleSession).Args("file", err))
-	}
-}
-
-func (m *Manager) createFileDriver() sessioncontract.Driver {
-	lifetime := m.config.GetInt("session.lifetime")
-	return driver.NewFile(m.config.GetString("session.files"), lifetime)
-}
-
-// startGcTimer starts a garbage collection timer for the session driver.
-func (m *Manager) startGcTimer(driver sessioncontract.Driver) {
-	interval := m.config.GetInt("session.gc_interval", 30)
+// startGcTimer remains (it operates on the Driver interface).
+func (m *Manager) startGcTimer(driverInstance sessioncontract.Driver) {
+	interval := m.config.GetInt("session.gc_interval")
 	if interval <= 0 {
 		// No need to start the timer if the interval is zero or negative
 		return
@@ -120,9 +193,12 @@ func (m *Manager) startGcTimer(driver sessioncontract.Driver) {
 	go func() {
 		for range ticker.C {
 			lifetime := ConfigFacade.GetInt("session.lifetime") * 60
-			if err := driver.Gc(lifetime); err != nil {
+			if err := driverInstance.Gc(lifetime); err != nil {
 				color.Errorf("Error performing garbage collection: %s\n", err)
 			}
 		}
 	}()
 }
+
+// Ensure interface implementation
+var _ sessioncontract.Manager = (*Manager)(nil)

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -2,9 +2,9 @@ package session
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goravel/framework/contracts/foundation"
@@ -12,14 +12,65 @@ import (
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/foundation/json"
 	mockconfig "github.com/goravel/framework/mocks/config"
-	"github.com/goravel/framework/support/str"
 )
+
+type MockSessionDriver struct {
+	mock.Mock
+}
+
+func (m *MockSessionDriver) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+func (m *MockSessionDriver) Destroy(id string) error {
+	args := m.Called(id)
+	return args.Error(0)
+}
+func (m *MockSessionDriver) Gc(maxLifetime int) error {
+	args := m.Called(maxLifetime)
+	return args.Error(0)
+}
+func (m *MockSessionDriver) Open(path string, name string) error {
+	args := m.Called(path, name)
+	return args.Error(0)
+}
+func (m *MockSessionDriver) Read(id string) (string, error) {
+	args := m.Called(id)
+	return args.String(0), args.Error(1)
+}
+func (m *MockSessionDriver) Write(id string, data string) error {
+	args := m.Called(id, data)
+	return args.Error(0)
+}
+
+func MockDriverFactory(mockDriverInstance *MockSessionDriver) func() (sessioncontract.Driver, error) {
+	return func() (sessioncontract.Driver, error) {
+		if mockDriverInstance == nil {
+			return nil, fmt.Errorf("mock driver instance not provided to factory")
+		}
+		return mockDriverInstance, nil
+	}
+}
+
+type CustomDriver struct{}
+
+func NewCustomDriver() (sessioncontract.Driver, error) {
+	return &CustomDriver{}, nil
+}
+func (c *CustomDriver) Close() error                { return nil }
+func (c *CustomDriver) Destroy(string) error        { return nil }
+func (c *CustomDriver) Gc(int) error                { return nil }
+func (c *CustomDriver) Open(string, string) error   { return nil }
+func (c *CustomDriver) Read(string) (string, error) { return "", nil }
+func (c *CustomDriver) Write(string, string) error  { return nil }
 
 type ManagerTestSuite struct {
 	suite.Suite
-	mockConfig *mockconfig.Config
-	manager    *Manager
-	json       foundation.Json
+	mockConfig        *mockconfig.Config
+	manager           *Manager
+	json              foundation.Json
+	mockFileDriver    *MockSessionDriver
+	mockFileDriverVia func() (sessioncontract.Driver, error)
 }
 
 func TestManagerTestSuite(t *testing.T) {
@@ -28,173 +79,197 @@ func TestManagerTestSuite(t *testing.T) {
 
 func (s *ManagerTestSuite) SetupTest() {
 	s.mockConfig = mockconfig.NewConfig(s.T())
-	s.mockConfig.On("GetInt", "session.lifetime").Return(120).Once()
-	s.mockConfig.On("GetInt", "session.gc_interval", 30).Return(30).Once()
-	s.mockConfig.On("GetString", "session.files").Return("storage/framework/sessions").Once()
-	s.manager = s.getManager()
 	s.json = json.NewJson()
+	s.mockFileDriver = new(MockSessionDriver)
+	s.mockFileDriverVia = MockDriverFactory(s.mockFileDriver)
+
+	s.mockConfig.On("Get", "session.drivers", mock.AnythingOfType("map[string]interface {}")).Return(
+
+		map[string]any{
+			"file": map[string]any{
+				"via": s.mockFileDriverVia,
+			},
+		},
+	).Maybe()
+
+	s.manager = NewManager(s.mockConfig, s.json)
+	s.Require().NotNil(s.manager)
+
 }
 
-func (s *ManagerTestSuite) TearDownSuite() {
+func (s *ManagerTestSuite) TearDownTest() {
 	s.mockConfig.AssertExpectations(s.T())
+
 }
 
-func (s *ManagerTestSuite) TestDriver() {
-	// provide driver name
+func (s *ManagerTestSuite) TestDriver_ResolveConfiguredFileDriver() {
+
+	s.mockConfig.On("GetString", "session.driver").Return("file").Maybe()
+	s.mockConfig.On("GetInt", "session.gc_interval").Return(30).Maybe()
+
 	driver, err := s.manager.Driver("file")
 	s.Nil(err)
 	s.NotNil(driver)
-	s.Equal("*driver.File", fmt.Sprintf("%T", driver))
 
-	// provide no driver name
+	s.Equal(s.mockFileDriver, driver)
+}
+
+func (s *ManagerTestSuite) TestDriver_ResolveDefaultDriver() {
+
+	s.mockConfig.ExpectedCalls = nil
 	s.mockConfig.On("GetString", "session.driver").Return("file").Once()
+	s.mockConfig.On("GetInt", "session.gc_interval").Return(30).Once()
 
-	driver, err = s.manager.Driver()
+	driver, err := s.manager.Driver()
 	s.Nil(err)
 	s.NotNil(driver)
-	s.Equal("*driver.File", fmt.Sprintf("%T", driver))
+	s.Equal(s.mockFileDriver, driver)
+}
 
-	// provide custom driver
-	s.mockConfig.On("GetInt", "session.gc_interval", 30).Return(30).Once()
-	err = s.manager.Extend("test", NewCustomDriver)
+func (s *ManagerTestSuite) TestDriver_ResolveExtendedDriver() {
+
+	s.mockConfig.On("GetString", "session.driver").Return("file").Maybe()
+	s.mockConfig.On("GetInt", "session.gc_interval").Return(30).Maybe()
+
+	err := s.manager.Extend("test", func() sessioncontract.Driver {
+		d, _ := NewCustomDriver()
+		return d
+	})
 	s.Nil(err)
-	driver, err = s.manager.Driver("test")
+
+	driver, err := s.manager.Driver("test")
 	s.Nil(err)
 	s.NotNil(driver)
 	s.Equal("*session.CustomDriver", fmt.Sprintf("%T", driver))
+}
 
-	// not supported a driver
-	s.mockConfig.On("GetString", "session.driver").Return("not_supported").Once()
-	driver, err = s.manager.Driver()
+func (s *ManagerTestSuite) TestDriver_NotSupported() {
+
+	s.mockConfig.ExpectedCalls = nil
+	s.mockConfig.On("GetString", "session.driver").Return("not_supported")
+
+	driver, err := s.manager.Driver()
 	s.NotNil(err)
 	s.ErrorIs(err, errors.SessionDriverNotSupported)
 	s.Equal(errors.SessionDriverNotSupported.Args("not_supported").Error(), err.Error())
 	s.Nil(driver)
+}
 
-	// driver is not set
+func (s *ManagerTestSuite) TestDriver_NotSet() {
+
+	s.mockConfig.ExpectedCalls = nil
 	s.mockConfig.On("GetString", "session.driver").Return("").Once()
-	driver, err = s.manager.Driver()
+
+	driver, err := s.manager.Driver()
 	s.NotNil(err)
 	s.ErrorIs(err, errors.SessionDriverIsNotSet)
 	s.Nil(driver)
 }
 
 func (s *ManagerTestSuite) TestExtend() {
-	s.mockConfig.On("GetInt", "session.gc_interval", 30).Return(30).Once()
-	err := s.manager.Extend("test", NewCustomDriver)
+
+	s.mockConfig.On("GetString", "session.driver").Return("file").Maybe()
+	s.mockConfig.On("GetInt", "session.gc_interval").Return(30).Maybe()
+
+	err := s.manager.Extend("test", func() sessioncontract.Driver {
+		d, _ := NewCustomDriver()
+		return d
+	})
 	s.Nil(err)
+
 	driver, err := s.manager.Driver("test")
 	s.Nil(err)
 	s.NotNil(driver)
 	s.Equal("*session.CustomDriver", fmt.Sprintf("%T", driver))
+}
 
-	// driver already exists
-	err = s.manager.Extend("test", NewCustomDriver)
-	s.ErrorIs(err, errors.SessionDriverAlreadyExists)
-	s.EqualError(err, errors.SessionDriverAlreadyExists.Args("test").Error())
+func (s *ManagerTestSuite) TestExtend_AlreadyExists() {
+
+	err1 := s.manager.Extend("test", func() sessioncontract.Driver {
+		d, _ := NewCustomDriver()
+		return d
+	})
+	s.Nil(err1)
+
+	err2 := s.manager.Extend("test", func() sessioncontract.Driver {
+		d, _ := NewCustomDriver()
+		return d
+	})
+	s.NotNil(err2)
+	s.ErrorIs(err2, errors.SessionDriverAlreadyExists)
+	s.EqualError(err2, errors.SessionDriverAlreadyExists.Args("test").Error())
 }
 
 func (s *ManagerTestSuite) TestBuildSession() {
-	driver, err := s.manager.Driver("file")
-	s.Nil(err)
-	s.NotNil(driver)
-	s.Equal("*driver.File", fmt.Sprintf("%T", driver))
 
 	s.mockConfig.On("GetString", "session.cookie").Return("test_cookie").Once()
+	s.mockConfig.On("GetString", "session.driver").Return("file").Maybe()
+	s.mockConfig.On("GetInt", "session.gc_interval").Return(30).Maybe()
+
+	driver, err := s.manager.Driver(s.manager.getDefaultDriver())
+	s.Nil(err)
+	s.Require().NotNil(driver)
+	s.Equal(s.mockFileDriver, driver)
+
 	session, err := s.manager.BuildSession(driver)
 	s.Nil(err)
-	s.NotNil(session)
+	s.Require().NotNil(session)
 
 	session.Put("name", "goravel")
-
 	s.Equal("test_cookie", session.GetName())
 	s.Equal("goravel", session.Get("name"))
+	s.NotEmpty(session.GetID(), "Session ID should be generated or set")
 
 	s.manager.ReleaseSession(session)
-	s.Empty(session.GetName())
-	s.Empty(session.All())
+	s.Empty(session.GetName(), "Session name should be empty after release")
+	s.Empty(session.All(), "Session attributes should be empty after release")
+}
 
-	// driver is nil
-	session, err = s.manager.BuildSession(nil)
+func (s *ManagerTestSuite) TestBuildSession_NilDriver() {
+
+	session, err := s.manager.BuildSession(nil)
 	s.ErrorIs(err, errors.SessionDriverIsNotSet)
 	s.Nil(session)
 }
 
 func (s *ManagerTestSuite) TestGetDefaultDriver() {
-	s.mockConfig.On("GetString", "session.driver").Return("file")
-	s.Equal("file", s.manager.getDefaultDriver())
+
+	s.mockConfig.ExpectedCalls = nil
+	s.mockConfig.On("GetString", "session.driver").Return("custom_default").Once()
+
+	s.Equal("custom_default", s.manager.getDefaultDriver())
 }
 
-func (s *ManagerTestSuite) getManager() *Manager {
-	return NewManager(s.mockConfig, s.json)
-}
-
-func BenchmarkSession_ReadWrite(b *testing.B) {
+func BenchmarkSession_ManagerInteraction(b *testing.B) {
 	s := new(ManagerTestSuite)
 	s.SetT(&testing.T{})
 	s.SetupTest()
 
-	// provide driver name
-	driver, err := s.manager.Driver("file")
-	s.Nil(err)
-	s.NotNil(driver)
-	s.Equal("*driver.File", fmt.Sprintf("%T", driver))
+	s.mockConfig.On("GetString", "session.driver", "file").Return("file")
+	s.mockConfig.On("GetInt", "session.gc_interval", 30).Return(30)
+	s.mockConfig.On("GetString", "session.cookie").Return("bench_cookie")
 
-	// provide no driver name
-	s.mockConfig.On("GetString", "session.driver").Return("file").Once()
-
-	driver, err = s.manager.Driver()
-	s.Nil(err)
-	s.NotNil(driver)
-	s.Equal("*driver.File", fmt.Sprintf("%T", driver))
-
-	b.StartTimer()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		id := str.Random(32)
-		s1 := str.Random(32)
-		s.Nil(driver.Write(id, s1))
-		data, err := driver.Read(id)
-		s.Nil(err)
-		s.Equal(s, data)
+
+		driver, err := s.manager.Driver()
+		if err != nil {
+			b.Fatalf("Driver() failed during benchmark: %v", err)
+		}
+		if driver == nil {
+			b.Fatal("Driver() returned nil driver during benchmark")
+		}
+
+		session, err := s.manager.BuildSession(driver)
+		if err != nil {
+			b.Fatalf("BuildSession() failed during benchmark: %v", err)
+		}
+		if session == nil {
+			b.Fatal("BuildSession() returned nil session during benchmark")
+		}
+
+		s.manager.ReleaseSession(session)
+
 	}
 	b.StopTimer()
-
-	s.Nil(driver.Destroy("test"))
-	s.Nil(os.RemoveAll("storage"))
-
-}
-
-type CustomDriver struct{}
-
-func NewCustomDriver() sessioncontract.Driver {
-	return &CustomDriver{}
-}
-
-func (c *CustomDriver) Close() error {
-	return nil
-}
-
-func (c *CustomDriver) Destroy(string) error {
-	return nil
-}
-
-func (c *CustomDriver) Gc(int) error {
-	return nil
-}
-
-func (c *CustomDriver) Get(string) string {
-	return ""
-}
-
-func (c *CustomDriver) Open(string, string) error {
-	return nil
-}
-
-func (c *CustomDriver) Read(string) (string, error) {
-	return "", nil
-}
-
-func (c *CustomDriver) Write(string, string) error {
-	return nil
 }


### PR DESCRIPTION
Refactor session manager architecture to allow for custom driver integration. Update file driver implementation to be compatible with these changes, making the session system more extensible and flexible.

## 📑 Description
### Overview
This pull request introduces a significant refactor of the Session Manager to allow the use of custom session drivers, including Redis. The initial goal was to implement a Redis session driver directly; however, I discovered that the current implementation of the Session Manager did not support such integration. To overcome this limitation, I refactored both the Session Manager and its associated file driver, paving the way for adding custom session drivers.

### Updated Session Configuration:
```go
package config

import (
	"github.com/goravel/framework/contracts/session" // Required for Driver type in factory signature
	"github.com/goravel/framework/facades"
	fileriver "github.com/goravel/framework/session/driver" // Import the package containing the driver AND its factory
	"github.com/goravel/framework/support/path"
	"github.com/goravel/framework/support/str"
)

func init() {
	config := facades.Config()
	config.Add("session", map[string]any{
		// Default Session Driver
		//
		// This option controls the default session "driver" that will be used on
		// requests. By default, we will use the lightweight file session driver, but you
		// may specify any of the other wonderful drivers provided here.
		//
		// Supported: "file"
		"driver": config.Env("SESSION_DRIVER", "file"),

		// Session Lifetime
		//
		// Here you may specify the number of minutes that you wish the session
		// to be allowed to remain idle before it expires. If you want them
		// to immediately expire when the browser is closed, then you may
		// indicate that via the expire_on_close configuration option.
		"lifetime": config.Env("SESSION_LIFETIME", 120),

		"expire_on_close": config.Env("SESSION_EXPIRE_ON_CLOSE", false),

		// Session File Location
		//
		// When using the file session driver, we need a location where the
		// session files may be stored. A default has been set for you, but a
		// different location may be specified. This is only needed for file sessions.
		"files": path.Storage("framework/sessions"),

		// Session Garbage Collection Running Time Interval (in minutes)
		//
		// Here you may specify how many minutes you want the session to be allowed
		// to remain idle before its garbage collection routine runs. If you want
		// to avoid hitting the garbage collection routine, you may set this value to -1.
		"gc_interval": config.Env("SESSION_GC_INTERVAL", 30),

		// Session Cookie Name
		//
		// Here you may change the name of the cookie used to identify a session
		// in the application. The name specified here will get used every time
		// a new session cookie is created by the framework for every driver.
		"cookie": config.Env("SESSION_COOKIE", str.Of(config.GetString("app.name")).Snake().Lower().String()+"_session"),

		// Session Cookie Path
		//
		// The session cookie path determines the path for which the cookie will
		// be regarded as available.Typically, this will be the root path of
		// your application, but you are free to change this when necessary.
		"path": config.Env("SESSION_PATH", "/"),

		// Session Cookie Domain
		//
		// Here you may change the domain of the cookie used to identify a session
		// in your application.This will determine which domains the cookie is
		// available to in your application.A sensible default has been set.
		"domain": config.Env("SESSION_DOMAIN", ""),

		// HTTPS Only Cookies
		//
		// By setting this option to true, session cookies will only be sent back
		// to the server if the browser has an HTTPS connection. This will keep
		// the cookie from being sent to you if it cannot be done securely.
		"secure": config.Env("SESSION_SECURE", false),

		// HTTP Access Only
		//
		// Setting this to true will prevent JavaScript from accessing the value of
		// the cookie, and the cookie will only be accessible through the HTTP protocol.
		"http_only": config.Env("SESSION_HTTP_ONLY", true),

		// Same-Site Cookies
		//
		// This option determines how your cookies behave when cross-site requests
		// take place, and can be used to mitigate CSRF attacks.By default, we
		// will set this value to "lax" since this is a secure default value.
		"same_site": config.Env("SESSION_SAME_SITE", "lax"),

		// Session Driver Configurations
		//
		// This map defines the available session drivers and how to create them.
		// The Session Manager reads this map to register driver factories.
		"drivers": map[string]any{

			// File Driver Configuration
			"file": map[string]any{
				// func() (session.Driver, error)
				"via": fileriver.FileDriverFactory,
			},

			// Example: Redis Driver Configuration (User would add this)
			/*
				"redis": map[string]any{
					"driver":     "redis",
					"connection": "default"

					// 'via' points to the factory function for the Redis driver
					"via": func() (session.Driver, error) {
						return redisfacades.RedisSession("redis"), nil
					},
				},
			*/
		},
	})
}
```
