### PR TITLE
fix: [#699] database timezone

### DIFF
--- a/database/migration/stubs.go
+++ b/database/migration/stubs.go
@@ -47,7 +47,7 @@ func (r *DummyMigration) Up() error {
 	if !facades.Schema().HasTable("DummyTable") {
 		return facades.Schema().Create("DummyTable", func(table schema.Blueprint) {
 			table.ID()
-			table.Timestamps()
+			table.TimestampsTz()
 		})
 	}
 


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/699

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

Currently, for `Timestamps` column of Postgres and Sqlserver, `2025-06-05 14:46:29 +08:00` will be saved with `2025-06-05 14:46:29`, but when reading, ORM considers that the timezone is UTC, the timezone metadata is missed.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
