### PR TITLE
feat: [#510] Get origin route path

### DIFF
--- a/contracts/http/request.go
+++ b/contracts/http/request.go
@@ -19,7 +19,7 @@ type ContextRequest interface {
 	// Method retrieves the HTTP request method (e.g., GET, POST, PUT).
 	Method() string
 	// OriginPath retrieves the original path of the request: /users/{id}
-	OriginPath()
+	OriginPath() string
 	// Path retrieves the current path information for the request: /users/1
 	Path() string
 	// Url retrieves the URL (excluding the query string) for the request.

--- a/mocks/http/ContextRequest.go
+++ b/mocks/http/ContextRequest.go
@@ -1303,8 +1303,21 @@ func (_c *ContextRequest_Origin_Call) RunAndReturn(run func() *nethttp.Request) 
 }
 
 // OriginPath provides a mock function with no fields
-func (_m *ContextRequest) OriginPath() {
-	_m.Called()
+func (_m *ContextRequest) OriginPath() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for OriginPath")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
 }
 
 // ContextRequest_OriginPath_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'OriginPath'
@@ -1324,13 +1337,13 @@ func (_c *ContextRequest_OriginPath_Call) Run(run func()) *ContextRequest_Origin
 	return _c
 }
 
-func (_c *ContextRequest_OriginPath_Call) Return() *ContextRequest_OriginPath_Call {
-	_c.Call.Return()
+func (_c *ContextRequest_OriginPath_Call) Return(_a0 string) *ContextRequest_OriginPath_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *ContextRequest_OriginPath_Call) RunAndReturn(run func()) *ContextRequest_OriginPath_Call {
-	_c.Run(run)
+func (_c *ContextRequest_OriginPath_Call) RunAndReturn(run func() string) *ContextRequest_OriginPath_Call {
+	_c.Call.Return(run)
 	return _c
 }
 


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/510

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request introduces enhancements to the `ContextRequest` interface and its associated mock implementation. The changes focus on adding support for retrieving the original path of an HTTP request, improving functionality and testing capabilities.

### Enhancements to the `ContextRequest` interface:

* Added a new method `OriginPath()` to retrieve the original path of the request (e.g., `/users/{id}`), alongside the existing `Path()` method for the current path (e.g., `/users/1`). (`contracts/http/request.go`, [contracts/http/request.goL21-R23](diffhunk://#diff-f4712554c84548c3b2a3dd1cabe9e172469ab7fd42cd08c2ce05734f12c27abcL21-R23))

### Updates to the mock implementation:

* Implemented the `OriginPath()` method in the mock `ContextRequest` class, including helper methods (`Run`, `Return`, and `RunAndReturn`) for defining mock behavior and expectations. (`mocks/http/ContextRequest.go`, [mocks/http/ContextRequest.goR1305-R1336](diffhunk://#diff-a34e02b5cc24f6367f2b8adf025c23bcac433d083db04fda5d9d90085bca1746R1305-R1336))

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
