### PR TITLE
feat: [#534] add schedule:run and schedule:list commands

### DIFF
--- a/contracts/schedule/schedule.go
+++ b/contracts/schedule/schedule.go
@@ -9,6 +9,8 @@ type Schedule interface {
 	Call(callback func()) Event
 	// Command adds a new Artisan command event to the schedule.
 	Command(command string) Event
+	// Events returns all registered schedule events.
+	Events() []Event
 	// Register schedules.
 	Register(events []Event)
 	// Run schedules.

--- a/mocks/schedule/Schedule.go
+++ b/mocks/schedule/Schedule.go
@@ -118,6 +118,53 @@ func (_c *Schedule_Command_Call) RunAndReturn(run func(string) schedule.Event) *
 	return _c
 }
 
+// Events provides a mock function with no fields
+func (_m *Schedule) Events() []schedule.Event {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Events")
+	}
+
+	var r0 []schedule.Event
+	if rf, ok := ret.Get(0).(func() []schedule.Event); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]schedule.Event)
+		}
+	}
+
+	return r0
+}
+
+// Schedule_Events_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Events'
+type Schedule_Events_Call struct {
+	*mock.Call
+}
+
+// Events is a helper method to define mock.On call
+func (_e *Schedule_Expecter) Events() *Schedule_Events_Call {
+	return &Schedule_Events_Call{Call: _e.mock.On("Events")}
+}
+
+func (_c *Schedule_Events_Call) Run(run func()) *Schedule_Events_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Schedule_Events_Call) Return(_a0 []schedule.Event) *Schedule_Events_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Schedule_Events_Call) RunAndReturn(run func() []schedule.Event) *Schedule_Events_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Register provides a mock function with given fields: events
 func (_m *Schedule) Register(events []schedule.Event) {
 	_m.Called(events)

--- a/schedule/console/list_command.go
+++ b/schedule/console/list_command.go
@@ -1,0 +1,98 @@
+package console
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+
+	"github.com/robfig/cron/v3"
+
+	"github.com/goravel/framework/contracts/console"
+	"github.com/goravel/framework/contracts/console/command"
+	"github.com/goravel/framework/contracts/schedule"
+	"github.com/goravel/framework/support/carbon"
+	"github.com/goravel/framework/support/str"
+)
+
+var cronParser = cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+
+type List struct {
+	schedule schedule.Schedule
+}
+
+func NewListCommand(schedule schedule.Schedule) *List {
+	return &List{
+		schedule: schedule,
+	}
+}
+
+// Signature The name and signature of the console command.
+func (r *List) Signature() string {
+	return "schedule:list"
+}
+
+// Description The console command description.
+func (r *List) Description() string {
+	return "List all scheduled tasks"
+}
+
+// Extend The console command extend.
+func (r *List) Extend() command.Extend {
+	return command.Extend{
+		Category: "schedule",
+	}
+}
+
+// Handle Execute the console command.
+func (r *List) Handle(ctx console.Context) error {
+	ctx.NewLine()
+	for _, event := range r.schedule.Events() {
+		cmd := event.GetName()
+
+		// display artisan command signature,when it has command
+		if c := event.GetCommand(); c != "" {
+			cmd = "artisan " + c
+			// highlight the parameters...
+			cmd = regexp.MustCompile(`(artisan [\w\-:]+) (.+)`).ReplaceAllString(cmd, `$1 <fg=yellow>$2</>`)
+		}
+
+		// display closure location,when it doesn't have a name
+		if len(cmd) == 0 && event.GetCallback() != nil {
+			file, line := r.getClosureLocation(event.GetCallback())
+			file, _ = filepath.Rel(str.Of(file).Dirname(3).String(), file)
+			cmd = fmt.Sprintf("Closure at: %s:%d", file, line)
+		}
+
+		var nextDue string
+		if nd := r.getNextDueDate(event.GetCron()); len(nd) > 0 {
+			nextDue = fmt.Sprintf("<fg=7472a3>Next Due: %s</>", nd)
+		}
+		ctx.TwoColumnDetail(fmt.Sprintf("<fg=yellow>%s</>  %s", event.GetCron(), cmd), nextDue)
+	}
+	return nil
+}
+
+func (r *List) getClosureLocation(closure any) (file string, line int) {
+	v := reflect.ValueOf(closure)
+	if v.Kind() == reflect.Func {
+		ptr := v.Pointer()
+		if fn := runtime.FuncForPC(ptr); fn != nil {
+			file, line = fn.FileLine(ptr)
+		}
+	}
+
+	return
+}
+
+func (r *List) getNextDueDate(cronSpec string) string {
+	if sch, err := cronParser.Parse(cronSpec); err == nil {
+		now := carbon.Now()
+		if next := sch.Next(now.StdTime()); !next.IsZero() {
+			return carbon.FromStdTime(next).DiffForHumans(now)
+		}
+	}
+
+	return ""
+}

