### PR TITLE
fix: [#660] WhereBetween, etc. method can't support string correctly

### DIFF
--- a/database/gorm/query.go
+++ b/database/gorm/query.go
@@ -949,19 +949,19 @@ func (r *Query) OrWhereNotIn(column string, values []any) contractsorm.Query {
 }
 
 func (r *Query) WhereBetween(column string, x, y any) contractsorm.Query {
-	return r.Where(fmt.Sprintf("%s BETWEEN %v AND %v", column, x, y))
+	return r.Where(fmt.Sprintf("%s BETWEEN ? AND ?", column), x, y)
 }
 
 func (r *Query) WhereNotBetween(column string, x, y any) contractsorm.Query {
-	return r.Where(fmt.Sprintf("%s NOT BETWEEN %v AND %v", column, x, y))
+	return r.Where(fmt.Sprintf("%s NOT BETWEEN ? AND ?", column), x, y)
 }
 
 func (r *Query) OrWhereBetween(column string, x, y any) contractsorm.Query {
-	return r.OrWhere(fmt.Sprintf("%s BETWEEN %v AND %v", column, x, y))
+	return r.OrWhere(fmt.Sprintf("%s BETWEEN ? AND ?", column), x, y)
 }
 
 func (r *Query) OrWhereNotBetween(column string, x, y any) contractsorm.Query {
-	return r.OrWhere(fmt.Sprintf("%s NOT BETWEEN %v AND %v", column, x, y))
+	return r.OrWhere(fmt.Sprintf("%s NOT BETWEEN ? AND ?", column), x, y)
 }
 
 func (r *Query) OrWhereNull(column string) contractsorm.Query {

--- a/tests/query.go
+++ b/tests/query.go
@@ -131,15 +131,15 @@ func NewTestQueryBuilder() *TestQueryBuilder {
 
 func (r *TestQueryBuilder) All(prefix string, singular bool) map[string]*TestQuery {
 	postgresTestQuery := r.Postgres(prefix, singular)
-	mysqlTestQuery := r.Mysql(prefix, singular)
-	sqlserverTestQuery := r.Sqlserver(prefix, singular)
-	sqliteTestQuery := r.Sqlite(prefix, singular)
+	// mysqlTestQuery := r.Mysql(prefix, singular)
+	// sqlserverTestQuery := r.Sqlserver(prefix, singular)
+	// sqliteTestQuery := r.Sqlite(prefix, singular)
 
 	return map[string]*TestQuery{
-		postgresTestQuery.Driver().Pool().Writers[0].Driver:  postgresTestQuery,
-		mysqlTestQuery.Driver().Pool().Writers[0].Driver:     mysqlTestQuery,
-		sqlserverTestQuery.Driver().Pool().Writers[0].Driver: sqlserverTestQuery,
-		sqliteTestQuery.Driver().Pool().Writers[0].Driver:    sqliteTestQuery,
+		postgresTestQuery.Driver().Pool().Writers[0].Driver: postgresTestQuery,
+		// mysqlTestQuery.Driver().Pool().Writers[0].Driver:     mysqlTestQuery,
+		// sqlserverTestQuery.Driver().Pool().Writers[0].Driver: sqlserverTestQuery,
+		// sqliteTestQuery.Driver().Pool().Writers[0].Driver:    sqliteTestQuery,
 	}
 }
 

--- a/tests/query.go
+++ b/tests/query.go
@@ -131,15 +131,15 @@ func NewTestQueryBuilder() *TestQueryBuilder {
 
 func (r *TestQueryBuilder) All(prefix string, singular bool) map[string]*TestQuery {
 	postgresTestQuery := r.Postgres(prefix, singular)
-	// mysqlTestQuery := r.Mysql(prefix, singular)
-	// sqlserverTestQuery := r.Sqlserver(prefix, singular)
-	// sqliteTestQuery := r.Sqlite(prefix, singular)
+	mysqlTestQuery := r.Mysql(prefix, singular)
+	sqlserverTestQuery := r.Sqlserver(prefix, singular)
+	sqliteTestQuery := r.Sqlite(prefix, singular)
 
 	return map[string]*TestQuery{
-		postgresTestQuery.Driver().Pool().Writers[0].Driver: postgresTestQuery,
-		// mysqlTestQuery.Driver().Pool().Writers[0].Driver:     mysqlTestQuery,
-		// sqlserverTestQuery.Driver().Pool().Writers[0].Driver: sqlserverTestQuery,
-		// sqliteTestQuery.Driver().Pool().Writers[0].Driver:    sqliteTestQuery,
+		postgresTestQuery.Driver().Pool().Writers[0].Driver:  postgresTestQuery,
+		mysqlTestQuery.Driver().Pool().Writers[0].Driver:     mysqlTestQuery,
+		sqlserverTestQuery.Driver().Pool().Writers[0].Driver: sqlserverTestQuery,
+		sqliteTestQuery.Driver().Pool().Writers[0].Driver:    sqliteTestQuery,
 	}
 }
 


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/660

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request includes updates to the `Query` methods in the `database/gorm/query.go` file to improve SQL query parameterization, as well as changes to the test suite in `tests/query.go` and `tests/query_test.go` to adjust test behavior and add new test cases for date-based filtering. Below are the most important changes grouped by theme:

### Query Parameterization Improvements:
* Updated the `WhereBetween`, `WhereNotBetween`, `OrWhereBetween`, and `OrWhereNotBetween` methods in `database/gorm/query.go` to use parameterized queries with placeholders (`?`) instead of directly embedding values in the SQL string. This change enhances security by preventing SQL injection and improves query performance.

### Test Suite Adjustments:
* Commented out the initialization of MySQL, SQL Server, and SQLite test queries in `tests/query.go`, leaving only PostgreSQL active. This change simplifies the test environment, likely for debugging or temporary exclusion of unsupported databases.
* Moved the creation of test tables from the `SetupSuite` method to the `SetupTest` method in `tests/query_test.go`. This ensures a clean test environment for each test case by recreating tables before each test.

### New Test Cases for Date-Based Filtering:
* Added test cases in `tests/query_test.go` for `WhereBetween`, `WhereNotBetween`, `OrWhereBetween`, and `OrWhereNotBetween` methods to validate filtering based on the `created_at` timestamp. These tests ensure that the methods work correctly with date ranges. [[1]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeR3331-R3334) [[2]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeR3365-R3369) [[3]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeR3389-R3402) [[4]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeR3422-R3435) 

### Minor Test Enhancements:
* Introduced a `carbon.Now()` timestamp in several test cases to provide dynamic date-based filtering, improving the robustness and relevance of the tests. [[1]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeR3314-R3315) [[2]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeR3354-R3356)

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
