### PR TITLE
chore: optimize auth session log

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -83,21 +83,20 @@ func (r *Auth) guard(name string) contractsauth.GuardDriver {
 	driverName := r.config.GetString(fmt.Sprintf("auth.guards.%s.driver", name))
 	guardFunc, ok := guardFuncs.Load(driverName)
 	if !ok {
-		r.log.Panic(errors.AuthGuardDriverNotFound.Args(driverName, name).Error())
-		return nil
+		// http recover will catch the panic and return the error to the client,
+		// to avoid print repeated log.
+		panic(errors.AuthGuardDriverNotFound.Args(driverName, name))
 	}
 
 	userProviderName := r.config.GetString(fmt.Sprintf("auth.guards.%s.provider", name))
 	userProvider, err := r.createUserProvider(userProviderName)
 	if err != nil {
-		r.log.Panic(err.Error())
-		return nil
+		panic(err)
 	}
 
 	guard, err := guardFunc.(contractsauth.GuardFunc)(r.ctx, name, userProvider)
 	if err != nil {
-		r.log.Panic(err.Error())
-		return nil
+		panic(err)
 	}
 
 	return guard

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -8,7 +8,6 @@ import (
 
 	contractsauth "github.com/goravel/framework/contracts/auth"
 	"github.com/goravel/framework/contracts/http"
-	"github.com/goravel/framework/errors"
 	mocksauth "github.com/goravel/framework/mocks/auth"
 	mockscache "github.com/goravel/framework/mocks/cache"
 	mocksconfig "github.com/goravel/framework/mocks/config"
@@ -94,10 +93,11 @@ func (s *AuthTestSuite) TestUserProviderReturnsError() {
 	s.mockConfig.EXPECT().GetString("auth.guards.admin.driver").Return("session").Once()
 	s.mockConfig.EXPECT().GetString("auth.guards.admin.provider").Return("admin").Once()
 	s.mockConfig.EXPECT().GetString("auth.providers.admin.driver").Return("mock").Once()
-	s.mockLog.EXPECT().Panic(assert.AnError.Error()).Once()
 
-	guard := s.auth.Guard("admin")
-	s.Nil(guard)
+	s.Panics(func() {
+		guard := s.auth.Guard("admin")
+		s.Nil(guard)
+	})
 }
 
 func (s *AuthTestSuite) TestGuardDriverReturnsError() {
@@ -112,26 +112,29 @@ func (s *AuthTestSuite) TestGuardDriverReturnsError() {
 	s.mockConfig.EXPECT().GetString("auth.guards.admin.driver").Return("session").Once()
 	s.mockConfig.EXPECT().GetString("auth.guards.admin.provider").Return("admin").Once()
 	s.mockConfig.EXPECT().GetString("auth.providers.admin.driver").Return("mock").Once()
-	s.mockLog.EXPECT().Panic(assert.AnError.Error()).Once()
 
-	guard := s.auth.Guard("admin")
-	s.Nil(guard)
+	s.Panics(func() {
+		guard := s.auth.Guard("admin")
+		s.Nil(guard)
+	})
 }
 
 func (s *AuthTestSuite) TestGuardDriverNotFound() {
 	s.mockConfig.EXPECT().GetString("auth.guards.admin.driver").Return("unknown").Once()
-	s.mockLog.EXPECT().Panic(errors.AuthGuardDriverNotFound.Args("unknown", "admin").Error()).Once()
 
-	guard := s.auth.Guard("admin")
-	s.Nil(guard)
+	s.Panics(func() {
+		guard := s.auth.Guard("admin")
+		s.Nil(guard)
+	})
 }
 
 func (s *AuthTestSuite) TestUserProviderDriverNotFound() {
 	s.mockConfig.EXPECT().GetString("auth.guards.admin.driver").Return("jwt").Once()
 	s.mockConfig.EXPECT().GetString("auth.guards.admin.provider").Return("admin").Once()
 	s.mockConfig.EXPECT().GetString("auth.providers.admin.driver").Return("unknown").Once()
-	s.mockLog.EXPECT().Panic(errors.AuthProviderDriverNotFound.Args("unknown", "admin").Error()).Once()
 
-	guard := s.auth.Guard("admin")
-	s.Nil(guard)
+	s.Panics(func() {
+		guard := s.auth.Guard("admin")
+		s.Nil(guard)
+	})
 }


### PR DESCRIPTION
## 📑 Description

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request refactors the error handling logic in the `auth` package, transitioning from logging and returning `nil` to using `panic` for error propagation. This change simplifies the code and aligns error handling with the framework's `http recover` mechanism. Corresponding updates have been made to the test cases to validate this new behavior.

### Refactoring of error handling:

* [`auth/auth.go`](diffhunk://#diff-f5c9a39fac1719f2a73593994b931d8a874449548e8a3753e1be46e761e503eaL86-R99): Replaced calls to `r.log.Panic` with `panic` to rely on `http recover` for error handling, ensuring errors are propagated without redundant logging.

### Updates to test cases:

* [`auth/auth_test.go`](diffhunk://#diff-b06746870e62f95017714121be6134cffdc4bd1d46dd21f8cae8c484e3e2829dL97-R100): Removed expectations for `mockLog.Panic` and replaced them with assertions using `s.Panics` to test the new `panic` behavior. This change applies to multiple test methods, including `TestUserProviderReturnsError`, `TestGuardDriverReturnsError`, `TestGuardDriverNotFound`, and `TestUserProviderDriverNotFound`. [[1]](diffhunk://#diff-b06746870e62f95017714121be6134cffdc4bd1d46dd21f8cae8c484e3e2829dL97-R100) [[2]](diffhunk://#diff-b06746870e62f95017714121be6134cffdc4bd1d46dd21f8cae8c484e3e2829dL115-R139)
* [`auth/auth_test.go`](diffhunk://#diff-b06746870e62f95017714121be6134cffdc4bd1d46dd21f8cae8c484e3e2829dL11): Removed the unused import for `errors` since `mockLog.Panic` is no longer used.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