--- a/schedule/console/list_command_test.go
+++ b/schedule/console/list_command_test.go
@@ -1,0 +1,109 @@
+package console
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/goravel/framework/contracts/console/command"
+	"github.com/goravel/framework/contracts/schedule"
+	consolemocks "github.com/goravel/framework/mocks/console"
+	schedulemocks "github.com/goravel/framework/mocks/schedule"
+	"github.com/goravel/framework/support/carbon"
+)
+
+type ListCommandTestSuite struct {
+	suite.Suite
+}
+
+func (s *ListCommandTestSuite) SetupTest() {
+	carbon.SetTestNow(carbon.Now().StartOfMinute())
+}
+
+func (s *ListCommandTestSuite) TearDownTest() {
+	carbon.UnsetTestNow()
+}
+
+func TestListCommandTestSuite(t *testing.T) {
+	suite.Run(t, new(ListCommandTestSuite))
+}
+
+func (s *ListCommandTestSuite) TestListCommand() {
+	listCommand := &List{}
+	s.Equal("schedule:list", listCommand.Signature())
+	s.Equal("List all scheduled tasks", listCommand.Description())
+	s.Equal(command.Extend{Category: "schedule"}, listCommand.Extend())
+
+	tests := []struct {
+		name     string
+		expected [2]string
+		setup    func(mockEvent *schedulemocks.Event)
+	}{
+		{
+			name: "schedule artisan command",
+			expected: [2]string{
+				"<fg=yellow>* * * * *</>  artisan send:emails <fg=yellow>name</>",
+				"<fg=7472a3>Next Due: 1 minute after</>",
+			},
+			setup: func(mockEvent *schedulemocks.Event) {
+				mockEvent.EXPECT().GetName().Return("")
+				mockEvent.EXPECT().GetCommand().Return("send:emails name")
+				mockEvent.EXPECT().GetCron().Return("* * * * *")
+			},
+		},
+		{
+			name: "schedule closure command(without name)",
+			expected: [2]string{
+				fmt.Sprintf("<fg=yellow>* * * * *</>  Closure at: %s:65", filepath.Join("schedule", "console", "list_command_test.go")),
+				"<fg=7472a3>Next Due: 1 minute after</>",
+			},
+			setup: func(mockEvent *schedulemocks.Event) {
+				mockEvent.EXPECT().GetName().Return("")
+				mockEvent.EXPECT().GetCommand().Return("")
+				mockEvent.EXPECT().GetCallback().Return(func() {})
+				mockEvent.EXPECT().GetCron().Return("* * * * *")
+			},
+		},
+		{
+			name: "schedule closure command(with name)",
+			expected: [2]string{
+				"<fg=yellow>* * * * *</>  test-command",
+				"<fg=7472a3>Next Due: 1 minute after</>",
+			},
+			setup: func(mockEvent *schedulemocks.Event) {
+				mockEvent.EXPECT().GetName().Return("test-command")
+				mockEvent.EXPECT().GetCommand().Return("")
+				mockEvent.EXPECT().GetCron().Return("* * * * *")
+			},
+		},
+		{
+			name: "schedule invalid cron expression",
+			expected: [2]string{
+				"<fg=yellow>* *</>  invalid-cron",
+				"",
+			},
+			setup: func(mockEvent *schedulemocks.Event) {
+				mockEvent.EXPECT().GetName().Return("invalid-cron")
+				mockEvent.EXPECT().GetCommand().Return("")
+				mockEvent.EXPECT().GetCron().Return("* *")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			mockContext := consolemocks.NewContext(s.T())
+			mockSchedule := schedulemocks.NewSchedule(s.T())
+			mockEvent := schedulemocks.NewEvent(s.T())
+
+			mockSchedule.EXPECT().Events().Return([]schedule.Event{mockEvent}).Once()
+			mockContext.EXPECT().NewLine().Return().Once()
+			mockContext.EXPECT().TwoColumnDetail(tt.expected[0], tt.expected[1]).Once()
+			tt.setup(mockEvent)
+
+			s.NoError(NewListCommand(mockSchedule).Handle(mockContext))
+		})
+	}
+}

