### PR TITLE
fix: [#667] package install typo

### DIFF
--- a/foundation/console/package_make_command_stubs.go
+++ b/foundation/console/package_make_command_stubs.go
@@ -37,23 +37,13 @@ var App foundation.Application
 type ServiceProvider struct {
 }
 
-// Bindings returns what bindings the service provider will register.
-func (r *ServiceProvider) Bindings() []string {
-	return []string{Binding}
-}
-
-// Dependencies returns what dependencies the service provider needs.
-// For example, the Cache package needs the Log facade.
-// You can get the binding from package service provider files.
-func (r *ServiceProvider) Dependencies() []string {
-	return []string{}
-}
-
-// ProvideFor returns what services the service provider provides for.
-// For example, the Redis package provides services for the Cache facade.
-// You can get the binding from package service provider files.
-func (r *ServiceProvider) ProvideFor() []string {
-	return []string{}
+// Relationship returns the relationship of the service provider.
+func (r *ServiceProvider) Relationship() binding.Relationship {
+	return binding.Relationship{
+		Bindings: []string{},
+		Dependencies: []string{},
+		ProvideFor: []string{},
+	}
 }
 
 // Register registers the service provider.


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/667

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request refactors the `ServiceProvider` class in `foundation/console/package_make_command_stubs.go` to consolidate multiple methods into a single `Relationship` method. This change simplifies the code and provides a more structured representation of bindings, dependencies, and services provided by the service provider.

### Refactoring of `ServiceProvider` class:

* [`foundation/console/package_make_command_stubs.go`](diffhunk://#diff-48b92f03d2f63d7dacefd122b98e617f162c486470d7875e28ec8dbb9edd7bcfL40-L56): Replaced the `Bindings`, `Dependencies`, and `ProvideFor` methods with a single `Relationship` method, which returns a `binding.Relationship` object containing structured data for bindings, dependencies, and services provided.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
