### PR TITLE
feat: optimize validate time

### DIFF
--- a/validation/validator.go
+++ b/validation/validator.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"net/url"
 	"reflect"
+	"time"
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/gookit/validate"
@@ -197,6 +198,10 @@ func (v *Validator) castValue() mapstructure.DecodeHookFunc {
 			case reflect.TypeOf(carbon.TimestampNano{}):
 				castedValue = castCarbon(from, func(c *carbon.Carbon) any {
 					return carbon.NewTimestampNano(c)
+				})
+			case reflect.TypeOf(time.Time{}):
+				castedValue = castCarbon(from, func(c *carbon.Carbon) any {
+					return c.StdTime()
 				})
 			}
 		default:

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/gookit/validate"
 	"github.com/spf13/cast"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/goravel/framework/foundation/json"
 	"github.com/goravel/framework/support/carbon"
+	"github.com/goravel/framework/support/convert"
 )
 
 func TestBind_Rule(t *testing.T) {
@@ -39,6 +41,7 @@ func TestBind_Rule(t *testing.T) {
 		TimestampMilli *carbon.TimestampMilli `form:"timestamp_milli" json:"timestamp_milli"`
 		TimestampMicro *carbon.TimestampMicro `form:"timestamp_micro" json:"timestamp_micro"`
 		TimestampNano  *carbon.TimestampNano  `form:"timestamp_nano" json:"timestamp_nano"`
+		Time           *time.Time             `form:"time" json:"time"`
 	}
 
 	tests := []struct {
@@ -542,6 +545,40 @@ func TestBind_Rule(t *testing.T) {
 			},
 		},
 		{
+			name: "data is post request with Time",
+			data: func() validate.DataFace {
+				request, err := http.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"time": "2025-05-23 22:16:39"}`))
+				request.Header.Set("Content-Type", "application/json")
+				assert.Nil(t, err)
+
+				data, err := validate.FromRequest(request)
+				assert.Nil(t, err)
+
+				return data
+			}(),
+			rules: map[string]string{"time": "required"},
+			assert: func(data Data) {
+				assert.Equal(t, "2025-05-23 22:16:39", data.Time.Format("2006-01-02 15:04:05"))
+			},
+		},
+		{
+			name: "data is post request with Time(date)",
+			data: func() validate.DataFace {
+				request, err := http.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"time": "2025-05-23"}`))
+				request.Header.Set("Content-Type", "application/json")
+				assert.Nil(t, err)
+
+				data, err := validate.FromRequest(request)
+				assert.Nil(t, err)
+
+				return data
+			}(),
+			rules: map[string]string{"time": "required"},
+			assert: func(data Data) {
+				assert.Equal(t, "2025-05-23", data.Time.Format("2006-01-02"))
+			},
+		},
+		{
 			name: "data is post request with body",
 			data: func() validate.DataFace {
 				request := buildRequest(t)
@@ -767,6 +804,7 @@ func TestCastValue(t *testing.T) {
 		PointerTimestampMilli *carbon.TimestampMilli `form:"PointerTimestampMilli" json:"PointerTimestampMilli"`
 		PointerTimestampMicro *carbon.TimestampMicro `form:"PointerTimestampMicro" json:"PointerTimestampMicro"`
 		PointerTimestampNano  *carbon.TimestampNano  `form:"PointerTimestampNano" json:"PointerTimestampNano"`
+		PointerTime           *time.Time             `form:"PointerTime" json:"PointerTime"`
 		Carbon                carbon.Carbon          `form:"Carbon" json:"Carbon"`
 		DateTime              carbon.DateTime        `form:"DateTime" json:"DateTime"`
 		DateTimeMilli         carbon.DateTimeMilli   `form:"DateTimeMilli" json:"DateTimeMilli"`
@@ -780,6 +818,7 @@ func TestCastValue(t *testing.T) {
 		TimestampMilli        carbon.TimestampMilli  `form:"TimestampMilli" json:"TimestampMilli"`
 		TimestampMicro        carbon.TimestampMicro  `form:"TimestampMicro" json:"TimestampMicro"`
 		TimestampNano         carbon.TimestampNano   `form:"TimestampNano" json:"TimestampNano"`
+		Time                  time.Time              `form:"Time" json:"Time"`
 	}
 
 	wantData := Data{
@@ -815,6 +854,7 @@ func TestCastValue(t *testing.T) {
 		PointerTimestampMilli: carbon.NewTimestampMilli(carbon.FromTimestampMilli(timestampMilli)),
 		PointerTimestampMicro: carbon.NewTimestampMicro(carbon.FromTimestampMicro(timestampMicro)),
 		PointerTimestampNano:  carbon.NewTimestampNano(carbon.FromTimestampNano(timestampNano)),
+		PointerTime:           convert.Pointer(carbon.NewDateTime(carbon.Parse(dateTime)).StdTime()),
 		Carbon:                *carbon.Parse(dateTime),
 		DateTime:              *carbon.NewDateTime(carbon.Parse(dateTime)),
 		DateTimeMilli:         *carbon.NewDateTimeMilli(carbon.Parse(dateTime)),
@@ -828,6 +868,7 @@ func TestCastValue(t *testing.T) {
 		TimestampMilli:        *carbon.NewTimestampMilli(carbon.FromTimestampMilli(timestampMilli)),
 		TimestampMicro:        *carbon.NewTimestampMicro(carbon.FromTimestampMicro(timestampMicro)),
 		TimestampNano:         *carbon.NewTimestampNano(carbon.FromTimestampNano(timestampNano)),
+		Time:                  carbon.NewDateTime(carbon.Parse(dateTime)).StdTime(),
 	}
 
 	tests := []struct {
@@ -871,6 +912,7 @@ func TestCastValue(t *testing.T) {
 					PointerTimestampMilli: carbon.NewTimestampMilli(carbon.Parse(dateTime)),
 					PointerTimestampMicro: carbon.NewTimestampMicro(carbon.Parse(dateTime)),
 					PointerTimestampNano:  carbon.NewTimestampNano(carbon.Parse(dateTime)),
+					PointerTime:           convert.Pointer(carbon.NewDateTime(carbon.Parse(dateTime)).StdTime()),
 					Carbon:                *carbon.Parse(dateTime),
 					DateTime:              *carbon.NewDateTime(carbon.Parse(dateTime)),
 					DateTimeMilli:         *carbon.NewDateTimeMilli(carbon.Parse(dateTime)),
@@ -884,6 +926,7 @@ func TestCastValue(t *testing.T) {
 					TimestampMilli:        *carbon.NewTimestampMilli(carbon.Parse(dateTime)),
 					TimestampMicro:        *carbon.NewTimestampMicro(carbon.Parse(dateTime)),
 					TimestampNano:         *carbon.NewTimestampNano(carbon.Parse(dateTime)),
+					Time:                  carbon.NewDateTime(carbon.Parse(dateTime)).StdTime(),
 				}
 				jsonBytes, err := json.New().Marshal(body)
 				assert.Nil(t, err)
@@ -932,6 +975,7 @@ func TestCastValue(t *testing.T) {
 					"PointerTimestampMilli": timestampMilli,
 					"PointerTimestampMicro": timestampMicro,
 					"PointerTimestampNano":  timestampNano,
+					"PointerTime":           dateTime,
 					"Carbon":                dateTime,
 					"DateTime":              dateTime,
 					"DateTimeMilli":         dateTime,
@@ -945,6 +989,7 @@ func TestCastValue(t *testing.T) {
 					"TimestampMilli":        timestampMilli,
 					"TimestampMicro":        timestampMicro,
 					"TimestampNano":         timestampNano,
+					"Time":                  dateTime,
 				}
 				jsonBytes, err := json.New().Marshal(body)
 				assert.Nil(t, err)


### PR DESCRIPTION
## 📑 Description

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request enhances the `Validator` functionality by adding support for the `time.Time` type and extends test coverage to validate this new feature. The main changes include updates to the `castValue` method in `validation/validator.go` and the addition of test cases in `validation/validator_test.go`.

### Enhancements to `Validator` functionality:
* **Support for `time.Time` in `castValue`**: Added logic to handle `time.Time` type in the `castValue` method, converting `carbon.Carbon` instances to standard Go `time.Time` objects. (`validation/validator.go`, [validation/validator.goR202-R205](diffhunk://#diff-9b2ad32411ea3fff2cc0a5c0fcd46747bc37e19550a97ee26e25c1afb236f1d7R202-R205))

### Test coverage improvements:
* **Updated test structures**: Modified test data structures in `TestBind_Rule` and `TestCastValue` to include `time.Time` and pointer to `time.Time`. (`validation/validator_test.go`, [[1]](diffhunk://#diff-f0c2fc95de076483a6e29279cb797275bfa1f3dc9e97052e4d24fab16e9e4536R44) [[2]](diffhunk://#diff-f0c2fc95de076483a6e29279cb797275bfa1f3dc9e97052e4d24fab16e9e4536R807) [[3]](diffhunk://#diff-f0c2fc95de076483a6e29279cb797275bfa1f3dc9e97052e4d24fab16e9e4536R821)
* **New test cases for `time.Time`**: Added test cases to validate `time.Time` parsing, including scenarios for full datetime strings and date-only strings. (`validation/validator_test.go`, [validation/validator_test.goR547-R580](diffhunk://#diff-f0c2fc95de076483a6e29279cb797275bfa1f3dc9e97052e4d24fab16e9e4536R547-R580))
* **Validation of casting behavior**: Extended `TestCastValue` to verify correct handling of `time.Time` and pointer to `time.Time` in various scenarios. (`validation/validator_test.go`, [[1]](diffhunk://#diff-f0c2fc95de076483a6e29279cb797275bfa1f3dc9e97052e4d24fab16e9e4536R857) [[2]](diffhunk://#diff-f0c2fc95de076483a6e29279cb797275bfa1f3dc9e97052e4d24fab16e9e4536R915)

### Additional changes:
* **Imports updated**: Added `time` and `convert` packages to support the new functionality. (`validation/validator.go`, [[1]](diffhunk://#diff-9b2ad32411ea3fff2cc0a5c0fcd46747bc37e19550a97ee26e25c1afb236f1d7R6); `validation/validator_test.go`, [[2]](diffhunk://#diff-f0c2fc95de076483a6e29279cb797275bfa1f3dc9e97052e4d24fab16e9e4536R12) [[3]](diffhunk://#diff-f0c2fc95de076483a6e29279cb797275bfa1f3dc9e97052e4d24fab16e9e4536R21)

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