--- a/schedule/console/list_command_test.go
+++ b/schedule/console/list_command_test.go
@@ -5,105 +5,114 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/goravel/framework/contracts/console/command"
 	"github.com/goravel/framework/contracts/schedule"
 	consolemocks "github.com/goravel/framework/mocks/console"
-	schedulemocks "github.com/goravel/framework/mocks/schedule"
+	mocksschedule "github.com/goravel/framework/mocks/schedule"
 	"github.com/goravel/framework/support/carbon"
 )
 
-type ListCommandTestSuite struct {
-	suite.Suite
-}
-
-func (s *ListCommandTestSuite) SetupTest() {
-	carbon.SetTestNow(carbon.Now().StartOfMinute())
-}
-
-func (s *ListCommandTestSuite) TearDownTest() {
-	carbon.UnsetTestNow()
-}
-
-func TestListCommandTestSuite(t *testing.T) {
-	suite.Run(t, new(ListCommandTestSuite))
-}
-
-func (s *ListCommandTestSuite) TestListCommand() {
+func TestListCommand(t *testing.T) {
 	listCommand := &List{}
-	s.Equal("schedule:list", listCommand.Signature())
-	s.Equal("List all scheduled tasks", listCommand.Description())
-	s.Equal(command.Extend{Category: "schedule"}, listCommand.Extend())
+	assert.Equal(t, "schedule:list", listCommand.Signature())
+	assert.Equal(t, "List all scheduled tasks", listCommand.Description())
+	assert.Equal(t, command.Extend{Category: "schedule"}, listCommand.Extend())
 
 	tests := []struct {
 		name     string
-		expected [2]string
-		setup    func(mockEvent *schedulemocks.Event)
+		expected []string
+		setup    func(t *testing.T) []schedule.Event
 	}{
 		{
+			name: "no schedule",
+			expected: []string{
+				"No scheduled tasks have been defined.",
+			},
+			setup: func(t *testing.T) []schedule.Event {
+				return nil
+			},
+		},
+		{
 			name: "schedule artisan command",
-			expected: [2]string{
+			expected: []string{
 				"<fg=yellow>* * * * *</>  artisan send:emails <fg=yellow>name</>",
 				"<fg=7472a3>Next Due: 1 minute after</>",
 			},
-			setup: func(mockEvent *schedulemocks.Event) {
-				mockEvent.EXPECT().GetName().Return("")
-				mockEvent.EXPECT().GetCommand().Return("send:emails name")
-				mockEvent.EXPECT().GetCron().Return("* * * * *")
+			setup: func(t *testing.T) []schedule.Event {
+				mockEvent := mocksschedule.NewEvent(t)
+				mockEvent.EXPECT().GetName().Return("").Once()
+				mockEvent.EXPECT().GetCommand().Return("send:emails name").Once()
+				mockEvent.EXPECT().GetCron().Return("* * * * *").Times(3)
+
+				return []schedule.Event{mockEvent}
 			},
 		},
 		{
 			name: "schedule closure command(without name)",
-			expected: [2]string{
-				fmt.Sprintf("<fg=yellow>* * * * *</>  Closure at: %s:65", filepath.Join("schedule", "console", "list_command_test.go")),
+			expected: []string{
+				fmt.Sprintf("<fg=yellow>* * * * *</>  Closure at: %s:62", filepath.Join("schedule", "console", "list_command_test.go")),
 				"<fg=7472a3>Next Due: 1 minute after</>",
 			},
-			setup: func(mockEvent *schedulemocks.Event) {
-				mockEvent.EXPECT().GetName().Return("")
-				mockEvent.EXPECT().GetCommand().Return("")
-				mockEvent.EXPECT().GetCallback().Return(func() {})
-				mockEvent.EXPECT().GetCron().Return("* * * * *")
+			setup: func(t *testing.T) []schedule.Event {
+				mockEvent := mocksschedule.NewEvent(t)
+				mockEvent.EXPECT().GetName().Return("").Once()
+				mockEvent.EXPECT().GetCommand().Return("").Once()
+				mockEvent.EXPECT().GetCallback().Return(func() {}).Twice()
+				mockEvent.EXPECT().GetCron().Return("* * * * *").Times(3)
+
+				return []schedule.Event{mockEvent}
 			},
 		},
 		{
 			name: "schedule closure command(with name)",
-			expected: [2]string{
+			expected: []string{
 				"<fg=yellow>* * * * *</>  test-command",
 				"<fg=7472a3>Next Due: 1 minute after</>",
 			},
-			setup: func(mockEvent *schedulemocks.Event) {
-				mockEvent.EXPECT().GetName().Return("test-command")
-				mockEvent.EXPECT().GetCommand().Return("")
-				mockEvent.EXPECT().GetCron().Return("* * * * *")
+			setup: func(t *testing.T) []schedule.Event {
+				mockEvent := mocksschedule.NewEvent(t)
+				mockEvent.EXPECT().GetName().Return("test-command").Once()
+				mockEvent.EXPECT().GetCommand().Return("").Once()
+				mockEvent.EXPECT().GetCron().Return("* * * * *").Times(3)
+
+				return []schedule.Event{mockEvent}
 			},
 		},
 		{
 			name: "schedule invalid cron expression",
-			expected: [2]string{
+			expected: []string{
 				"<fg=yellow>* *</>  invalid-cron",
 				"",
 			},
-			setup: func(mockEvent *schedulemocks.Event) {
-				mockEvent.EXPECT().GetName().Return("invalid-cron")
-				mockEvent.EXPECT().GetCommand().Return("")
-				mockEvent.EXPECT().GetCron().Return("* *")
+			setup: func(t *testing.T) []schedule.Event {
+				mockEvent := mocksschedule.NewEvent(t)
+				mockEvent.EXPECT().GetName().Return("invalid-cron").Once()
+				mockEvent.EXPECT().GetCommand().Return("").Once()
+				mockEvent.EXPECT().GetCron().Return("* *").Times(3)
+
+				return []schedule.Event{mockEvent}
 			},
 		},
 	}
 
+	carbon.SetTestNow(carbon.Now().StartOfMinute())
 	for _, tt := range tests {
-		s.Run(tt.name, func() {
-			mockContext := consolemocks.NewContext(s.T())
-			mockSchedule := schedulemocks.NewSchedule(s.T())
-			mockEvent := schedulemocks.NewEvent(s.T())
-
-			mockSchedule.EXPECT().Events().Return([]schedule.Event{mockEvent}).Once()
+		t.Run(tt.name, func(t *testing.T) {
+			mockContext := consolemocks.NewContext(t)
+			mockSchedule := mocksschedule.NewSchedule(t)
+			mockSchedule.EXPECT().Events().Return(tt.setup(t)).Once()
 			mockContext.EXPECT().NewLine().Return().Once()
-			mockContext.EXPECT().TwoColumnDetail(tt.expected[0], tt.expected[1]).Once()
-			tt.setup(mockEvent)
 
-			s.NoError(NewListCommand(mockSchedule).Handle(mockContext))
+			if len(tt.expected) > 1 {
+				mockContext.EXPECT().TwoColumnDetail(tt.expected[0], tt.expected[1]).Once()
+			} else {
+				mockContext.EXPECT().Warning(tt.expected[0]).Once()
+			}
+
+			assert.NoError(t, NewList(mockSchedule).Handle(mockContext))
 		})
 	}
+	carbon.UnsetTestNow()
 }

--- a/schedule/console/run_command.go
+++ b/schedule/console/run_command.go
@@ -10,7 +10,7 @@ type Run struct {
 	schedule schedule.Schedule
 }
 
-func NewRunCommand(schedule schedule.Schedule) *Run {
+func NewRun(schedule schedule.Schedule) *Run {
 	return &Run{
 		schedule: schedule,
 	}

--- a/schedule/console/run_command.go
+++ b/schedule/console/run_command.go
@@ -1,0 +1,41 @@
+package console
+
+import (
+	"github.com/goravel/framework/contracts/console"
+	"github.com/goravel/framework/contracts/console/command"
+	"github.com/goravel/framework/contracts/schedule"
+)
+
+type Run struct {
+	schedule schedule.Schedule
+}
+
+func NewRunCommand(schedule schedule.Schedule) *Run {
+	return &Run{
+		schedule: schedule,
+	}
+}
+
+// Signature The name and signature of the console command.
+func (r *Run) Signature() string {
+	return "schedule:run"
+}
+
+// Description The console command description.
+func (r *Run) Description() string {
+	return "Run the scheduled commands"
+}
+
+// Extend The console command extend.
+func (r *Run) Extend() command.Extend {
+	return command.Extend{
+		Category: "schedule",
+	}
+}
+
+// Handle Execute the console command.
+func (r *Run) Handle(_ console.Context) error {
+	r.schedule.Run()
+
+	return nil
+}

--- a/schedule/console/run_command_test.go
+++ b/schedule/console/run_command_test.go
@@ -1,0 +1,23 @@
+package console
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/goravel/framework/contracts/console/command"
+	consolemocks "github.com/goravel/framework/mocks/console"
+	schedulemocks "github.com/goravel/framework/mocks/schedule"
+)
+
+func TestRunCommand(t *testing.T) {
+	mockSchedule := schedulemocks.NewSchedule(t)
+	runCommand := NewRunCommand(mockSchedule)
+
+	mockSchedule.EXPECT().Run().Once()
+
+	assert.Equal(t, "schedule:run", runCommand.Signature())
+	assert.Equal(t, "Run the scheduled commands", runCommand.Description())
+	assert.Equal(t, command.Extend{Category: "schedule"}, runCommand.Extend())
+	assert.NoError(t, runCommand.Handle(consolemocks.NewContext(t)))
+}

--- a/schedule/console/run_command_test.go
+++ b/schedule/console/run_command_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRunCommand(t *testing.T) {
 	mockSchedule := schedulemocks.NewSchedule(t)
-	runCommand := NewRunCommand(mockSchedule)
+	runCommand := NewRun(mockSchedule)
 
 	mockSchedule.EXPECT().Run().Once()
 

--- a/schedule/event.go
+++ b/schedule/event.go
@@ -106,7 +106,7 @@ func (receiver *Event) EveryFifteenMinutes() schedule.Event {
 
 // EveryThirtyMinutes Schedule the event to run every thirty minutes.
 func (receiver *Event) EveryThirtyMinutes() schedule.Event {
-	return receiver.Cron(receiver.spliceIntoPosition(1, "0,30"))
+	return receiver.Cron(receiver.spliceIntoPosition(1, "*/30"))
 }
 
 // EveryTwoHours Schedule the event to run every two hours.

--- a/schedule/event_test.go
+++ b/schedule/event_test.go
@@ -65,7 +65,7 @@ func (s *EventTestSuite) TestEveryFifteenMinutes() {
 }
 
 func (s *EventTestSuite) TestEveryThirtyMinutes() {
-	s.Equal("0,30 * * * *", s.event.EveryThirtyMinutes().GetCron())
+	s.Equal("*/30 * * * *", s.event.EveryThirtyMinutes().GetCron())
 }
 
 func (s *EventTestSuite) TestEveryTwoHours() {

--- a/schedule/service_provider.go
+++ b/schedule/service_provider.go
@@ -2,8 +2,10 @@ package schedule
 
 import (
 	"github.com/goravel/framework/contracts"
+	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
 	"github.com/goravel/framework/errors"
+	scheduleconsole "github.com/goravel/framework/schedule/console"
 )
 
 type ServiceProvider struct {
@@ -36,5 +38,12 @@ func (r *ServiceProvider) Register(app foundation.Application) {
 }
 
 func (r *ServiceProvider) Boot(app foundation.Application) {
+	r.registerCommands(app)
+}
 
+func (r *ServiceProvider) registerCommands(app foundation.Application) {
+	app.MakeArtisan().Register([]console.Command{
+		scheduleconsole.NewListCommand(app.MakeSchedule()),
+		scheduleconsole.NewRunCommand(app.MakeSchedule()),
+	})
 }

--- a/schedule/service_provider.go
+++ b/schedule/service_provider.go
@@ -43,7 +43,7 @@ func (r *ServiceProvider) Boot(app foundation.Application) {
 
 func (r *ServiceProvider) registerCommands(app foundation.Application) {
 	app.MakeArtisan().Register([]console.Command{
-		scheduleconsole.NewListCommand(app.MakeSchedule()),
-		scheduleconsole.NewRunCommand(app.MakeSchedule()),
+		scheduleconsole.NewList(app.MakeSchedule()),
+		scheduleconsole.NewRun(app.MakeSchedule()),
 	})
 }


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/534

This PR adds two new Artisan commands:

- schedule:run: Starts the internal scheduler and runs all due tasks.

- schedule:list: Lists all registered scheduled tasks.

Goravel has a built-in task scheduling system based on [robfig/cron](https://github.com/robfig/cron), a robust and flexible cron engine for Go.
Thanks to this internal scheduler, there is no need to rely on the system’s crontab to trigger scheduled tasks. We can manage task execution entirely within the application by keeping the schedule:run process alive.

We only need to:

- Run artisan schedule:run as the main process in a Docker container, or

- Use a process manager like supervisord, systemd, or pm2 to ensure the schedule:run process remains running.

This approach provides a reliable, container-friendly, and framework-native solution for task scheduling in Goravel applications.

![code](https://github.com/user-attachments/assets/21f2abdb-78ba-413b-868f-3d4e0662bf7e)




<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
