### PR TITLE
chore: optimzie failer

### DIFF
--- a/queue/failer.go
+++ b/queue/failer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/goravel/framework/queue/models"
 	"github.com/goravel/framework/queue/utils"
 	"github.com/goravel/framework/support/carbon"
+	"github.com/goravel/framework/support/convert"
 )
 
 type Failer struct {
@@ -44,12 +45,7 @@ func (r *Failer) Get(connection, queue string, uuids []string) ([]contractsqueue
 	}
 
 	if len(uuids) > 0 {
-		uuidsAny := make([]any, len(uuids))
-		for i, uuid := range uuids {
-			uuidsAny[i] = uuid
-		}
-
-		query = query.WhereIn("uuid", uuidsAny)
+		query = query.WhereIn("uuid", convert.ToAnySlice(uuids...))
 	}
 
 	var modelFailedJobs []models.FailedJob

--- a/queue/failer.go
+++ b/queue/failer.go
@@ -45,7 +45,7 @@ func (r *Failer) Get(connection, queue string, uuids []string) ([]contractsqueue
 	}
 
 	if len(uuids) > 0 {
-		query = query.WhereIn("uuid", convert.ToAnySlice(uuids...))
+		query = query.WhereIn("uuid", convert.ToAnySlice(uuids))
 	}
 
 	var modelFailedJobs []models.FailedJob

--- a/support/convert/convert.go
+++ b/support/convert/convert.go
@@ -79,18 +79,6 @@ func Transform[T, R any](value T, callback func(T) R) R {
 	return callback(value)
 }
 
-// ToAnySlice converts a slice of any type T to a slice of type []any.
-//
-//	ToAnySlice("foo", "bar") // []any{"foo", "bar"}
-func ToAnySlice[T any](s ...T) []any {
-	res := make([]any, len(s))
-	for i, v := range s {
-		res[i] = v
-	}
-
-	return res
-}
-
 // With calls the given callbacks with the given value then return the value.
 //
 //	With("foo", func(s string) string {

--- a/support/convert/convert_test.go
+++ b/support/convert/convert_test.go
@@ -164,29 +164,3 @@ func TestCopyBytes(t *testing.T) {
 		assert.Equal(t, 0, cap(copied))
 	})
 }
-
-func TestToAnySlice(t *testing.T) {
-	t.Run("empty slice", func(t *testing.T) {
-		var input []int
-		result := ToAnySlice(input...)
-		assert.NotNil(t, result)
-		assert.Empty(t, result)
-	})
-
-	t.Run("string slice", func(t *testing.T) {
-		input := []string{"a", "b", "c"}
-		assert.Equal(t, []any{"a", "b", "c"}, ToAnySlice(input...))
-	})
-
-	t.Run("int slice", func(t *testing.T) {
-		assert.Equal(t, []any{1, 2, 3}, ToAnySlice(1, 2, 3))
-	})
-
-	t.Run("bool slice", func(t *testing.T) {
-		assert.Equal(t, []any{true, false}, ToAnySlice(true, false))
-	})
-
-	t.Run("float slice", func(t *testing.T) {
-		assert.Equal(t, []any{1.1, 2.2, 3.3}, ToAnySlice(1.1, 2.2, 3.3))
-	})
-}

--- a/support/convert/type.go
+++ b/support/convert/type.go
@@ -102,3 +102,15 @@ func ToSliceE[T int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | 
 		return []T{}, fmt.Errorf("unable to cast %#v of type %T", i, i)
 	}
 }
+
+// ToAnySlice converts a slice of any type T to a slice of type []any.
+//
+//	ToAnySlice("foo", "bar") // []any{"foo", "bar"}
+func ToAnySlice[T any](s ...T) []any {
+	res := make([]any, len(s))
+	for i, v := range s {
+		res[i] = v
+	}
+
+	return res
+}

--- a/support/convert/type.go
+++ b/support/convert/type.go
@@ -104,9 +104,29 @@ func ToSliceE[T int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | 
 }
 
 // ToAnySlice converts a slice of any type T to a slice of type []any.
+// It supports both variadic arguments and slice arguments.
 //
 //	ToAnySlice("foo", "bar") // []any{"foo", "bar"}
