### PR TITLE
chore: ensure imports are unused before removing

### DIFF
--- a/foundation/console/package_make_command_stubs.go
+++ b/foundation/console/package_make_command_stubs.go
@@ -144,8 +144,8 @@ func main() {
 		).
 		Uninstall(
 			modify.File(path.Config("app.go")).
-				Find(match.Imports()).Modify(modify.RemoveImport(packages.GetModulePath())).
-				Find(match.Providers()).Modify(modify.RemoveProvider("&DummyName.ServiceProvider{}")),
+				Find(match.Providers()).Modify(modify.RemoveProvider("&DummyName.ServiceProvider{}")).
+				Find(match.Imports()).Modify(modify.RemoveImport(packages.GetModulePath())),
 		).
 		Execute()
 }

--- a/packages/modify/actions.go
+++ b/packages/modify/actions.go
@@ -123,6 +123,10 @@ func RemoveConfig(name string) modify.Action {
 // RemoveImport removes an import statement from the file.
 func RemoveImport(path string, name ...string) modify.Action {
 	return func(cursor *dstutil.Cursor) {
+		if IsUsingImport(cursor.Parent().(*dst.File), path, name...) {
+			return
+		}
+
 		node := cursor.Node().(*dst.GenDecl)
 		node.Specs = slices.DeleteFunc(node.Specs, func(spec dst.Spec) bool {
 			return match.Import(path, name...).MatchNode(spec)

--- a/packages/modify/actions_test.go
+++ b/packages/modify/actions_test.go
@@ -2,6 +2,7 @@ package modify
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -302,8 +303,19 @@ func (s *ModifyActionsTestSuite) TestActions() {
 			},
 		},
 		{
-			name:     "remove import",
+			name:     "remove import(in use)",
 			content:  s.config,
+			matchers: match.Imports(),
+			actions: []modify.Action{
+				RemoveImport("github.com/goravel/framework/auth"),
+			},
+			assert: func(content string) {
+				s.Contains(content, `"github.com/goravel/framework/auth"`)
+			},
+		},
+		{
+			name:     "remove import(not in use)",
+			content:  strings.Replace(s.config, "&auth.AuthServiceProvider{},", "", 1),
 			matchers: match.Imports(),
 			actions: []modify.Action{
 				RemoveImport("github.com/goravel/framework/auth"),

--- a/packages/modify/utils_test.go
+++ b/packages/modify/utils_test.go
@@ -57,6 +57,23 @@ func (s *UtilsTestSuite) TestExprExists() {
 
 }
 
+func (s *UtilsTestSuite) TestUsesImport() {
+	df, err := decorator.Parse(`package main
+import (
+    "fmt"        
+    mylog "log"
+)
+
+func main() {
+    fmt.Println("hello")
+}`)
+	s.Require().NoError(err)
+	s.Require().NotNil(df)
+
+	s.True(IsUsingImport(df, "fmt"))
+	s.False(IsUsingImport(df, "log", "mylog"))
+}
+
 func (s *UtilsTestSuite) TestKeyExists() {
 	s.NotPanics(func() {
 		s.Run("key exists", func() {


### PR DESCRIPTION
## 📑 Description

This change adds a check to ensure that an import is actually unused before it is removed from the source file.
It prevents accidentally deleting shared imports that are still required by other packages.

For example, multiple filesystem drivers like `github.com/goravel/cloudinary` and `github.com/goravel/minio` may each import `github.com/goravel/framework/contracts/filesystem`. When both are installed, this import is shared. If one of them is uninstalled, we should not remove the shared import unless it is truly unused.

This fix avoids such cases by checking whether the import alias is still referenced in the AST before removing it.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
