### PR TITLE
feat: [#649]  auto-register migration and seeder when created via CLI

### DIFF
--- a/contracts/database/migration/migrator.go
+++ b/contracts/database/migration/migrator.go
@@ -13,7 +13,7 @@ type Status struct {
 
 type Migrator interface {
 	// Create a new migration file.
-	Create(name string) error
+	Create(name string) (string, error)
 	// Fresh the migrations.
 	Fresh() error
 	// Reset the migrations.

--- a/contracts/packages/modify/modify.go
+++ b/contracts/packages/modify/modify.go
@@ -15,7 +15,7 @@ type File interface {
 
 type GoFile interface {
 	File
-	Find(matchers ...match.GoNode) GoNode
+	Find(matchers []match.GoNode) GoNode
 }
 
 type GoNode interface {

--- a/database/console/migration/migrate_make_command.go
+++ b/database/console/migration/migrate_make_command.go
@@ -73,8 +73,8 @@ func (r *MigrateMakeCommand) Handle(ctx console.Context) error {
 	info, _ := debug.ReadBuildInfo()
 	structName := str.Of(fileName).Prepend("m_").Studly().String()
 	if err = modify.GoFile(path.Database("kernel.go")).
-		Find(match.Imports()...).Modify(modify.AddImport(fmt.Sprintf("%s/database/migrations", info.Main.Path))).
-		Find(match.Migrations()...).Modify(modify.Register(fmt.Sprintf("&migrations.%s{}", structName))).
+		Find(match.Imports()).Modify(modify.AddImport(fmt.Sprintf("%s/database/migrations", info.Main.Path))).
+		Find(match.Migrations()).Modify(modify.Register(fmt.Sprintf("&migrations.%s{}", structName))).
 		Apply(); err != nil {
 		ctx.Warning(errors.MigrationRegisterFailed.Args(err).Error())
 		return nil

--- a/database/console/migration/migrate_make_command_test.go
+++ b/database/console/migration/migrate_make_command_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/goravel/framework/errors"
 	mocksconsole "github.com/goravel/framework/mocks/console"
 	mocksmigration "github.com/goravel/framework/mocks/database/migration"
+	"github.com/goravel/framework/support/file"
 )
 
 func TestMigrateMakeCommand(t *testing.T) {
@@ -64,6 +65,38 @@ func TestMigrateMakeCommand(t *testing.T) {
 				mockContext.EXPECT().Argument(0).Return("create_users_table").Once()
 				mockMigrator.EXPECT().Create("create_users_table").Return("", assert.AnError).Once()
 				mockContext.EXPECT().Error(errors.MigrationCreateFailed.Args(assert.AnError).Error()).Once()
+			},
+		},
+		{
+			name: "Register success",
+			setup: func() {
+				mockContext.EXPECT().Argument(0).Return("create_users_table").Once()
+				mockMigrator.EXPECT().Create("create_users_table").Return("20240915060148_create_users_table", nil).Once()
+				mockContext.EXPECT().Success("Created Migration: create_users_table").Once()
+				mockContext.EXPECT().Success("Migration registered successfully").Once()
+				assert.NoError(t, file.PutContent("database/kernel.go", `package database
+
+import (
+	"github.com/goravel/framework/contracts/database/schema"
+	"github.com/goravel/framework/contracts/database/seeder"
+
+	"goravel/database/migrations"
+)
+
+type Kernel struct {
+}
+
+func (kernel Kernel) Migrations() []schema.Migration {
+	return []schema.Migration{}
+}`))
+				t.Cleanup(func() {
+					assert.True(t, file.Contain("database/kernel.go", `func (kernel Kernel) Migrations() []schema.Migration {
+	return []schema.Migration{
+		&migrations.M20240915060148CreateUsersTable{},
+	}
+}`))
+					assert.NoError(t, file.Remove("database"))
+				})
 			},
 		},
 	}

--- a/database/console/migration/migrate_make_command_test.go
+++ b/database/console/migration/migrate_make_command_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,16 +32,22 @@ func TestMigrateMakeCommand(t *testing.T) {
 			setup: func() {
 				mockContext.EXPECT().Argument(0).Return("").Once()
 				mockContext.EXPECT().Ask("Enter the migration name", mock.Anything).Return("create_users_table", nil).Once()
-				mockMigrator.EXPECT().Create("create_users_table").Return(nil).Once()
+				mockMigrator.EXPECT().Create("create_users_table").Return("", nil).Once()
 				mockContext.EXPECT().Success("Created Migration: create_users_table").Once()
+				mockContext.EXPECT().Warning(mock.MatchedBy(func(msg string) bool {
+					return strings.HasPrefix(msg, "migration register failed:")
+				})).Once()
 			},
 		},
 		{
 			name: "Happy path - name is not empty",
 			setup: func() {
 				mockContext.EXPECT().Argument(0).Return("create_users_table").Once()
-				mockMigrator.EXPECT().Create("create_users_table").Return(nil).Once()
+				mockMigrator.EXPECT().Create("create_users_table").Return("", nil).Once()
 				mockContext.EXPECT().Success("Created Migration: create_users_table").Once()
+				mockContext.EXPECT().Warning(mock.MatchedBy(func(msg string) bool {
+					return strings.HasPrefix(msg, "migration register failed:")
+				})).Once()
 			},
 		},
 		{
@@ -55,7 +62,7 @@ func TestMigrateMakeCommand(t *testing.T) {
 			name: "Sad path - failed to create",
 			setup: func() {
 				mockContext.EXPECT().Argument(0).Return("create_users_table").Once()
-				mockMigrator.EXPECT().Create("create_users_table").Return(assert.AnError).Once()
+				mockMigrator.EXPECT().Create("create_users_table").Return("", assert.AnError).Once()
 				mockContext.EXPECT().Error(errors.MigrationCreateFailed.Args(assert.AnError).Error()).Once()
 			},
 		},

--- a/database/console/seeder_make_command.go
+++ b/database/console/seeder_make_command.go
@@ -61,8 +61,8 @@ func (r *SeederMakeCommand) Handle(ctx console.Context) error {
 	ctx.Success("Seeder created successfully")
 
 	if err = modify.GoFile(path.Database("kernel.go")).
-		Find(match.Imports()...).Modify(modify.AddImport(m.GetPackageImportPath())).
-		Find(match.Seeders()...).Modify(modify.Register(fmt.Sprintf("&%s.%s{}", m.GetPackageName(), m.GetStructName()))).
+		Find(match.Imports()).Modify(modify.AddImport(m.GetPackageImportPath())).
+		Find(match.Seeders()).Modify(modify.Register(fmt.Sprintf("&%s.%s{}", m.GetPackageName(), m.GetStructName()))).
 		Apply(); err != nil {
 		ctx.Warning(errors.DatabaseSeederRegisterFailed.Args(err.Error()).Error())
 		return nil

--- a/database/console/stubs.go
+++ b/database/console/stubs.go
@@ -52,7 +52,7 @@ type DummySeeder struct {
 
 // Signature The name and signature of the seeder.
 func (s *DummySeeder) Signature() string {
-	return "DummySeeder"
+	return "DummySignature"
 }
 
 // Run executes the seeder logic.

--- a/database/migration/migrator.go
+++ b/database/migration/migrator.go
@@ -29,7 +29,7 @@ func NewMigrator(artisan console.Artisan, schema contractsschema.Schema, table s
 	}
 }
 
-func (r *Migrator) Create(name string) error {
+func (r *Migrator) Create(name string) (string, error) {
 	table, create := TableGuesser{}.Guess(name)
 
 	stub := r.creator.GetStub(table, create)
@@ -39,10 +39,10 @@ func (r *Migrator) Create(name string) error {
 
 	// Create the up.sql file.
 	if err := supportfile.PutContent(r.creator.GetPath(fileName), r.creator.PopulateStub(stub, fileName, table)); err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return fileName, nil
 }
 
 func (r *Migrator) Fresh() error {

--- a/database/migration/migrator_test.go
+++ b/database/migration/migrator_test.go
@@ -58,7 +58,9 @@ func (s *MigratorSuite) TestCreate() {
 	path := filepath.Join(pwd, "database", "migrations")
 	name := "create_users_table"
 
-	s.NoError(s.migrator.Create(name))
+	fileName, err := s.migrator.Create(name)
+	s.NoError(err)
+	s.Equal("20240817214501_"+name, fileName)
 
 	migrationFile := filepath.Join(path, "20240817214501_"+name+".go")
 	s.True(file.Exists(migrationFile))

--- a/errors/list.go
+++ b/errors/list.go
@@ -51,6 +51,7 @@ var (
 	DatabaseTableIsRequired             = New("table is required")
 	DatabaseForceIsRequiredInProduction = New("application in production use --force to run this command")
 	DatabaseSeederNotFound              = New("not found %s seeder")
+	DatabaseSeederRegisterFailed        = New("seeder register failed: %v")
 	DatabaseFailToRunSeeder             = New("fail to run seeder: %v")
 	DatabaseUnsupportedType             = New("unsupported type: %s, expected %s")
 	DatabaseInvalidArgumentNumber       = New("invalid argument number: %s, expected %s")
@@ -92,6 +93,7 @@ var (
 	MigrationMigrateFailed   = New("migrate failed: %v")
 	MigrationNameIsRequired  = New("migration name cannot be empty")
 	MigrationRefreshFailed   = New("migration refresh failed: %v")
+	MigrationRegisterFailed  = New("migration register failed: %v")
 	MigrationResetFailed     = New("migration reset failed: %v")
 	MigrationRollbackFailed  = New("migration rollback failed: %v")
 

--- a/foundation/console/package_make_command_stubs.go
+++ b/foundation/console/package_make_command_stubs.go
@@ -139,13 +139,13 @@ func main() {
 	packages.Setup(os.Args).
 		Install(
 			modify.File(path.Config("app.go")).
-				Find(match.Imports()...).Modify(modify.AddImport(packages.GetModulePath())).
-				Find(match.Providers()...).Modify(modify.AddProvider("&DummyName.ServiceProvider{}")),
+				Find(match.Imports()).Modify(modify.AddImport(packages.GetModulePath())).
+				Find(match.Providers()).Modify(modify.AddProvider("&DummyName.ServiceProvider{}")),
 		).
 		Uninstall(
 			modify.File(path.Config("app.go")).
-				Find(match.Imports()...).Modify(modify.RemoveImport(packages.GetModulePath())).
-				Find(match.Providers()...).Modify(modify.RemoveProvider("&DummyName.ServiceProvider{}")),
+				Find(match.Imports()).Modify(modify.RemoveImport(packages.GetModulePath())).
+				Find(match.Providers()).Modify(modify.RemoveProvider("&DummyName.ServiceProvider{}")),
 		).
 		Execute()
 }

--- a/mocks/database/migration/Migrator.go
+++ b/mocks/database/migration/Migrator.go
@@ -21,21 +21,31 @@ func (_m *Migrator) EXPECT() *Migrator_Expecter {
 }
 
 // Create provides a mock function with given fields: name
-func (_m *Migrator) Create(name string) error {
+func (_m *Migrator) Create(name string) (string, error) {
 	ret := _m.Called(name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Create")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return rf(name)
+	}
+	if rf, ok := ret.Get(0).(func(string) string); ok {
 		r0 = rf(name)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(string)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Migrator_Create_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Create'
@@ -56,12 +66,12 @@ func (_c *Migrator_Create_Call) Run(run func(name string)) *Migrator_Create_Call
 	return _c
 }
 
-func (_c *Migrator_Create_Call) Return(_a0 error) *Migrator_Create_Call {
-	_c.Call.Return(_a0)
+func (_c *Migrator_Create_Call) Return(_a0 string, _a1 error) *Migrator_Create_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *Migrator_Create_Call) RunAndReturn(run func(string) error) *Migrator_Create_Call {
+func (_c *Migrator_Create_Call) RunAndReturn(run func(string) (string, error)) *Migrator_Create_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/packages/modify/GoFile.go
+++ b/mocks/packages/modify/GoFile.go
@@ -68,22 +68,16 @@ func (_c *GoFile_Apply_Call) RunAndReturn(run func() error) *GoFile_Apply_Call {
 }
 
 // Find provides a mock function with given fields: matchers
-func (_m *GoFile) Find(matchers ...match.GoNode) modify.GoNode {
-	_va := make([]interface{}, len(matchers))
-	for _i := range matchers {
-		_va[_i] = matchers[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+func (_m *GoFile) Find(matchers []match.GoNode) modify.GoNode {
+	ret := _m.Called(matchers)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Find")
 	}
 
 	var r0 modify.GoNode
-	if rf, ok := ret.Get(0).(func(...match.GoNode) modify.GoNode); ok {
-		r0 = rf(matchers...)
+	if rf, ok := ret.Get(0).(func([]match.GoNode) modify.GoNode); ok {
+		r0 = rf(matchers)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(modify.GoNode)
@@ -99,21 +93,14 @@ type GoFile_Find_Call struct {
 }
 
 // Find is a helper method to define mock.On call
-//   - matchers ...match.GoNode
-func (_e *GoFile_Expecter) Find(matchers ...interface{}) *GoFile_Find_Call {
-	return &GoFile_Find_Call{Call: _e.mock.On("Find",
-		append([]interface{}{}, matchers...)...)}
+//   - matchers []match.GoNode
+func (_e *GoFile_Expecter) Find(matchers interface{}) *GoFile_Find_Call {
+	return &GoFile_Find_Call{Call: _e.mock.On("Find", matchers)}
 }
 
-func (_c *GoFile_Find_Call) Run(run func(matchers ...match.GoNode)) *GoFile_Find_Call {
+func (_c *GoFile_Find_Call) Run(run func(matchers []match.GoNode)) *GoFile_Find_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]match.GoNode, len(args)-0)
-		for i, a := range args[0:] {
-			if a != nil {
-				variadicArgs[i] = a.(match.GoNode)
-			}
-		}
-		run(variadicArgs...)
+		run(args[0].([]match.GoNode))
 	})
 	return _c
 }
@@ -123,7 +110,7 @@ func (_c *GoFile_Find_Call) Return(_a0 modify.GoNode) *GoFile_Find_Call {
 	return _c
 }
 
-func (_c *GoFile_Find_Call) RunAndReturn(run func(...match.GoNode) modify.GoNode) *GoFile_Find_Call {
+func (_c *GoFile_Find_Call) RunAndReturn(run func([]match.GoNode) modify.GoNode) *GoFile_Find_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/packages/modify/actions_test.go
+++ b/packages/modify/actions_test.go
@@ -337,7 +337,7 @@ func (kernel Kernel) Commands() []console.Command {
 		s.Run(tt.name, func() {
 			sourceFile := filepath.Join(s.T().TempDir(), "test.go")
 			s.Require().NoError(file.PutContent(sourceFile, tt.content))
-			s.Require().NoError(GoFile(sourceFile).Find(tt.matchers...).Modify(tt.actions...).Apply())
+			s.Require().NoError(GoFile(sourceFile).Find(tt.matchers).Modify(tt.actions...).Apply())
 			content, err := file.GetContent(sourceFile)
 			s.Require().NoError(err)
 			tt.assert(content)

--- a/packages/modify/modify.go
+++ b/packages/modify/modify.go
@@ -49,7 +49,7 @@ func (r goFile) Apply() error {
 	return file.PutContent(r.file, buf.String())
 }
 
-func (r goFile) Find(matchers ...match.GoNode) modify.GoNode {
+func (r goFile) Find(matchers []match.GoNode) modify.GoNode {
 	modifier := &GoNode{
 		matchers: matchers,
 		file:     &r,

--- a/packages/modify/modify_test.go
+++ b/packages/modify/modify_test.go
@@ -105,7 +105,7 @@ func main() {
 			if tt.setup != nil {
 				tt.setup()
 			}
-			tt.assert(GoFile(s.file).Find(tt.matchers...).Modify(tt.actions...).Apply())
+			tt.assert(GoFile(s.file).Find(tt.matchers).Modify(tt.actions...).Apply())
 		})
 	}
 }

--- a/support/console/console.go
+++ b/support/console/console.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"github.com/goravel/framework/contracts/console"
@@ -52,11 +53,33 @@ func (m *Make) GetFilePath() string {
 	return filepath.Join(pwd, m.root, m.GetFolderPath(), str.Of(m.GetStructName()).Snake().String()+".go")
 }
 
+func (m *Make) GetSignature() string {
+	return str.Of(filepath.Join(m.GetFolderPath(), m.GetStructName())).
+		Replace(string(filepath.Separator), "_").Studly().String()
+}
+
 func (m *Make) GetStructName() string {
 	name := strings.TrimSuffix(m.name, ".go")
 	segments := strings.Split(name, "/")
 
 	return str.Of(segments[len(segments)-1]).Studly().String()
+}
+
+func (m *Make) GetPackageImportPath() string {
+	var paths []string
+	if info, ok := debug.ReadBuildInfo(); ok {
+		paths = append(paths, info.Main.Path)
+	}
+
+	if len(m.root) > 0 {
+		paths = append(paths, strings.Split(m.root, string(filepath.Separator))...)
+	}
+
+	if folders := m.GetFolderPath(); len(folders) > 0 {
+		paths = append(paths, strings.Split(folders, string(filepath.Separator))...)
+	}
+
+	return strings.Join(paths, "/")
 }
 
 func (m *Make) GetPackageName() string {

--- a/support/console/console_test.go
+++ b/support/console/console_test.go
@@ -58,7 +58,7 @@ func (s *MakeTestSuite) TestGetStructName() {
 	s.Equal("Lowercase", s.make.GetStructName())
 }
 
-func (s *MakeTestSuite) TestGetImportPath() {
+func (s *MakeTestSuite) TestGetPackageImportPath() {
 	s.Contains(s.make.GetPackageImportPath(), "/app/rules")
 
 	s.make.name = "user/Lowercase"

--- a/support/console/console_test.go
+++ b/support/console/console_test.go
@@ -38,6 +38,16 @@ func (s *MakeTestSuite) TestGetFilePath() {
 	s.Equal(filepath.Join(pwd, s.make.root, "user", "lowercase.go"), s.make.GetFilePath())
 }
 
+func (s *MakeTestSuite) TestGetSignature() {
+	s.Equal("Lowercase", s.make.GetSignature())
+
+	s.make.name = "user/Lowercase"
+	s.Equal("UserLowercase", s.make.GetSignature())
+
+	s.make.name = "user/Lowercase/Uppercase"
+	s.Equal("UserLowercaseUppercase", s.make.GetSignature())
+}
+
 func (s *MakeTestSuite) TestGetStructName() {
 	s.Equal("Lowercase", s.make.GetStructName())
 
@@ -46,6 +56,16 @@ func (s *MakeTestSuite) TestGetStructName() {
 
 	s.make.name = "user/Lowercase"
 	s.Equal("Lowercase", s.make.GetStructName())
+}
+
+func (s *MakeTestSuite) TestGetImportPath() {
+	s.Contains(s.make.GetPackageImportPath(), "/app/rules")
+
+	s.make.name = "user/Lowercase"
+	s.Contains(s.make.GetPackageImportPath(), "/app/rules/user")
+
+	s.make.name = "user/Lowercase/Uppercase"
+	s.Contains(s.make.GetPackageImportPath(), "/app/rules/user/Lowercase")
 }
 
 func (s *MakeTestSuite) TestGetPackageName() {


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/649


This change improves workflow efficiency by automatically registering migration and seeder files created via artisan `make:migration` and `artisan make:seeder`.

These files are now injected into database/kernel.go, eliminating the need for manual inclusion and streamlining the setup process.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
