### PR TITLE
feat: [#560] facades.Testing().Docker() supports lanuching any image

### DIFF
--- a/contracts/testing/docker/image.go
+++ b/contracts/testing/docker/image.go
@@ -7,3 +7,17 @@ type Image struct {
 	Tag          string
 	Args         []string
 }
+
+type ImageDriver interface {
+	// Build the image.
+	Build() error
+	// Config gets the image configuration.
+	Config() ImageConfig
+	// Shutdown the image.
+	Shutdown() error
+}
+
+type ImageConfig struct {
+	ContainerID  string
+	ExposedPorts map[int]int
+}

--- a/contracts/testing/testing.go
+++ b/contracts/testing/testing.go
@@ -14,4 +14,6 @@ type Docker interface {
 	Cache(store ...string) (docker.CacheDriver, error)
 	// Database gets a database connection instance.
 	Database(connection ...string) (docker.Database, error)
+	// Image gets a image instance.
+	Image(image docker.Image) docker.ImageDriver
 }

--- a/errors/list.go
+++ b/errors/list.go
@@ -176,6 +176,10 @@ var (
 	TemplateFailedToParse         = New("failed to parse template: %v")
 	TemplateFailedToFormateGoCode = New("failed to format go code: %v")
 
+	TestingImageBuildFailed   = New("init %s docker error: %v")
+	TestingImageNoContainerId = New("no container id return when creating %s docker")
+	TestingImageStopFailed    = New("stop %s docker error: %v")
+
 	UnknownFileExtension = New("unknown file extension")
 
 	ValidationDataInvalidType      = New("data must be map[string]any or map[string][]string or struct")

--- a/support/docker/utils.go
+++ b/support/docker/utils.go
@@ -10,21 +10,7 @@ import (
 	"github.com/goravel/framework/support/process"
 )
 
-func ExposedPort(exposedPorts []string, port int) int {
-	for _, exposedPort := range exposedPorts {
-		if !strings.Contains(exposedPort, cast.ToString(port)) {
-			continue
-		}
-
-		ports := strings.Split(exposedPort, ":")
-
-		return cast.ToInt(ports[0])
-	}
-
-	return 0
-}
-
-func ImageToCommand(image *docker.Image) (command string, exposedPorts []string) {
+func ImageToCommand(image *docker.Image) (command string, exposedPorts map[int]int) {
 	if image == nil {
 		return "", nil
 	}
@@ -35,13 +21,13 @@ func ImageToCommand(image *docker.Image) (command string, exposedPorts []string)
 			commands = append(commands, "-e", env)
 		}
 	}
-	var ports []string
+	ports := make(map[int]int)
 	if len(image.ExposedPorts) > 0 {
 		for _, port := range image.ExposedPorts {
 			if !strings.Contains(port, ":") {
 				port = fmt.Sprintf("%d:%s", process.ValidPort(), port)
 			}
-			ports = append(ports, port)
+			ports[cast.ToInt(strings.Split(port, ":")[1])] = cast.ToInt(strings.Split(port, ":")[0])
 			commands = append(commands, "-p", port)
 		}
 	}

--- a/support/docker/utils_test.go
+++ b/support/docker/utils_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/goravel/framework/contracts/testing/docker"
 )
 
-func TestExposedPort(t *testing.T) {
-	assert.Equal(t, 1, ExposedPort([]string{"1:2"}, 2))
-}
-
 func TestImageToCommand(t *testing.T) {
 	command, exposedPorts := ImageToCommand(nil)
 	assert.Equal(t, "", command)
@@ -32,8 +28,8 @@ func TestImageToCommand(t *testing.T) {
 		ExposedPorts: []string{"6379"},
 		Env:          []string{"a=b"},
 	})
-	assert.Equal(t, fmt.Sprintf("docker run --rm -d -e a=b -p %d:6379 redis:latest", ExposedPort(exposedPorts, 6379)), command)
-	assert.True(t, ExposedPort(exposedPorts, 6379) > 0)
+	assert.Equal(t, fmt.Sprintf("docker run --rm -d -e a=b -p %d:6379 redis:latest", exposedPorts[6379]), command)
+	assert.True(t, exposedPorts[6379] > 0)
 
 	command, exposedPorts = ImageToCommand(&docker.Image{
 		Repository:   "redis",
@@ -43,5 +39,5 @@ func TestImageToCommand(t *testing.T) {
 		Args:         []string{"--a=b"},
 	})
 	assert.Equal(t, "docker run --rm -d -e a=b -p 1234:6379 redis:latest --a=b", command)
-	assert.Equal(t, []string{"1234:6379"}, exposedPorts)
+	assert.Equal(t, map[int]int{6379: 1234}, exposedPorts)
 }

--- a/testing/docker/docker.go
+++ b/testing/docker/docker.go
@@ -44,3 +44,7 @@ func (r *Docker) Database(connection ...string) (docker.Database, error) {
 		return NewDatabase(r.artisan, r.config, r.orm, connection[0])
 	}
 }
+
+func (r *Docker) Image(image docker.Image) docker.ImageDriver {
+	return NewImageDriver(image)
+}

