### PR TITLE
feat: [#632] Add GetRoutes method

### DIFF
--- a/contracts/route/route.go
+++ b/contracts/route/route.go
@@ -74,7 +74,6 @@ type Router interface {
 }
 
 type RouteInfo struct {
-	Method  string
-	Path    string
-	Handler string
+	Method string
+	Path   string
 }

--- a/contracts/route/route.go
+++ b/contracts/route/route.go
@@ -14,6 +14,8 @@ type Route interface {
 	Router
 	// Fallback registers a handler to be executed when no other route was matched.
 	Fallback(handler contractshttp.HandlerFunc)
+	// GetRoutes retrieves all the routes registered with the router.
+	GetRoutes() []RouteInfo
 	// GlobalMiddleware registers global middleware to be applied to all routes of the router.
 	GlobalMiddleware(middlewares ...contractshttp.Middleware)
 	// Listen starts the HTTP server and listens on the specified listener.
@@ -69,4 +71,10 @@ type Router interface {
 	StaticFile(relativePath, filepath string)
 	// StaticFS registers a new route with a path prefix to serve static files from the provided file system.
 	StaticFS(relativePath string, fs http.FileSystem)
+}
+
+type RouteInfo struct {
+	Method  string
+	Path    string
+	Handler string
 }

--- a/mocks/route/Route.go
+++ b/mocks/route/Route.go
@@ -163,6 +163,53 @@ func (_c *Route_Get_Call) RunAndReturn(run func(string, http.HandlerFunc)) *Rout
 	return _c
 }
 
+// GetRoutes provides a mock function with no fields
+func (_m *Route) GetRoutes() []route.RouteInfo {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRoutes")
+	}
+
+	var r0 []route.RouteInfo
+	if rf, ok := ret.Get(0).(func() []route.RouteInfo); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]route.RouteInfo)
+		}
+	}
+
+	return r0
+}
+
+// Route_GetRoutes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRoutes'
+type Route_GetRoutes_Call struct {
+	*mock.Call
+}
+
+// GetRoutes is a helper method to define mock.On call
+func (_e *Route_Expecter) GetRoutes() *Route_GetRoutes_Call {
+	return &Route_GetRoutes_Call{Call: _e.mock.On("GetRoutes")}
+}
+
+func (_c *Route_GetRoutes_Call) Run(run func()) *Route_GetRoutes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Route_GetRoutes_Call) Return(_a0 []route.RouteInfo) *Route_GetRoutes_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Route_GetRoutes_Call) RunAndReturn(run func() []route.RouteInfo) *Route_GetRoutes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GlobalMiddleware provides a mock function with given fields: middlewares
 func (_m *Route) GlobalMiddleware(middlewares ...http.Middleware) {
 	_va := make([]interface{}, len(middlewares))


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/632

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request introduces a new method, `GetRoutes`, to the `Route` interface in `contracts/route/route.go` for retrieving all registered routes, along with its implementation in the mock `Route` object in `mocks/route/Route.go`. Additionally, it defines a new `RouteInfo` struct to encapsulate route metadata such as method, path, and handler.

### Enhancements to route management:

* **Added `GetRoutes` method to `Route` interface**: Enables retrieval of all registered routes in the router.
* **Introduced `RouteInfo` struct**: Represents metadata for routes, including HTTP method, path, and handler name.

### Mock implementation updates:

* **Implemented `GetRoutes` in mock `Route`**: Provides a mock function for testing the `GetRoutes` method, including helper methods like `Return` and `RunAndReturn` for defining mock behavior.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
