### PR TITLE
fix: file.Extension

### DIFF
--- a/support/file/file.go
+++ b/support/file/file.go
@@ -57,22 +57,25 @@ func Exists(file string) bool {
 
 // Extension Supported types: https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md
 func Extension(file string, originalWhenUnknown ...bool) (string, error) {
+	getOriginal := false
+	if len(originalWhenUnknown) > 0 {
+		getOriginal = originalWhenUnknown[0]
+	}
+
 	mtype, err := mimetype.DetectFile(file)
-	if err != nil {
+	if err != nil && !getOriginal {
 		return "", err
 	}
 
-	if mtype.String() == "" {
-		if len(originalWhenUnknown) > 0 {
-			if originalWhenUnknown[0] {
-				return ClientOriginalExtension(file), nil
-			}
-		}
-
-		return "", errors.UnknownFileExtension
+	if mtype != nil && mtype.Extension() != "" {
+		return strings.TrimPrefix(mtype.Extension(), "."), nil
 	}
 
-	return strings.TrimPrefix(mtype.Extension(), "."), nil
+	if getOriginal {
+		return ClientOriginalExtension(file), nil
+	}
+
+	return "", errors.UnknownFileExtension
 }
 
 func GetContent(file string) (string, error) {


### PR DESCRIPTION
## 📑 Description

The extension can't be returned when judging some special files, eg: [test.unity3d.zip](https://github.com/user-attachments/files/21017007/test.unity3d.zip).

Can't add test cases for this scenario.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