--- a/testing/docker/image.go
+++ b/testing/docker/image.go
@@ -1,0 +1,53 @@
+package docker
+
+import (
+	"fmt"
+
+	contractsdocker "github.com/goravel/framework/contracts/testing/docker"
+	"github.com/goravel/framework/errors"
+	supportdocker "github.com/goravel/framework/support/docker"
+	"github.com/goravel/framework/support/process"
+)
+
+type ImageDriver struct {
+	config contractsdocker.ImageConfig
+	image  contractsdocker.Image
+}
+
+func NewImageDriver(image contractsdocker.Image) *ImageDriver {
+	return &ImageDriver{
+		image: image,
+	}
+}
+
+func (r *ImageDriver) Build() error {
+	command, exposedPorts := supportdocker.ImageToCommand(&r.image)
+	containerID, err := process.Run(command)
+	if err != nil {
+		return errors.TestingImageBuildFailed.Args(r.image.Repository, err)
+	}
+	if containerID == "" {
+		return errors.TestingImageNoContainerId.Args(r.image.Repository)
+	}
+
+	r.config = contractsdocker.ImageConfig{
+		ContainerID:  containerID,
+		ExposedPorts: exposedPorts,
+	}
+
+	return nil
+}
+
+func (r *ImageDriver) Config() contractsdocker.ImageConfig {
+	return r.config
+}
+
+func (r *ImageDriver) Shutdown() error {
+	if r.config.ContainerID != "" {
+		if _, err := process.Run(fmt.Sprintf("docker stop %s", r.config.ContainerID)); err != nil {
+			return errors.TestingImageStopFailed.Args(r.image.Repository, err)
+		}
+	}
+
+	return nil
+}

--- a/testing/docker/image_test.go
+++ b/testing/docker/image_test.go
@@ -1,0 +1,46 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	contractsdocker "github.com/goravel/framework/contracts/testing/docker"
+)
+
+type ImageDriverTestSuite struct {
+	suite.Suite
+	image contractsdocker.Image
+}
+
+func TestImageDriverTestSuite(t *testing.T) {
+	suite.Run(t, new(ImageDriverTestSuite))
+}
+
+func (s *ImageDriverTestSuite) SetupTest() {
+	s.image = contractsdocker.Image{
+		Repository:   "redis",
+		Tag:          "latest",
+		ExposedPorts: []string{"6379"},
+	}
+}
+
+func (s *ImageDriverTestSuite) TestNewImageDriver() {
+	driver := NewImageDriver(s.image)
+	assert.NotNil(s.T(), driver)
+	assert.Equal(s.T(), s.image, driver.image)
+}
+
+func (s *ImageDriverTestSuite) TestBuildConfigShutdown() {
+	driver := NewImageDriver(s.image)
+	err := driver.Build()
+	s.NoError(err)
+
+	config := driver.Config()
+	s.NotEmpty(config.ContainerID)
+	s.True(config.ExposedPorts[6379] > 0)
+
+	err = driver.Shutdown()
+	s.NoError(err)
+}


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/560

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request introduces a new `ImageDriver` interface and its implementation, along with related changes to manage Docker images more effectively. The changes include the addition of a new driver for handling Docker image operations, updates to utility functions, and new error messages for better error handling.

### Addition of `ImageDriver` functionality:
* Added the `ImageDriver` interface and its implementation in `testing/docker/image.go` to handle Docker image operations like `Build`, `Config`, and `Shutdown`. It includes logic for running Docker commands and managing container configurations.
* Introduced the `ImageConfig` struct in `contracts/testing/docker/image.go` to store container IDs and exposed ports.
* Added a new method `Image` in the `Docker` interface in `contracts/testing/testing.go` to retrieve an `ImageDriver` instance.

### Updates to utility functions:
* Refactored the `ImageToCommand` function in `support/docker/utils.go` to return a `map[int]int` for exposed ports instead of a `[]string`. This improves clarity and simplifies port mapping logic. [[1]](diffhunk://#diff-dd7c9ea2f1f4d4d65892fc1e4e7539306bd15c034626dc7d12dbe75283ffb6ceL13-R13) [[2]](diffhunk://#diff-dd7c9ea2f1f4d4d65892fc1e4e7539306bd15c034626dc7d12dbe75283ffb6ceL38-R30)
* Removed the `ExposedPort` utility function as it is no longer needed after the refactoring.

### Enhancements to error handling:
* Added new error messages in `errors/list.go` for handling Docker image-related failures, such as build errors, missing container IDs, and shutdown errors.

### Testing improvements:
* Added unit tests for the `ImageDriver` implementation in `testing/docker/image_test.go`, covering initialization, build, configuration retrieval, and shutdown.
* Updated existing tests in `support/docker/utils_test.go` to align with the refactored `ImageToCommand` function and new port mapping logic. [[1]](diffhunk://#diff-0b0079b3abb7d848e45c39c8b6134eb50204bb1c6b5f6361a3b22ff5701f41f2L12-L15) [[2]](diffhunk://#diff-0b0079b3abb7d848e45c39c8b6134eb50204bb1c6b5f6361a3b22ff5701f41f2L35-R32) [[3]](diffhunk://#diff-0b0079b3abb7d848e45c39c8b6134eb50204bb1c6b5f6361a3b22ff5701f41f2L46-R42)

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
