### PR TITLE
fix: module path separator on Windows

### DIFF
--- a/packages/setup.go
+++ b/packages/setup.go
@@ -2,7 +2,7 @@ package packages
 
 import (
 	"os"
-	"path/filepath"
+	"path"
 	"runtime/debug"
 	"strings"
 
@@ -24,7 +24,7 @@ var osExit = os.Exit
 
 func GetModulePath() string {
 	if info, ok := debug.ReadBuildInfo(); ok && strings.HasSuffix(info.Path, "setup") {
-		return filepath.Dir(info.Path)
+		return path.Dir(info.Path)
 	}
 
 	return ""


### PR DESCRIPTION
## 📑 Description

<img width="1477" alt="image" src="https://github.com/user-attachments/assets/bd20b731-bc3c-45d4-b8b7-6eee4eadf122" />


`filepath.Dir` returns `\` as a path separator on Windows, which leads to invalid Go import paths when writing module paths into source files (e.g. during `package:install`). Replacing it with `path.Dir` ensures `/` is always used, as required by Go import syntax. This issue only affects Windows systems.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
