### PR TITLE
fix: [#706] Setting timezone in MySQL DSN (e.g., Asia/Shanghai) causes “invalid DSN” error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rabbitmq/amqp091-go v1.10.0 // indirect
-	github.com/redis/go-redis/v9 v9.5.1 // indirect
+	github.com/redis/go-redis/v9 v9.8.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/zerolog v1.33.0 // indirect
 	github.com/sagikazarmark/locafero v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1019,8 +1019,8 @@ github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzuk
 github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/redis/go-redis/v9 v9.0.2/go.mod h1:/xDTe9EF1LM61hek62Poq2nzQSGj0xSrEtEHbBQevps=
 github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
-github.com/redis/go-redis/v9 v9.5.1 h1:H1X4D3yHPaYrkL5X06Wh6xNVM/pX0Ft4RV0vMGvLBh8=
-github.com/redis/go-redis/v9 v9.5.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
+github.com/redis/go-redis/v9 v9.8.0 h1:q3nRvjrlge/6UD7eTu/DSg2uYiU2mCL0G/uzBWqhicI=
+github.com/redis/go-redis/v9 v9.8.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/redis/rueidis v1.0.19 h1:s65oWtotzlIFN8eMPhyYwxlwLR1lUdhza2KtWprKYSo=
 github.com/redis/rueidis v1.0.19/go.mod h1:8B+r5wdnjwK3lTFml5VtxjzGOQAC+5UmujoD12pDrEo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/tests/db_test.go
+++ b/tests/db_test.go
@@ -1396,7 +1396,7 @@ func TestDB_Connection(t *testing.T) {
 
 	dbConfig := sqliteTestQuery.Driver().Pool().Writers[0]
 	sqliteConnection := dbConfig.Connection
-	mockDatabaseConfig(postgresTestQuery.MockConfig(), dbConfig, sqliteConnection, "", false)
+	mockDatabaseConfig(postgresTestQuery.MockConfig(), dbConfig)
 
 	result, err := postgresTestQuery.DB().Table("products").Insert(Product{
 		Name: "connection",
@@ -1435,7 +1435,7 @@ func TestDB_Connection(t *testing.T) {
 }
 
 func TestDbReadWriteSeparate(t *testing.T) {
-	dbs := NewTestQueryBuilder().AllOfReadWrite()
+	dbs := NewTestQueryBuilder().AllWithReadWrite()
 
 	for drive, db := range dbs {
 		t.Run(drive, func(t *testing.T) {

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -9,8 +9,8 @@ godebug x509negativeserial=1
 require (
 	github.com/brianvoe/gofakeit/v7 v7.2.1
 	github.com/goravel/framework v1.15.9
-	github.com/goravel/mysql v0.0.0-20250614082643-dc2e9d06fa87
-	github.com/goravel/postgres v0.0.2-0.20250614082532-c93c5c0b19d2
+	github.com/goravel/mysql v0.0.0-20250614145606-b31ab56d1e4c
+	github.com/goravel/postgres v0.0.2-0.20250614145557-ab2119aeac96
 	github.com/goravel/sqlite v0.0.0-20250614082629-1038310944c3
 	github.com/goravel/sqlserver v0.0.0-20250614082609-66b6852361e5
 	github.com/spf13/cast v1.9.2

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -90,10 +90,10 @@ github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQ
 github.com/gookit/color v1.5.0/go.mod h1:43aQb+Zerm/BWh2GnrgOQm7ffz7tvQXEKV6BFMl7wAo=
 github.com/gookit/color v1.5.4 h1:FZmqs7XOyGgCAxmWyPslpiok1k05wmY3SJTytgvYFs0=
 github.com/gookit/color v1.5.4/go.mod h1:pZJOeOS8DM43rXbp4AZo1n9zCU2qjpcRko0b6/QJi9w=
-github.com/goravel/mysql v0.0.0-20250614082643-dc2e9d06fa87 h1:XJs7+IWH8l3b4ebK1GkWowpZMdAwEU38JFwJuT3vU6A=
-github.com/goravel/mysql v0.0.0-20250614082643-dc2e9d06fa87/go.mod h1:CRpn9cxGddS8vp98RM+9arrfUaMZL9wnHOEpc3rNSig=
-github.com/goravel/postgres v0.0.2-0.20250614082532-c93c5c0b19d2 h1:Kf8qeOlCtDfTNqhJ1lmzJfHMKMjk6/8Ye6fVMDpzXyM=
-github.com/goravel/postgres v0.0.2-0.20250614082532-c93c5c0b19d2/go.mod h1:pS8c1br3gN2lKh0KQm/75a3RjYtF7QIXWX3OsheQCwQ=
+github.com/goravel/mysql v0.0.0-20250614145606-b31ab56d1e4c h1:/yxqbdOCrNRbJ71VTLaNEO8xt/LBcsDM1Q4z0+bj/PM=
+github.com/goravel/mysql v0.0.0-20250614145606-b31ab56d1e4c/go.mod h1:CRpn9cxGddS8vp98RM+9arrfUaMZL9wnHOEpc3rNSig=
+github.com/goravel/postgres v0.0.2-0.20250614145557-ab2119aeac96 h1:SYZcopDwFPiIYUqDj7iMQHbj/phYAL0mF1QZl0VW1Zs=
+github.com/goravel/postgres v0.0.2-0.20250614145557-ab2119aeac96/go.mod h1:pS8c1br3gN2lKh0KQm/75a3RjYtF7QIXWX3OsheQCwQ=
 github.com/goravel/sqlite v0.0.0-20250614082629-1038310944c3 h1:3OwFzNEpf5IthUaUVAJFkcimsoMdmN+bgzWCFM0FD3U=
 github.com/goravel/sqlite v0.0.0-20250614082629-1038310944c3/go.mod h1:sw2F1gwcWtT37QYEEtbIilJeSalAubzoK/EBqgs66Bc=
 github.com/goravel/sqlserver v0.0.0-20250614082609-66b6852361e5 h1:fbg8Kdc0Fo0PgHUh00BcCtjN5smSmSLKl5aekQcmteo=

--- a/tests/mock_config.go
+++ b/tests/mock_config.go
@@ -14,14 +14,16 @@ import (
 	"github.com/goravel/sqlserver"
 )
 
-func mockDatabaseConfig(mockConfig *mocksconfig.Config, config database.Config, connection string, prefix string, singular bool) {
-	mockConfig.EXPECT().Get(fmt.Sprintf("database.connections.%s.write", connection)).Return(nil)
-	mockConfig.EXPECT().Get(fmt.Sprintf("database.connections.%s.read", connection)).Return(nil)
+func mockDatabaseConfig(mockConfig *mocksconfig.Config, config database.Config) {
+	mockConfig.EXPECT().Get(fmt.Sprintf("database.connections.%s.write", config.Connection)).Return(nil)
+	mockConfig.EXPECT().Get(fmt.Sprintf("database.connections.%s.read", config.Connection)).Return(nil)
 
-	mockDatabaseConfigWithoutWriteAndRead(mockConfig, config, connection, prefix, singular)
+	mockDatabaseConfigWithoutWriteAndRead(mockConfig, config)
 }
 
-func mockDatabaseConfigWithoutWriteAndRead(mockConfig *mocksconfig.Config, config database.Config, connection string, prefix string, singular bool) {
+func mockDatabaseConfigWithoutWriteAndRead(mockConfig *mocksconfig.Config, config database.Config) {
+	connection := config.Connection
+
 	mockConfig.EXPECT().GetBool("app.debug").Return(true)
 	mockConfig.EXPECT().GetInt("database.slow_threshold", 200).Return(200)
 	mockConfig.EXPECT().GetInt("database.pool.max_idle_conns", 10).Return(10)
@@ -34,8 +36,8 @@ func mockDatabaseConfigWithoutWriteAndRead(mockConfig *mocksconfig.Config, confi
 	mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.username", connection)).Return(config.Username)
 	mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.password", connection)).Return(config.Password)
 	mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.database", connection)).Return(config.Database)
-	mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.prefix", connection)).Return(prefix)
-	mockConfig.EXPECT().GetBool(fmt.Sprintf("database.connections.%s.singular", connection)).Return(singular)
+	mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.prefix", connection)).Return(config.Prefix)
+	mockConfig.EXPECT().GetBool(fmt.Sprintf("database.connections.%s.singular", connection)).Return(config.Singular)
 	mockConfig.EXPECT().GetBool(fmt.Sprintf("database.connections.%s.no_lower_case", connection)).Return(false)
 	mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.dsn", connection)).Return("")
 	mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.schema", connection), "public").Return("public")
@@ -43,13 +45,13 @@ func mockDatabaseConfigWithoutWriteAndRead(mockConfig *mocksconfig.Config, confi
 
 	if config.Driver == postgres.Name {
 		mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.sslmode", connection)).Return("disable")
-		mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.timezone", connection)).Return("UTC")
+		mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.timezone", connection)).Return(config.Timezone)
 		mockConfig.EXPECT().Get(fmt.Sprintf("database.connections.%s.via", connection)).Return(func() (driver.Driver, error) {
 			return postgres.NewPostgres(mockConfig, utils.NewTestLog(), connection), nil
 		})
 	}
 	if config.Driver == mysql.Name {
-		mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.loc", connection)).Return("UTC")
+		mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.loc", connection)).Return(config.Timezone)
 		mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.charset", connection)).Return("utf8mb4")
 		mockConfig.EXPECT().Get(fmt.Sprintf("database.connections.%s.via", connection)).Return(func() (driver.Driver, error) {
 			return mysql.NewMysql(mockConfig, utils.NewTestLog(), connection), nil

--- a/tests/query.go
+++ b/tests/query.go
@@ -433,6 +433,7 @@ func (r *TestQueryBuilder) mix(driver string, writeDatabaseConfig, readDatabaseC
 		Connection: connection,
 		Prefix:     "",
 		Singular:   false,
+		Timezone:   "UTC",
 	})
 
 	ctx := context.WithValue(context.Background(), testContextKey, "goravel")


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/706

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request introduces several changes to the database testing and configuration logic, focusing on simplifying the `mockDatabaseConfig` function, improving timezone handling, and enhancing test query builders. Key updates include refactoring function signatures, adding timezone support, and introducing a new test for timezone functionality.

### Refactoring and Simplification:

* [`tests/mock_config.go`](diffhunk://#diff-e99a73045ad79e1cf1d850b270fde5d7be9357a7527093e6428ee1df4ddff2c5L17-R26): Refactored the `mockDatabaseConfig` and `mockDatabaseConfigWithoutWriteAndRead` functions to remove unused parameters (`prefix`, `singular`) and directly use the `Connection` attribute from `database.Config`. [[1]](diffhunk://#diff-e99a73045ad79e1cf1d850b270fde5d7be9357a7527093e6428ee1df4ddff2c5L17-R26) [[2]](diffhunk://#diff-e99a73045ad79e1cf1d850b270fde5d7be9357a7527093e6428ee1df4ddff2c5L37-R54)
* [`tests/query_test.go`](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeL426-R428): Updated multiple test cases to simplify `mockDatabaseConfig` calls by removing redundant arguments and setting `Connection` directly on the configuration object. [[1]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeL426-R428) [[2]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeL716-R720) [[3]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeL1807-R1813) [[4]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeL2063-R2071) [[5]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeL3653-R3663) [[6]](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeL3667-R3679)

### Timezone Handling:

* [`tests/query.go`](diffhunk://#diff-cdce4aeec88dce0187a29d201c5aaf4bf7780ca83efc5889bb00b4d9a615e570L145-R159): Added support for timezone-specific queries by introducing new methods like `AllWithTimezone`, `MysqlWithTimezone`, `PostgresWithTimezone`, `SqliteWithTimezone`, and `SqlserverWithTimezone`. These methods allow specifying a timezone for database configurations. [[1]](diffhunk://#diff-cdce4aeec88dce0187a29d201c5aaf4bf7780ca83efc5889bb00b4d9a615e570L145-R159) [[2]](diffhunk://#diff-cdce4aeec88dce0187a29d201c5aaf4bf7780ca83efc5889bb00b4d9a615e570L155-R174) [[3]](diffhunk://#diff-cdce4aeec88dce0187a29d201c5aaf4bf7780ca83efc5889bb00b4d9a615e570L164-R188) [[4]](diffhunk://#diff-cdce4aeec88dce0187a29d201c5aaf4bf7780ca83efc5889bb00b4d9a615e570L184-R237) [[5]](diffhunk://#diff-cdce4aeec88dce0187a29d201c5aaf4bf7780ca83efc5889bb00b4d9a615e570L212-R278)
* [`tests/query_test.go`](diffhunk://#diff-7bcc9c7ae126a9b448e510097eb9812b3f264e95cbc5a690fb59ce332c0b85eeR3777-R3811): Added a new test case `TestTimezone` to validate timezone handling across different database drivers.

### Test Query Builder Enhancements:

* [`tests/query.go`](diffhunk://#diff-0f947c1cc37c4d76f6cc055536b2b37f53143066eb32a698c1e912067f7eef5eL1438-R1438): Replaced `AllOfReadWrite` with `AllWithReadWrite` to improve naming consistency and added support for timezone-specific queries in the `single` and `readWriteMix` methods. [[1]](diffhunk://#diff-0f947c1cc37c4d76f6cc055536b2b37f53143066eb32a698c1e912067f7eef5eL1438-R1438) [[2]](diffhunk://#diff-cdce4aeec88dce0187a29d201c5aaf4bf7780ca83efc5889bb00b4d9a615e570L263-R325) [[3]](diffhunk://#diff-cdce4aeec88dce0187a29d201c5aaf4bf7780ca83efc5889bb00b4d9a615e570L275-R338) [[4]](diffhunk://#diff-cdce4aeec88dce0187a29d201c5aaf4bf7780ca83efc5889bb00b4d9a615e570L371-R436)

### Dependency Update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L115-R115): Updated the `github.com/redis/go-redis/v9` dependency from version `v9.5.1` to `v9.8.0`.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