+//	ToAnySlice([]int{1, 2, 3}) // []any{1, 2, 3}
 func ToAnySlice[T any](s ...T) []any {
+	if len(s) == 0 {
+		return []any{}
+	}
+
+	// Check if the first argument is a slice
+	if len(s) == 1 {
+		v := reflect.ValueOf(s[0])
+		if v.Kind() == reflect.Slice {
+			// Handle slice case
+			result := make([]any, v.Len())
+			for i := 0; i < v.Len(); i++ {
+				result[i] = v.Index(i).Interface()
+			}
+			return result
+		}
+	}
+
+	// Handle variadic arguments case
 	res := make([]any, len(s))
 	for i, v := range s {
 		res[i] = v

--- a/support/convert/type_test.go
+++ b/support/convert/type_test.go
@@ -375,3 +375,29 @@ func TestToSliceDifferentTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestToAnySlice(t *testing.T) {
+	t.Run("empty slice", func(t *testing.T) {
+		var input []int
+		result := ToAnySlice(input...)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("string slice", func(t *testing.T) {
+		input := []string{"a", "b", "c"}
+		assert.Equal(t, []any{"a", "b", "c"}, ToAnySlice(input...))
+	})
+
+	t.Run("int slice", func(t *testing.T) {
+		assert.Equal(t, []any{1, 2, 3}, ToAnySlice(1, 2, 3))
+	})
+
+	t.Run("bool slice", func(t *testing.T) {
+		assert.Equal(t, []any{true, false}, ToAnySlice(true, false))
+	})
+
+	t.Run("float slice", func(t *testing.T) {
+		assert.Equal(t, []any{1.1, 2.2, 3.3}, ToAnySlice(1.1, 2.2, 3.3))
+	})
+}

--- a/support/convert/type_test.go
+++ b/support/convert/type_test.go
@@ -405,7 +405,22 @@ func TestToAnySlice(t *testing.T) {
 		assert.Equal(t, []any{1}, ToAnySlice(1))
 	})
 
-	t.Run("single slice", func(t *testing.T) {
+	// Additional test cases to demonstrate the optimization
+	t.Run("empty variadic", func(t *testing.T) {
+		assert.Equal(t, []any{}, ToAnySlice[int]())
+	})
+
+	t.Run("int of slice", func(t *testing.T) {
 		assert.Equal(t, []any{1, 2, 3}, ToAnySlice([]int{1, 2, 3}))
+	})
+
+	t.Run("slice of strings", func(t *testing.T) {
+		input := []string{"hello", "world"}
+		assert.Equal(t, []any{"hello", "world"}, ToAnySlice(input))
+	})
+
+	t.Run("slice of floats", func(t *testing.T) {
+		input := []float64{1.1, 2.2, 3.3}
+		assert.Equal(t, []any{1.1, 2.2, 3.3}, ToAnySlice(input))
 	})
 }

--- a/support/convert/type_test.go
+++ b/support/convert/type_test.go
@@ -400,4 +400,12 @@ func TestToAnySlice(t *testing.T) {
 	t.Run("float slice", func(t *testing.T) {
 		assert.Equal(t, []any{1.1, 2.2, 3.3}, ToAnySlice(1.1, 2.2, 3.3))
 	})
+
+	t.Run("single value", func(t *testing.T) {
+		assert.Equal(t, []any{1}, ToAnySlice(1))
+	})
+
+	t.Run("single slice", func(t *testing.T) {
+		assert.Equal(t, []any{1, 2, 3}, ToAnySlice([]int{1, 2, 3}))
+	})
 }


### PR DESCRIPTION
## 📑 Description

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request refactors the `ToAnySlice` function by relocating it from `support/convert/convert.go` to `support/convert/type.go`, along with its associated tests. The changes streamline the codebase and improve organization by grouping type-related utilities together.

### Code Refactoring:

* [`queue/failer.go`](diffhunk://#diff-e751df76a45505e9614e773c2a47e785de145a48662b9cafcb0f5b00bc1b01c8L47-R48): Updated the `Failer.Get` method to use the relocated `ToAnySlice` function for converting slices, simplifying the code.
* [`support/convert/convert.go`](diffhunk://#diff-3a492504b005a8bdf625fd4072ff43986a636adb7ab1af07bb66b161c969789fL82-L93): Removed the `ToAnySlice` function from this file as part of the relocation effort.

### Code Relocation:

* [`support/convert/type.go`](diffhunk://#diff-ab2f6738140aafb039167fccdf916cd25b0c400542395f6b36910609b37497cdR105-R116): Added the `ToAnySlice` function to this file to consolidate type-related utilities.

### Test Relocation:

* [`support/convert/convert_test.go`](diffhunk://#diff-2a51a75c0a1310da90ba8d9c961d99328b49883f0ae4ddcf7b4885ef47df26d3L167-L192): Removed tests for the `ToAnySlice` function from this file.
* [`support/convert/type_test.go`](diffhunk://#diff-a47f2e6c7208656522d4fec8235da91e61fbea62f99f84a6621af521e9f542c2R378-R403): Added tests for the `ToAnySlice` function to this file to align with its new location.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
