### PR TITLE
feat: [#707] Change the configuration session.driver to session.default

### DIFF
--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -392,7 +392,7 @@ func (s *ApplicationTestSuite) TestMakeSchedule() {
 
 func (s *ApplicationTestSuite) TestMakeSession() {
 	mockConfig := mocksconfig.NewConfig(s.T())
-	mockConfig.EXPECT().GetString("session.driver", "file").Return("file").Once()
+	mockConfig.EXPECT().GetString("session.default", "file").Return("file").Once()
 	mockConfig.EXPECT().GetString("session.drivers.file.driver").Return("file").Once()
 	mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
 	mockConfig.EXPECT().GetInt("session.gc_interval", 30).Return(30).Once()

--- a/foundation/console/about_command.go
+++ b/foundation/console/about_command.go
@@ -103,7 +103,7 @@ func (r *AboutCommand) gatherApplicationInformation() {
 		}()},
 		{Key: "Mail", Value: configFacade.GetString("mail.default", "smtp")},
 		{Key: "Queue", Value: configFacade.GetString("queue.default")},
-		{Key: "Session", Value: configFacade.GetString("session.driver")},
+		{Key: "Session", Value: configFacade.GetString("session.default")},
 	})
 	for i := range customInformationResolvers {
 		customInformationResolvers[i]()

--- a/foundation/console/about_command_test.go
+++ b/foundation/console/about_command_test.go
@@ -98,7 +98,7 @@ func (s *AboutCommandTestSuite) TestHandle() {
 	mockConfig.EXPECT().Get("logging.channels.stack.channels").Return([]string{"test"}).Once()
 	mockConfig.EXPECT().GetString("mail.default", "smtp").Return("test_mail").Once()
 	mockConfig.EXPECT().GetString("queue.default").Return("test_queue").Once()
-	mockConfig.EXPECT().GetString("session.driver").Return("test_session").Once()
+	mockConfig.EXPECT().GetString("session.default").Return("test_session").Once()
 
 	mockContext.EXPECT().NewLine().Return().Times(4)
 	mockContext.EXPECT().Option("only").Return("").Once()

--- a/session/manager.go
+++ b/session/manager.go
@@ -33,7 +33,7 @@ type Manager struct {
 
 func NewManager(config config.Config, json foundation.Json) *Manager {
 	cookie := config.GetString("session.cookie")
-	defaultDriver := config.GetString("session.driver", "file")
+	defaultDriver := config.GetString("session.default", "file")
 	files := config.GetString("session.files")
 	gcInterval := config.GetInt("session.gc_interval", 30)
 	lifetime := config.GetInt("session.lifetime", 120)

--- a/session/manager_test.go
+++ b/session/manager_test.go
@@ -55,7 +55,7 @@ func (s *ManagerTestSuite) SetupTest() {
 	s.mockOtherFactory = MockDriverFactory(s.mockOtherDriver)
 
 	s.mockConfig = mockconfig.NewConfig(s.T())
-	s.mockConfig.EXPECT().GetString("session.driver", "file").Return("file").Once()
+	s.mockConfig.EXPECT().GetString("session.default", "file").Return("file").Once()
 	s.mockConfig.EXPECT().GetString("session.drivers.file.driver").Return("file").Once()
 	s.mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
 	s.mockConfig.EXPECT().GetInt("session.gc_interval", 30).Return(30).Once()
@@ -156,7 +156,7 @@ func BenchmarkSession_ManagerInteraction(b *testing.B) {
 	s.SetT(&testing.T{})
 	s.SetupTest()
 
-	s.mockConfig.On("GetString", "session.driver").Return("file")
+	s.mockConfig.On("GetString", "session.default").Return("file")
 	s.mockConfig.On("GetInt", "session.gc_interval").Return(30)
 	s.mockConfig.On("GetString", "session.cookie").Return("bench_cookie")
 

--- a/session/middleware/start_session.go
+++ b/session/middleware/start_session.go
@@ -12,7 +12,7 @@ func StartSession() http.Middleware {
 		req := ctx.Request()
 
 		// Check if session exists
-		if req.HasSession() || session.ConfigFacade.GetString("session.driver") == "" {
+		if req.HasSession() || session.ConfigFacade.GetString("session.default") == "" {
 			req.Next()
 			return
 		}

--- a/session/middleware/start_session_test.go
+++ b/session/middleware/start_session_test.go
@@ -28,7 +28,7 @@ func testHttpSessionMiddleware(next nethttp.Handler, mockConfig *configmocks.Con
 }
 
 func mockConfigFacade(mockConfig *configmocks.Config) {
-	mockConfig.On("GetString", "session.driver").Return("file").Once()
+	mockConfig.On("GetString", "session.default").Return("file").Once()
 	mockConfig.On("GetInt", "session.lifetime", 120).Return(120).Once()
 	mockConfig.On("GetString", "session.path").Return("/").Once()
 	mockConfig.On("GetString", "session.domain").Return("").Once()
@@ -40,7 +40,7 @@ func mockConfigFacade(mockConfig *configmocks.Config) {
 func TestStartSession(t *testing.T) {
 	mockConfig := configmocks.NewConfig(t)
 	session.ConfigFacade = mockConfig
-	mockConfig.EXPECT().GetString("session.driver", "file").Return("file").Once()
+	mockConfig.EXPECT().GetString("session.default", "file").Return("file").Once()
 	mockConfig.EXPECT().GetString("session.drivers.file.driver").Return("file").Once()
 	mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
 	mockConfig.EXPECT().GetInt("session.gc_interval", 30).Return(30).Once()


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/707

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request updates the configuration key for session management across multiple files, replacing `"session.driver"` with `"session.default"`. This change ensures consistency in the naming convention and aligns with the updated configuration structure.

### Updates to session configuration:

* [`foundation/application_test.go`](diffhunk://#diff-6557bfe8e38b58d9171f71a99a6402529163c1ebc89309419e4f62e5cf68855eL395-R395): Updated mock configuration in `TestMakeSession` to use `"session.default"` instead of `"session.driver"`.
* [`foundation/console/about_command.go`](diffhunk://#diff-ab50162808a2b574b9fbd0a4b8d5472e8637fbe4da3d903a07d68a282a97a147L106-R106): Modified `gatherApplicationInformation` to retrieve the session configuration using `"session.default"` instead of `"session.driver"`.
* [`foundation/console/about_command_test.go`](diffhunk://#diff-11ac3931c190cc08f1b3d1c7f9e209d152111bc1a114acaef33bc2610f5067d9L101-R101): Adjusted mock configuration in `TestHandle` to reflect the change to `"session.default"`.

### Updates to session manager:

* [`session/manager.go`](diffhunk://#diff-de205823b6eb47772acfff7212edb5a689ac07c48762817bfff80315c07a6b7eL36-R36): Changed the default session driver key from `"session.driver"` to `"session.default"` in the `Manager` struct initialization.
* [`session/manager_test.go`](diffhunk://#diff-510f518473724df45b4fe9267ae9ac7abea2f8a65f8aab1ccb00b8da45475151L58-R58): Updated mock configurations in `SetupTest` and `BenchmarkSession_ManagerInteraction` to use `"session.default"`. [[1]](diffhunk://#diff-510f518473724df45b4fe9267ae9ac7abea2f8a65f8aab1ccb00b8da45475151L58-R58) [[2]](diffhunk://#diff-510f518473724df45b4fe9267ae9ac7abea2f8a65f8aab1ccb00b8da45475151L159-R159)

### Updates to session middleware:

* [`session/middleware/start_session.go`](diffhunk://#diff-45705bf0aca9e2b99f797bfa29c3de6ff0de2ce4c7f991d4e192f4d06b9177f8L15-R15): Replaced `"session.driver"` with `"session.default"` in the `StartSession` middleware logic.
* [`session/middleware/start_session_test.go`](diffhunk://#diff-de1dcc480426b9ecbf0761e911033c7f08793a3d3f1b283f1f0624c04bec1e42L31-R31): Updated mock configurations in `testHttpSessionMiddleware` and `mockConfigFacade` to use `"session.default"`. [[1]](diffhunk://#diff-de1dcc480426b9ecbf0761e911033c7f08793a3d3f1b283f1f0624c04bec1e42L31-R31) [[2]](diffhunk://#diff-de1dcc480426b9ecbf0761e911033c7f08793a3d3f1b283f1f0624c04bec1e42L43-R43)

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
