### PR TITLE
fix: migration reset and rollback

### DIFF
--- a/database/migration/migrator.go
+++ b/database/migration/migrator.go
@@ -57,6 +57,12 @@ func (r *Migrator) Fresh() error {
 }
 
 func (r *Migrator) Reset() error {
+	if !r.repository.RepositoryExists() {
+		color.Warningln("Migration table not found")
+
+		return nil
+	}
+
 	if err := r.prepareDatabase(); err != nil {
 		return err
 	}
@@ -70,6 +76,12 @@ func (r *Migrator) Reset() error {
 }
 
 func (r *Migrator) Rollback(step, batch int) error {
+	if !r.repository.RepositoryExists() {
+		color.Warningln("Migration table not found")
+
+		return nil
+	}
+
 	files, err := r.getFilesForRollback(step, batch)
 	if err != nil {
 		return err

--- a/database/migration/migrator.go
+++ b/database/migration/migrator.go
@@ -63,10 +63,6 @@ func (r *Migrator) Reset() error {
 		return nil
 	}
 
-	if err := r.prepareDatabase(); err != nil {
-		return err
-	}
-
 	ran, err := r.repository.GetRan()
 	if err != nil {
 		return err

--- a/database/migration/migrator_test.go
+++ b/database/migration/migrator_test.go
@@ -216,14 +216,23 @@ func (s *MigratorSuite) TestReset() {
 		{
 			name: "Get ran failed",
 			setup: func() {
+				s.mockRepository.EXPECT().RepositoryExists().Return(false).Once()
+			},
+		},
+		{
+			name: "failed to get ran",
+			setup: func() {
+				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetRan().Return(nil, assert.AnError).Once()
 			},
 			expectErr: assert.AnError.Error(),
 		},
 		{
-			name: "Rollback with no files",
+			name: "happy path",
 			setup: func() {
+				s.mockRepository.EXPECT().RepositoryExists().Return(true).Twice()
+
 				previousConnection := "postgres"
 				testMigration := NewTestMigration(s.mockSchema)
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
@@ -262,14 +271,17 @@ func (s *MigratorSuite) TestRollback() {
 		expectErr string
 	}{
 		{
-			name: "Rollback with no files",
+			name: "happy path - no files",
 			setup: func() {
+				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return(nil, nil).Once()
 			},
 		},
 		{
-			name: "Rollback with files",
+			name: "happy path",
 			setup: func() {
+				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
+
 				previousConnection := "postgres"
 				testMigration := NewTestMigration(s.mockSchema)
 
@@ -283,14 +295,17 @@ func (s *MigratorSuite) TestRollback() {
 			},
 		},
 		{
-			name: "Rollback with missing migration",
+			name: "happy path - missing migration",
 			setup: func() {
+				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return([]migration.File{{Migration: "20240817214502_create_users_table"}}, nil).Once()
 			},
 		},
 		{
-			name: "Rollback with error",
+			name: "failed to rollback",
 			setup: func() {
+				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
+
 				previousConnection := "postgres"
 				testMigration := NewTestMigration(s.mockSchema)
 
@@ -303,6 +318,20 @@ func (s *MigratorSuite) TestRollback() {
 				s.mockRunDown(mockOrm, previousConnection, testMigration.Signature(), "users", assert.AnError)
 			},
 			expectErr: assert.AnError.Error(),
+		},
+		{
+			name: "failed to get migrations by step",
+			setup: func() {
+				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
+				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return(nil, assert.AnError).Once()
+			},
+			expectErr: assert.AnError.Error(),
+		},
+		{
+			name: "repository doesn't exist",
+			setup: func() {
+				s.mockRepository.EXPECT().RepositoryExists().Return(false).Once()
+			},
 		},
 	}
 

--- a/database/migration/migrator_test.go
+++ b/database/migration/migrator_test.go
@@ -222,8 +222,7 @@ func (s *MigratorSuite) TestReset() {
 		{
 			name: "failed to get ran",
 			setup: func() {
-				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
-				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
+				s.mockRepository.EXPECT().RepositoryExists().Return(true).Twice()
 				s.mockRepository.EXPECT().GetRan().Return(nil, assert.AnError).Once()
 			},
 			expectErr: assert.AnError.Error(),

--- a/database/migration/migrator_test.go
+++ b/database/migration/migrator_test.go
@@ -222,7 +222,7 @@ func (s *MigratorSuite) TestReset() {
 		{
 			name: "failed to get ran",
 			setup: func() {
-				s.mockRepository.EXPECT().RepositoryExists().Return(true).Twice()
+				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetRan().Return(nil, assert.AnError).Once()
 			},
 			expectErr: assert.AnError.Error(),
@@ -234,7 +234,6 @@ func (s *MigratorSuite) TestReset() {
 
 				previousConnection := "postgres"
 				testMigration := NewTestMigration(s.mockSchema)
-				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetRan().Return([]string{testMigration.Signature()}, nil).Once()
 
 				s.mockSchema.EXPECT().Migrations().Return([]contractsschema.Migration{

--- a/tests/migrator_test.go
+++ b/tests/migrator_test.go
@@ -65,10 +65,11 @@ func (s *DefaultMigratorWithDBSuite) TestReset() {
 
 			migrator := migration.NewMigrator(nil, schema, "migrations")
 
+			s.NoError(migrator.Reset())
 			s.NoError(migrator.Run())
 			s.True(schema.HasTable("users"))
-
 			s.NoError(migrator.Reset())
+			s.False(schema.HasTable("users"))
 		})
 	}
 }
@@ -84,10 +85,11 @@ func (s *DefaultMigratorWithDBSuite) TestRollback() {
 
 			migrator := migration.NewMigrator(nil, schema, "migrations")
 
+			s.NoError(migrator.Rollback(1, 0))
 			s.NoError(migrator.Run())
 			s.True(schema.HasTable("users"))
-
 			s.NoError(migrator.Rollback(1, 0))
+			s.False(schema.HasTable("users"))
 		})
 	}
 }


### PR DESCRIPTION
## 📑 Description

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request enhances the `Migrator` functionality by adding checks for the existence of the migration repository and improves test coverage for the `Reset` and `Rollback` methods. Key changes include adding repository existence checks in the `Reset` and `Rollback` methods, updating test cases to handle these scenarios, and verifying behavior when the repository does not exist.

### Enhancements to `Migrator` functionality:
* Added a check in `Reset` to verify if the migration repository exists. If it does not, a warning is logged, and the method exits early. (`database/migration/migrator.go`, [database/migration/migrator.goR60-R65](diffhunk://#diff-f8d858a2d874212813f0762d22b0310413ce5972f6439bc386e8cd28cf3d1091R60-R65))
* Added a similar repository existence check in `Rollback` to ensure the method exits early if the repository is missing. (`database/migration/migrator.go`, [database/migration/migrator.goR79-R84](diffhunk://#diff-f8d858a2d874212813f0762d22b0310413ce5972f6439bc386e8cd28cf3d1091R79-R84))

### Test coverage improvements:
* Updated `TestReset` in `MigratorSuite` to include a case where the repository does not exist, ensuring `Reset` handles this scenario gracefully. (`database/migration/migrator_test.go`, [database/migration/migrator_test.goR219-R235](diffhunk://#diff-30e5a3dd92f4e95ac8ff367411c7b1dcbec508abd2a78ae68b65deec3241ce6cR219-R235))
* Enhanced `TestRollback` in `MigratorSuite` with additional cases, including scenarios where the repository does not exist or errors occur during migration retrieval. (`database/migration/migrator_test.go`, [[1]](diffhunk://#diff-30e5a3dd92f4e95ac8ff367411c7b1dcbec508abd2a78ae68b65deec3241ce6cL265-R284) [[2]](diffhunk://#diff-30e5a3dd92f4e95ac8ff367411c7b1dcbec508abd2a78ae68b65deec3241ce6cL286-R308) [[3]](diffhunk://#diff-30e5a3dd92f4e95ac8ff367411c7b1dcbec508abd2a78ae68b65deec3241ce6cR322-R335)
* Modified integration tests in `DefaultMigratorWithDBSuite` to verify that `Reset` and `Rollback` correctly handle table existence after execution. (`tests/migrator_test.go`, [[1]](diffhunk://#diff-7c39ba02910f9824dabbbc635ad6117fd41e9ed2e5e952c6ddf34dea70b3e75aR68-R72) [[2]](diffhunk://#diff-7c39ba02910f9824dabbbc635ad6117fd41e9ed2e5e952c6ddf34dea70b3e75aR88-R92)

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
