### PR TITLE
feat: [#667] Registering service providers don't dependent order

### DIFF
--- a/cache/service_provider.go
+++ b/cache/service_provider.go
@@ -11,6 +11,23 @@ import (
 type ServiceProvider struct {
 }
 
+func (r *ServiceProvider) Bindings() []string {
+	return []string{
+		contracts.BindingCache,
+	}
+}
+
+func (r *ServiceProvider) Dependencies() []string {
+	return []string{
+		contracts.BindingConfig,
+		contracts.BindingLog,
+	}
+}
+
+func (r *ServiceProvider) ProvideFor() []string {
+	return []string{}
+}
+
 func (r *ServiceProvider) Register(app foundation.Application) {
 	app.Singleton(contracts.BindingCache, func(app foundation.Application) (any, error) {
 		config := app.MakeConfig()

--- a/database/service_provider.go
+++ b/database/service_provider.go
@@ -22,6 +22,26 @@ import (
 type ServiceProvider struct {
 }
 
+func (r *ServiceProvider) Bindings() []string {
+	return []string{
+		contracts.BindingOrm,
+		contracts.BindingDB,
+		contracts.BindingSchema,
+		contracts.BindingSeeder,
+	}
+}
+
+func (r *ServiceProvider) Dependencies() []string {
+	return []string{
+		contracts.BindingConfig,
+		contracts.BindingLog,
+	}
+}
+
+func (r *ServiceProvider) ProvideFor() []string {
+	return []string{}
+}
+
 func (r *ServiceProvider) Register(app foundation.Application) {
 	app.Singleton(contracts.BindingOrm, func(app foundation.Application) (any, error) {
 		ctx := context.Background()

--- a/errors/list.go
+++ b/errors/list.go
@@ -2,9 +2,9 @@ package errors
 
 var (
 	ApplicationNotSet       = New("application instance is not initialized")
-	ArtisanFacadeNotSet     = New("artisan facade is not initialized")
 	CacheFacadeNotSet       = New("cache facade is not initialized")
 	ConfigFacadeNotSet      = New("config facade is not initialized")
+	ConsoleFacadeNotSet     = New("console facade is not initialized, skipping artisan command execution")
 	DBFacadeNotSet          = New("db facade is not initialized")
 	JSONParserNotSet        = New("JSON parser is not initialized")
 	LogFacadeNotSet         = New("log facade is not initialized")
@@ -16,6 +16,7 @@ var (
 	InvalidHttpContext      = New("invalid http context")
 	RouteFacadeNotSet       = New("route facade is not initialized")
 	SessionFacadeNotSet     = New("session facade is not initialized")
+	ServiceProviderCycle    = New("circular dependency detected between providers: %s")
 
 	AuthEmptySecret             = New("authentication secret is missing or required")
 	AuthInvalidClaims           = New("authentication token contains invalid claims")
@@ -35,6 +36,8 @@ var (
 	CacheMemoryDriverNotSupportDocker = New("memory driver doesn't support docker")
 	CacheMemoryInvalidIntValueType    = New("value type of %s is not *atomic.Int64 or *int64 or *atomic.Int32 or *int32")
 	CacheStoreContractNotFulfilled    = New("%s doesn't implement contracts/cache/store")
+
+	ConsoleProvidersNotArray = New("the app.providers configuration is not of type []foundation.ServiceProvider, skipping registering service providers")
 
 	ConsoleCommandRegisterFailed = New("command register failed: %v")
 	ConsoleDropAllTablesFailed   = New("drop all tables failed: %v")

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -3,15 +3,18 @@ package foundation
 import (
 	"context"
 	"flag"
+	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/goravel/framework/config"
 	contractsconsole "github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/foundation"
+	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/foundation/console"
 	"github.com/goravel/framework/foundation/json"
 	"github.com/goravel/framework/support"
@@ -43,16 +46,16 @@ func init() {
 
 type Application struct {
 	*Container
-	publishes     map[string]map[string]string
-	publishGroups map[string]map[string]string
-	json          foundation.Json
+	configuredServiceProviders []foundation.ServiceProvider
+	publishes                  map[string]map[string]string
+	publishGroups              map[string]map[string]string
+	json                       foundation.Json
 }
 
 func NewApplication() foundation.Application {
 	return App
 }
 
-// Boot Register and bootstrap configured service providers.
 func (r *Application) Boot() {
 	r.setTimezone()
 	r.registerConfiguredServiceProviders()
@@ -180,7 +183,6 @@ func (r *Application) IsLocale(ctx context.Context, locale string) bool {
 	return r.CurrentLocale(ctx) == locale
 }
 
-// absPath ensures the returned path is absolute
 func (r *Application) absPath(paths ...string) string {
 	path := filepath.Join(paths...)
 	abs, err := filepath.Abs(path)
@@ -198,68 +200,66 @@ func (r *Application) addPublishGroup(group string, paths map[string]string) {
 	maps.Copy(r.publishGroups[group], paths)
 }
 
-// bootArtisan Boot artisan command.
 func (r *Application) bootArtisan() {
 	artisanFacade := r.MakeArtisan()
 	if artisanFacade == nil {
-		color.Warningln("Artisan Facade is not initialized. Skipping artisan command execution.")
+		color.Warningln(errors.ConsoleFacadeNotSet.Error())
 		return
 	}
 
 	_ = artisanFacade.Run(os.Args, true)
 }
 
-// getBaseServiceProviders Get base service providers.
 func (r *Application) getBaseServiceProviders() []foundation.ServiceProvider {
 	return []foundation.ServiceProvider{
 		&config.ServiceProvider{},
 	}
 }
 
-// getConfiguredServiceProviders Get configured service providers.
 func (r *Application) getConfiguredServiceProviders() []foundation.ServiceProvider {
+	if len(r.configuredServiceProviders) > 0 {
+		return r.configuredServiceProviders
+	}
+
 	configFacade := r.MakeConfig()
 	if configFacade == nil {
-		color.Warningln("config facade is not initialized. Skipping registering service providers.")
+		color.Warningln(errors.ConfigFacadeNotSet.Error())
 		return []foundation.ServiceProvider{}
 	}
 
 	providers, ok := configFacade.Get("app.providers").([]foundation.ServiceProvider)
 	if !ok {
-		color.Warningln("providers configuration is not of type []foundation.ServiceProvider. Skipping registering service providers.")
+		color.Warningln(errors.ConsoleProvidersNotArray.Error())
 		return []foundation.ServiceProvider{}
 	}
-	return providers
+
+	r.configuredServiceProviders = sortConfiguredServiceProviders(providers)
+
+	return r.configuredServiceProviders
 }
 
-// registerBaseServiceProviders Register base service providers.
 func (r *Application) registerBaseServiceProviders() {
 	r.registerServiceProviders(r.getBaseServiceProviders())
 }
 
-// bootBaseServiceProviders Bootstrap base service providers.
 func (r *Application) bootBaseServiceProviders() {
 	r.bootServiceProviders(r.getBaseServiceProviders())
 }
 
-// registerConfiguredServiceProviders Register configured service providers.
 func (r *Application) registerConfiguredServiceProviders() {
 	r.registerServiceProviders(r.getConfiguredServiceProviders())
 }
 
-// bootConfiguredServiceProviders Bootstrap configured service providers.
 func (r *Application) bootConfiguredServiceProviders() {
 	r.bootServiceProviders(r.getConfiguredServiceProviders())
 }
 
-// registerServiceProviders Register service providers.
 func (r *Application) registerServiceProviders(serviceProviders []foundation.ServiceProvider) {
 	for _, serviceProvider := range serviceProviders {
 		serviceProvider.Register(r)
 	}
 }
 
-// bootServiceProviders Bootstrap service providers.
 func (r *Application) bootServiceProviders(serviceProviders []foundation.ServiceProvider) {
 	for _, serviceProvider := range serviceProviders {
 		serviceProvider.Boot(r)
@@ -269,7 +269,7 @@ func (r *Application) bootServiceProviders(serviceProviders []foundation.Service
 func (r *Application) registerCommands(commands []contractsconsole.Command) {
 	artisanFacade := r.MakeArtisan()
 	if artisanFacade == nil {
-		color.Warningln("Artisan Facade is not initialized. Skipping command registration.")
+		color.Warningln(errors.ConsoleFacadeNotSet.Error())
 		return
 	}
 
@@ -279,7 +279,7 @@ func (r *Application) registerCommands(commands []contractsconsole.Command) {
 func (r *Application) setTimezone() {
 	configFacade := r.MakeConfig()
 	if configFacade == nil {
-		color.Warningln("config facade is not initialized. Using default timezone UTC.")
+		color.Warningln(errors.ConfigFacadeNotSet.Error())
 		carbon.SetTimezone(carbon.UTC)
 		return
 	}
@@ -361,4 +361,215 @@ func getEnvFilePath() string {
 	}
 
 	return envFilePath
+}
+
+func sortConfiguredServiceProviders(providers []foundation.ServiceProvider) []foundation.ServiceProvider {
+	if len(providers) == 0 {
+		return providers
+	}
+
+	// Helper function to get binding names from a provider
+	getBindings := func(provider foundation.ServiceProvider) []string {
+		if p, ok := provider.(interface{ Bindings() []string }); ok {
+			return p.Bindings()
+		}
+		return []string{}
+	}
+
+	// Helper function to get dependencies from a provider
+	getDependencies := func(provider foundation.ServiceProvider) []string {
+		if p, ok := provider.(interface{ Dependencies() []string }); ok {
+			return p.Dependencies()
+		}
+		return []string{}
+	}
+
+	// Helper function to get provide-for bindings from a provider
+	getProvideFor := func(provider foundation.ServiceProvider) []string {
+		if p, ok := provider.(interface{ ProvideFor() []string }); ok {
+			return p.ProvideFor()
+		}
+		return []string{}
+	}
+
+	// Create a map for quick lookup of providers by their binding names
+	providerMap := make(map[string]foundation.ServiceProvider)
+	bindingToProvider := make(map[string]foundation.ServiceProvider)
+	for _, provider := range providers {
+		for _, binding := range getBindings(provider) {
+			providerMap[binding] = provider
+			bindingToProvider[binding] = provider
+		}
+	}
+
+	// Create adjacency list for dependency graph
+	graph := make(map[string][]string)
+	inDegree := make(map[string]int)
+
+	// Initialize inDegree for all providers
+	for _, provider := range providers {
+		for _, binding := range getBindings(provider) {
+			inDegree[binding] = 0
+		}
+	}
+
+	// Build the dependency graph using both Dependencies and ProvideFor
+	for _, provider := range providers {
+		for _, binding := range getBindings(provider) {
+			// Add dependencies (this provider depends on others)
+			for _, dep := range getDependencies(provider) {
+				if _, exists := providerMap[dep]; exists {
+					graph[dep] = append(graph[dep], binding)
+					inDegree[binding]++
+				}
+			}
+
+			// Add provide-for relationships (others depend on this provider)
+			for _, provideFor := range getProvideFor(provider) {
+				if _, exists := providerMap[provideFor]; exists {
+					graph[binding] = append(graph[binding], provideFor)
+					inDegree[provideFor]++
+				}
+			}
+		}
+	}
+
+	// Topological sort using Kahn's algorithm
+	var queue []string
+	var result []string
+
+	// Add all nodes with in-degree 0 to queue
+	for binding, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, binding)
+		}
+	}
+
+	// Process queue
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		result = append(result, current)
+
+		// Reduce in-degree of all neighbors
+		for _, neighbor := range graph[current] {
+			inDegree[neighbor]--
+			if inDegree[neighbor] == 0 {
+				queue = append(queue, neighbor)
+			}
+		}
+	}
+
+	// If we couldn't process all nodes, there's a cycle
+	if len(result) != len(inDegree) {
+		// Detect and report the cycle
+		cycle := detectCycle(graph, bindingToProvider)
+		if len(cycle) > 0 {
+			panic(errors.ServiceProviderCycle.Args(strings.Join(cycle, " -> ")))
+		}
+	}
+
+	// Convert back to service providers in sorted order
+	sortedProviders := make([]foundation.ServiceProvider, 0, len(providers))
+	used := make(map[foundation.ServiceProvider]bool)
+
+	for _, binding := range result {
+		provider := providerMap[binding]
+		if !used[provider] {
+			sortedProviders = append(sortedProviders, provider)
+			used[provider] = true
+		}
+	}
+
+	// Add any remaining providers that weren't in the dependency graph
+	for _, provider := range providers {
+		if !used[provider] {
+			sortedProviders = append(sortedProviders, provider)
+		}
+	}
+
+	return sortedProviders
+}
+
+// detectCycle detects a cycle in the dependency graph and returns a descriptive error message
+func detectCycle(graph map[string][]string, bindingToProvider map[string]foundation.ServiceProvider) []string {
+	visited := make(map[string]bool)
+	recStack := make(map[string]bool)
+	path := make([]string, 0)
+	cycle := make([]string, 0)
+
+	var dfs func(node string) bool
+	dfs = func(node string) bool {
+		visited[node] = true
+		recStack[node] = true
+		path = append(path, node)
+
+		for _, neighbor := range graph[node] {
+			if !visited[neighbor] {
+				if dfs(neighbor) {
+					return true
+				}
+			} else if recStack[neighbor] {
+				// Found a cycle, collect the cycle path
+				cycleStart := -1
+				for i, p := range path {
+					if p == neighbor {
+						cycleStart = i
+						break
+					}
+				}
+				if cycleStart != -1 {
+					cycle = append(cycle, path[cycleStart:]...)
+					cycle = append(cycle, neighbor)
+				}
+				return true
+			}
+		}
+
+		recStack[node] = false
+		path = path[:len(path)-1]
+		return false
+	}
+
+	// Find cycles starting from each unvisited node
+	// Sort nodes to ensure consistent behavior when multiple cycles exist
+	var nodes []string
+	for node := range graph {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+
+	for _, node := range nodes {
+		if !visited[node] {
+			if dfs(node) {
+				break
+			}
+		}
+	}
+
+	// Build error message with provider names
+	if len(cycle) > 0 {
+		var cycleProviders []string
+		providerSet := make(map[string]struct{})
+
+		for _, binding := range cycle {
+			if provider, exists := bindingToProvider[binding]; exists {
+				providerName := fmt.Sprintf("%T", provider)
+				cycleProviders = append(cycleProviders, providerName)
+				providerSet[providerName] = struct{}{}
+			}
+		}
+
+		// If the cycle is a self-loop (A -> A), only show as 'A -> A' if there are two unique providers, otherwise just 'A'
+		if len(cycleProviders) == 2 && cycleProviders[0] == cycleProviders[1] {
+			if len(providerSet) == 1 && len(cycle) > 2 {
+				// This is a missing mapping case, only one provider in the cycle
+				return cycleProviders[0:1]
+			}
+		}
+
+		return cycleProviders
+	}
+
+	return nil
 }

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -435,3 +435,413 @@ func (s *ApplicationTestSuite) TestMakeValidation() {
 
 	s.NotNil(s.app.MakeValidation())
 }
+
+func TestSortConfiguredServiceProviders(t *testing.T) {
+	testCases := []struct {
+		name      string
+		providers []foundation.ServiceProvider
+		expected  []foundation.ServiceProvider
+	}{
+		{
+			name: "BasicSorting",
+			providers: []foundation.ServiceProvider{
+				&BServiceProvider{},
+				&CServiceProvider{},
+				&AServiceProvider{},
+			},
+			expected: []foundation.ServiceProvider{
+				&AServiceProvider{},
+				&BServiceProvider{},
+				&CServiceProvider{},
+			},
+		},
+		{
+			name: "SingleProvider",
+			providers: []foundation.ServiceProvider{
+				&BasicServiceProvider{},
+			},
+			expected: []foundation.ServiceProvider{
+				&BasicServiceProvider{},
+			},
+		},
+		{
+			name:      "EmptyProviders",
+			providers: []foundation.ServiceProvider{},
+			expected:  []foundation.ServiceProvider{},
+		},
+		{
+			name: "ProvideForRelationship",
+			providers: []foundation.ServiceProvider{
+				&ProvideForBServiceProvider{},
+				&ProvideForAServiceProvider{},
+			},
+			expected: []foundation.ServiceProvider{
+				&ProvideForAServiceProvider{},
+				&ProvideForBServiceProvider{},
+			},
+		},
+		{
+			name: "SingleProviderWithMock",
+			providers: []foundation.ServiceProvider{
+				&MockProviderE{},
+			},
+			expected: []foundation.ServiceProvider{
+				&MockProviderE{},
+			},
+		},
+		{
+			name: "EmptyBindings",
+			providers: []foundation.ServiceProvider{
+				&EmptyBindingsProvider{},
+				&MockProviderA{},
+			},
+			expected: []foundation.ServiceProvider{
+				&MockProviderA{},
+				&EmptyBindingsProvider{},
+			},
+		},
+		{
+			name: "EmptyDependencies",
+			providers: []foundation.ServiceProvider{
+				&EmptyDependenciesProvider{},
+				&MockProviderC{},
+			},
+			expected: []foundation.ServiceProvider{
+				&EmptyDependenciesProvider{},
+				&MockProviderC{},
+			},
+		},
+		{
+			name: "EmptyProvideFor",
+			providers: []foundation.ServiceProvider{
+				&EmptyProvideForProvider{},
+				&MockProviderA{},
+			},
+			expected: []foundation.ServiceProvider{
+				&MockProviderA{},
+				&EmptyProvideForProvider{},
+			},
+		},
+		{
+			name: "AllEmptyMethods",
+			providers: []foundation.ServiceProvider{
+				&AllEmptyProvider{},
+				&MockProviderE{},
+				&BasicServiceProvider{},
+			},
+			expected: []foundation.ServiceProvider{
+				&MockProviderE{},
+				&BasicServiceProvider{},
+				&AllEmptyProvider{},
+			},
+		},
+		{
+			name: "MixedEmptyAndNonEmpty",
+			providers: []foundation.ServiceProvider{
+				&EmptyBindingsProvider{},
+				&EmptyDependenciesProvider{},
+				&EmptyProvideForProvider{},
+				&AllEmptyProvider{},
+				&MockProviderE{},
+			},
+			expected: []foundation.ServiceProvider{
+				&EmptyDependenciesProvider{},
+				&EmptyProvideForProvider{},
+				&MockProviderE{},
+				&EmptyBindingsProvider{},
+				&AllEmptyProvider{},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := sortConfiguredServiceProviders(tc.providers)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestSortConfiguredServiceProvidersWithCircularDependency(t *testing.T) {
+	providers := []foundation.ServiceProvider{
+		&ComplexProviderA{},
+		&ComplexProviderB{},
+		&ComplexProviderC{},
+	}
+
+	// 捕获 panic 并验证错误消息
+	defer func() {
+		if r := recover(); r != nil {
+			err, ok := r.(error)
+			assert.True(t, ok, "Expected panic to be an error")
+			assert.Contains(t, err.Error(), "circular dependency detected between providers:")
+			assert.Contains(t, err.Error(), "*foundation.ComplexProviderA")
+			assert.Contains(t, err.Error(), "*foundation.ComplexProviderB")
+			assert.Contains(t, err.Error(), "*foundation.ComplexProviderC")
+		} else {
+			t.Error("Expected panic but none occurred")
+		}
+	}()
+
+	sortConfiguredServiceProviders(providers)
+}
+
+func Test_detectCycle(t *testing.T) {
+	testCases := []struct {
+		name              string
+		graph             map[string][]string
+		bindingToProvider map[string]foundation.ServiceProvider
+		expected          []string
+	}{
+		{
+			name: "SimpleCycle",
+			graph: map[string][]string{
+				"A": {"B"},
+				"B": {"A"},
+			},
+			bindingToProvider: map[string]foundation.ServiceProvider{
+				"A": &MockProviderA{},
+				"B": &MockProviderB{},
+			},
+			expected: []string{"*foundation.MockProviderA", "*foundation.MockProviderB", "*foundation.MockProviderA"},
+		},
+		{
+			name: "ComplexCycle",
+			graph: map[string][]string{
+				"A": {"B"},
+				"B": {"C"},
+				"C": {"A"},
+			},
+			bindingToProvider: map[string]foundation.ServiceProvider{
+				"A": &MockProviderA{},
+				"B": &MockProviderB{},
+				"C": &MockProviderC{},
+			},
+			expected: []string{"*foundation.MockProviderA", "*foundation.MockProviderB", "*foundation.MockProviderC", "*foundation.MockProviderA"},
+		},
+		{
+			name:              "SelfLoop",
+			graph:             map[string][]string{"A": {"A"}},
+			bindingToProvider: map[string]foundation.ServiceProvider{"A": &MockProviderA{}},
+			expected:          []string{"*foundation.MockProviderA", "*foundation.MockProviderA"},
+		},
+		{
+			name:              "NoCycle",
+			graph:             map[string][]string{"A": {"B"}, "B": {"C"}, "C": {}},
+			bindingToProvider: map[string]foundation.ServiceProvider{"A": &MockProviderA{}, "B": &MockProviderB{}, "C": &MockProviderC{}},
+			expected:          nil,
+		},
+		{
+			name:              "DisconnectedComponents",
+			graph:             map[string][]string{"A": {"B"}, "B": {"A"}, "C": {"D"}, "D": {}},
+			bindingToProvider: map[string]foundation.ServiceProvider{"A": &MockProviderA{}, "B": &MockProviderB{}, "C": &MockProviderC{}, "D": &MockProviderD{}},
+			expected:          []string{"*foundation.MockProviderA", "*foundation.MockProviderB", "*foundation.MockProviderA"},
+		},
+		{
+			name:              "EmptyGraph",
+			graph:             map[string][]string{},
+			bindingToProvider: map[string]foundation.ServiceProvider{},
+			expected:          nil,
+		},
+		{
+			name:              "SingleNode",
+			graph:             map[string][]string{"A": {}},
+			bindingToProvider: map[string]foundation.ServiceProvider{"A": &MockProviderA{}},
+			expected:          nil,
+		},
+		{
+			name:              "MultipleCycles",
+			graph:             map[string][]string{"A": {"B"}, "B": {"A"}, "C": {"D"}, "D": {"C"}},
+			bindingToProvider: map[string]foundation.ServiceProvider{"A": &MockProviderA{}, "B": &MockProviderB{}, "C": &MockProviderC{}, "D": &MockProviderD{}},
+			expected:          []string{"*foundation.MockProviderA", "*foundation.MockProviderB", "*foundation.MockProviderA"},
+		},
+		{
+			name:              "ComplexPath",
+			graph:             map[string][]string{"A": {"B"}, "B": {"C"}, "C": {"D"}, "D": {"B"}},
+			bindingToProvider: map[string]foundation.ServiceProvider{"A": &MockProviderA{}, "B": &MockProviderB{}, "C": &MockProviderC{}, "D": &MockProviderD{}},
+			expected:          []string{"*foundation.MockProviderB", "*foundation.MockProviderC", "*foundation.MockProviderD", "*foundation.MockProviderB"},
+		},
+		{
+			name:              "IsolatedNodes",
+			graph:             map[string][]string{"A": {"B"}, "B": {"A"}, "C": {}, "D": {}},
+			bindingToProvider: map[string]foundation.ServiceProvider{"A": &MockProviderA{}, "B": &MockProviderB{}, "C": &MockProviderC{}, "D": &MockProviderD{}},
+			expected:          []string{"*foundation.MockProviderA", "*foundation.MockProviderB", "*foundation.MockProviderA"},
+		},
+		{
+			name:              "LongCycle",
+			graph:             map[string][]string{"A": {"B"}, "B": {"C"}, "C": {"D"}, "D": {"E"}, "E": {"A"}},
+			bindingToProvider: map[string]foundation.ServiceProvider{"A": &MockProviderA{}, "B": &MockProviderB{}, "C": &MockProviderC{}, "D": &MockProviderD{}, "E": &MockProviderE{}},
+			expected:          []string{"*foundation.MockProviderA", "*foundation.MockProviderB", "*foundation.MockProviderC", "*foundation.MockProviderD", "*foundation.MockProviderE", "*foundation.MockProviderA"},
+		},
+		{
+			name:              "MissingProviderMapping",
+			graph:             map[string][]string{"A": {"B"}, "B": {"A"}},
+			bindingToProvider: map[string]foundation.ServiceProvider{"A": &MockProviderA{}}, // B missing
+			expected:          []string{"*foundation.MockProviderA"},
+		},
+		{
+			name:              "DuplicateProviderNames",
+			graph:             map[string][]string{"A1": {"B"}, "A2": {"C"}, "B": {"A1"}, "C": {"A2"}},
+			bindingToProvider: map[string]foundation.ServiceProvider{"A1": &MockProviderA{}, "A2": &MockProviderA{}, "B": &MockProviderB{}, "C": &MockProviderC{}},
+			expected:          []string{"*foundation.MockProviderA", "*foundation.MockProviderB", "*foundation.MockProviderA"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := detectCycle(tc.graph, tc.bindingToProvider)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+type AServiceProvider struct{}
+
+func (r *AServiceProvider) Bindings() []string                  { return []string{"A"} }
+func (r *AServiceProvider) Dependencies() []string              { return []string{} }
+func (r *AServiceProvider) ProvideFor() []string                { return []string{} }
+func (r *AServiceProvider) Register(app foundation.Application) {}
+func (r *AServiceProvider) Boot(app foundation.Application)     {}
+
+type BServiceProvider struct{}
+
+func (r *BServiceProvider) Bindings() []string                  { return []string{"B"} }
+func (r *BServiceProvider) Dependencies() []string              { return []string{"A"} }
+func (r *BServiceProvider) ProvideFor() []string                { return []string{"C"} }
+func (r *BServiceProvider) Register(app foundation.Application) {}
+func (r *BServiceProvider) Boot(app foundation.Application)     {}
+
+type CServiceProvider struct{}
+
+func (r *CServiceProvider) Bindings() []string                  { return []string{"C"} }
+func (r *CServiceProvider) Dependencies() []string              { return []string{"A"} }
+func (r *CServiceProvider) ProvideFor() []string                { return []string{} }
+func (r *CServiceProvider) Register(app foundation.Application) {}
+func (r *CServiceProvider) Boot(app foundation.Application)     {}
+
+type CircularAServiceProvider struct{}
+
+func (r *CircularAServiceProvider) Bindings() []string                  { return []string{"CircularA"} }
+func (r *CircularAServiceProvider) Dependencies() []string              { return []string{"CircularB"} }
+func (r *CircularAServiceProvider) ProvideFor() []string                { return []string{} }
+func (r *CircularAServiceProvider) Register(app foundation.Application) {}
+func (r *CircularAServiceProvider) Boot(app foundation.Application)     {}
+
+type CircularBServiceProvider struct{}
+
+func (r *CircularBServiceProvider) Bindings() []string                  { return []string{"CircularB"} }
+func (r *CircularBServiceProvider) Dependencies() []string              { return []string{"CircularA"} }
+func (r *CircularBServiceProvider) ProvideFor() []string                { return []string{} }
+func (r *CircularBServiceProvider) Register(app foundation.Application) {}
+func (r *CircularBServiceProvider) Boot(app foundation.Application)     {}
+
+type BasicServiceProvider struct{}
+
+func (r *BasicServiceProvider) Bindings() []string                  { return []string{"Basic"} }
+func (r *BasicServiceProvider) Dependencies() []string              { return []string{} }
+func (r *BasicServiceProvider) ProvideFor() []string                { return []string{} }
+func (r *BasicServiceProvider) Register(app foundation.Application) {}
+func (r *BasicServiceProvider) Boot(app foundation.Application)     {}
+
+type ProvideForBServiceProvider struct{}
+
+func (r *ProvideForBServiceProvider) Bindings() []string                  { return []string{"ProvideForB"} }
+func (r *ProvideForBServiceProvider) Dependencies() []string              { return []string{"ProvideForA"} }
+func (r *ProvideForBServiceProvider) ProvideFor() []string                { return []string{} }
+func (r *ProvideForBServiceProvider) Register(app foundation.Application) {}
+func (r *ProvideForBServiceProvider) Boot(app foundation.Application)     {}
+
+type ProvideForAServiceProvider struct{}
+
+func (r *ProvideForAServiceProvider) Bindings() []string                  { return []string{"ProvideForA"} }
+func (r *ProvideForAServiceProvider) Dependencies() []string              { return []string{} }
+func (r *ProvideForAServiceProvider) ProvideFor() []string                { return []string{"ProvideForB"} }
+func (r *ProvideForAServiceProvider) Register(app foundation.Application) {}
+func (r *ProvideForAServiceProvider) Boot(app foundation.Application)     {}
+
+type MockProviderA struct{}
+
+func (p *MockProviderA) Register(app foundation.Application) {}
+func (p *MockProviderA) Boot(app foundation.Application)     {}
+func (p *MockProviderA) Bindings() []string                  { return []string{"provider_a"} }
+func (p *MockProviderA) Dependencies() []string              { return []string{"provider_b"} }
+
+type MockProviderB struct{}
+
+func (p *MockProviderB) Register(app foundation.Application) {}
+func (p *MockProviderB) Boot(app foundation.Application)     {}
+func (p *MockProviderB) Bindings() []string                  { return []string{"provider_b"} }
+func (p *MockProviderB) Dependencies() []string              { return []string{"provider_a"} }
+
+type MockProviderC struct{}
+
+func (p *MockProviderC) Register(app foundation.Application) {}
+func (p *MockProviderC) Boot(app foundation.Application)     {}
+func (p *MockProviderC) Bindings() []string                  { return []string{"provider_c"} }
+func (p *MockProviderC) Dependencies() []string              { return []string{"provider_d"} }
+
+type MockProviderD struct{}
+
+func (p *MockProviderD) Register(app foundation.Application) {}
+func (p *MockProviderD) Boot(app foundation.Application)     {}
+func (p *MockProviderD) Bindings() []string                  { return []string{"provider_d"} }
+func (p *MockProviderD) Dependencies() []string              { return []string{"provider_c"} }
+
+type MockProviderE struct{}
+
+func (p *MockProviderE) Register(app foundation.Application) {}
+func (p *MockProviderE) Boot(app foundation.Application)     {}
+func (p *MockProviderE) Bindings() []string                  { return []string{"provider_e"} }
+
+type ComplexProviderA struct{}
+
+func (p *ComplexProviderA) Register(app foundation.Application) {}
+func (p *ComplexProviderA) Boot(app foundation.Application)     {}
+func (p *ComplexProviderA) Bindings() []string                  { return []string{"complex_a"} }
+func (p *ComplexProviderA) Dependencies() []string              { return []string{"complex_b"} }
+
+type ComplexProviderB struct{}
+
+func (p *ComplexProviderB) Register(app foundation.Application) {}
+func (p *ComplexProviderB) Boot(app foundation.Application)     {}
+func (p *ComplexProviderB) Bindings() []string                  { return []string{"complex_b"} }
+func (p *ComplexProviderB) Dependencies() []string              { return []string{"complex_c"} }
+
+type ComplexProviderC struct{}
+
+func (p *ComplexProviderC) Register(app foundation.Application) {}
+func (p *ComplexProviderC) Boot(app foundation.Application)     {}
+func (p *ComplexProviderC) Bindings() []string                  { return []string{"complex_c"} }
+func (p *ComplexProviderC) Dependencies() []string              { return []string{"complex_a"} }
+
+type EmptyBindingsProvider struct{}
+
+func (p *EmptyBindingsProvider) Register(app foundation.Application) {}
+func (p *EmptyBindingsProvider) Boot(app foundation.Application)     {}
+func (p *EmptyBindingsProvider) Bindings() []string                  { return []string{} }
+func (p *EmptyBindingsProvider) Dependencies() []string              { return []string{"provider_a"} }
+func (p *EmptyBindingsProvider) ProvideFor() []string                { return []string{"provider_b"} }
+
+type EmptyDependenciesProvider struct{}
+
+func (p *EmptyDependenciesProvider) Register(app foundation.Application) {}
+func (p *EmptyDependenciesProvider) Boot(app foundation.Application)     {}
+func (p *EmptyDependenciesProvider) Bindings() []string                  { return []string{"empty_deps"} }
+func (p *EmptyDependenciesProvider) Dependencies() []string              { return []string{} }
+func (p *EmptyDependenciesProvider) ProvideFor() []string                { return []string{"provider_c"} }
+
+type EmptyProvideForProvider struct{}
+
+func (p *EmptyProvideForProvider) Register(app foundation.Application) {}
+func (p *EmptyProvideForProvider) Boot(app foundation.Application)     {}
+func (p *EmptyProvideForProvider) Bindings() []string                  { return []string{"empty_provide"} }
+func (p *EmptyProvideForProvider) Dependencies() []string              { return []string{"provider_a"} }
+func (p *EmptyProvideForProvider) ProvideFor() []string                { return []string{} }
+
+type AllEmptyProvider struct{}
+
+func (p *AllEmptyProvider) Register(app foundation.Application) {}
+func (p *AllEmptyProvider) Boot(app foundation.Application)     {}
+func (p *AllEmptyProvider) Bindings() []string                  { return []string{} }
+func (p *AllEmptyProvider) Dependencies() []string              { return []string{} }
+func (p *AllEmptyProvider) ProvideFor() []string                { return []string{} }

--- a/foundation/console/package_make_command_stubs.go
+++ b/foundation/console/package_make_command_stubs.go
@@ -37,6 +37,18 @@ var App foundation.Application
 type ServiceProvider struct {
 }
 
+func (r *ServiceProvider) Bindings() []string {
+	return []string{}
+}
+
+func (r *ServiceProvider) Dependencies() []string {
+	return []string{}
+}
+
+func (r *ServiceProvider) ProvideFor() []string {
+	return []string{}
+}
+
 func (r *ServiceProvider) Register(app foundation.Application) {
 	App = app
 

--- a/schedule/service_provider.go
+++ b/schedule/service_provider.go
@@ -20,7 +20,7 @@ func (r *ServiceProvider) Register(app foundation.Application) {
 
 		artisan := app.MakeArtisan()
 		if artisan == nil {
-			return nil, errors.ArtisanFacadeNotSet.SetModule(errors.ModuleSchedule)
+			return nil, errors.ConsoleFacadeNotSet.SetModule(errors.ModuleSchedule)
 		}
 
 		log := app.MakeLog()

--- a/testing/docker/database.go
+++ b/testing/docker/database.go
@@ -22,7 +22,7 @@ type Database struct {
 
 func NewDatabase(artisan contractsconsole.Artisan, config contractsconfig.Config, orm contractsorm.Orm, connection string) (*Database, error) {
 	if artisan == nil {
-		return nil, errors.ArtisanFacadeNotSet
+		return nil, errors.ConsoleFacadeNotSet
 	}
 	if config == nil {
 		return nil, errors.ConfigFacadeNotSet

--- a/testing/docker/database_test.go
+++ b/testing/docker/database_test.go
@@ -105,7 +105,7 @@ func TestNewDatabase(t *testing.T) {
 		{
 			name:    "error when artisan facade is not set",
 			setup:   func() {},
-			wantErr: errors.ArtisanFacadeNotSet,
+			wantErr: errors.ConsoleFacadeNotSet,
 		},
 		{
 			name:    "error when config facade is not set",

--- a/testing/service_provider.go
+++ b/testing/service_provider.go
@@ -29,7 +29,7 @@ func (r *ServiceProvider) Register(app foundation.Application) {
 func (r *ServiceProvider) Boot(app foundation.Application) {
 	artisanFacade = app.MakeArtisan()
 	if artisanFacade == nil {
-		color.Errorln(errors.ArtisanFacadeNotSet.SetModule(errors.ModuleTesting))
+		color.Errorln(errors.ConsoleFacadeNotSet.SetModule(errors.ModuleTesting))
 	}
 
 	routeFacade = app.MakeRoute()

--- a/testing/test_case.go
+++ b/testing/test_case.go
@@ -19,7 +19,7 @@ func (r *TestCase) Http(t *testing.T) contractshttp.Request {
 
 func (r *TestCase) Seed(seeders ...contractsseeder.Seeder) {
 	if artisanFacade == nil {
-		panic(errors.ArtisanFacadeNotSet.SetModule(errors.ModuleTesting))
+		panic(errors.ConsoleFacadeNotSet.SetModule(errors.ModuleTesting))
 	}
 
 	if err := artisanFacade.Call("--no-ansi db:seed" + getCommandOptionOfSeeders(seeders)); err != nil {
@@ -29,7 +29,7 @@ func (r *TestCase) Seed(seeders ...contractsseeder.Seeder) {
 
 func (r *TestCase) RefreshDatabase(seeders ...contractsseeder.Seeder) {
 	if artisanFacade == nil {
-		panic(errors.ArtisanFacadeNotSet.SetModule(errors.ModuleTesting))
+		panic(errors.ConsoleFacadeNotSet.SetModule(errors.ModuleTesting))
 	}
 
 	if err := artisanFacade.Call("--no-ansi migrate:refresh" + getCommandOptionOfSeeders(seeders)); err != nil {


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/667

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request introduces several changes to improve service provider handling, error messaging, and dependency management in the application. The most notable updates include adding dependency and binding methods to service providers, implementing a topological sort for service provider dependencies, and replacing the `ArtisanFacadeNotSet` error with `ConsoleFacadeNotSet` for better clarity. Below are the key changes grouped by theme:

### Service Provider Enhancements:
* Added `Bindings`, `Dependencies`, and `ProvideFor` methods to multiple service providers (`cache/service_provider.go`, `database/service_provider.go`, `foundation/console/package_make_command_stubs.go`). These methods define bindings, dependencies, and provide-for relationships to facilitate dependency management. [[1]](diffhunk://#diff-0de21bad623b663c1f8c18f0d64dcd3cdef44058f7cb33e2b98cd37f0183b5c6R14-R30) [[2]](diffhunk://#diff-0131799948ac426f5aef7995161522f4dbbb9cc9c4a36ebd01d9d08d1018b89dR25-R44) [[3]](diffhunk://#diff-48b92f03d2f63d7dacefd122b98e617f162c486470d7875e28ec8dbb9edd7bcfR40-R51)

* Implemented a `sortConfiguredServiceProviders` function in `foundation/application.go` to perform a topological sort of service providers based on their dependencies and provide-for relationships. This ensures proper initialization order and detects circular dependencies.

### Error Handling Improvements:
* Replaced the `ArtisanFacadeNotSet` error with a more descriptive `ConsoleFacadeNotSet` error across multiple files, improving clarity in error messages related to the artisan facade. [[1]](diffhunk://#diff-09e2cb8a4609ac36f4934019ec625682dbb45aad80e344693a88745975a7287cL5-R7) [[2]](diffhunk://#diff-4799c825a82f20f8a1d435ad0e5a216fcb004bb16704c497ba323cd99d712908L23-R23) [[3]](diffhunk://#diff-d7c28159d01bd47680916d5413e0cade2a05f33b3b12cd2a4f238d8d97ce400dL25-R25) [[4]](diffhunk://#diff-cc535afa918e58a85dc4139e0380901d60e8124b537a414bb7c1e03641790c30L108-R108) [[5]](diffhunk://#diff-f747b8cb65e79abf502f5a9a3ec49595227248d2a224f744a15b7b25acc85991L32-R32) [[6]](diffhunk://#diff-9ac03d6a2c4c2cd8e9a2bfa91e98d44b7463c2e51bbe63004a5738b16b3a2b49L22-R22) [[7]](diffhunk://#diff-9ac03d6a2c4c2cd8e9a2bfa91e98d44b7463c2e51bbe63004a5738b16b3a2b49L32-R32)

* Added new error types: `ServiceProviderCycle` for circular dependency detection and `ConsoleProvidersNotArray` for invalid `app.providers` configuration. These errors enhance robustness in service provider management. [[1]](diffhunk://#diff-09e2cb8a4609ac36f4934019ec625682dbb45aad80e344693a88745975a7287cR19) [[2]](diffhunk://#diff-09e2cb8a4609ac36f4934019ec625682dbb45aad80e344693a88745975a7287cR40-R41)

### Dependency Management:
* Modified `getConfiguredServiceProviders` in `foundation/application.go` to cache sorted service providers and handle invalid configurations gracefully.

* Enhanced the `bootArtisan` and `setTimezone` methods to use the new error types for better error reporting when facades are not initialized. [[1]](diffhunk://#diff-fc0e8c2ae3af78aa10c8fc5dbacc4fb74d177609882d9e2933363cd92358c3b7L272-R272) [[2]](diffhunk://#diff-fc0e8c2ae3af78aa10c8fc5dbacc4fb74d177609882d9e2933363cd92358c3b7L282-R282)

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
