### PR TITLE
chore: optimize jwt code

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -46,7 +46,7 @@ func (s *AuthTestSuite) SetupTest() {
 
 	s.mockConfig.EXPECT().GetString("auth.guards.user.driver").Return("jwt").Once()
 	s.mockConfig.EXPECT().GetString("auth.guards.user.provider").Return("user").Once()
-	s.mockConfig.EXPECT().Get("auth.guards.user.ttl").Return(2).Once()
+	s.mockConfig.EXPECT().GetInt("auth.guards.user.ttl").Return(2).Once()
 	s.mockConfig.EXPECT().GetString("auth.providers.user.driver").Return("orm").Once()
 
 	s.mockConfig.EXPECT().GetString("auth.guards.user.secret").Return("a").Once()

--- a/auth/jwt_guard_test.go
+++ b/auth/jwt_guard_test.go
@@ -52,7 +52,7 @@ func (s *JwtGuardTestSuite) SetupTest() {
 
 	s.mockConfig.EXPECT().GetString("auth.guards.user.secret").Return("a").Once()
 	s.mockConfig.EXPECT().GetInt("auth.guards.user.refresh_ttl").Return(2).Once()
-	s.mockConfig.EXPECT().Get("auth.guards.user.ttl").Return(2).Once()
+	s.mockConfig.EXPECT().GetInt("auth.guards.user.ttl").Return(2).Once()
 
 	jwtGuard, err := NewJwtGuard(s.mockContext, testUserGuard, s.mockUserProvider)
 	s.Require().Nil(err)
@@ -334,7 +334,7 @@ func (s *JwtGuardTestSuite) TestUser_Success() {
 func (s *JwtGuardTestSuite) TestUser_Success_MultipleParse() {
 	testAdminGuard := "admin"
 
-	s.mockConfig.EXPECT().Get("auth.guards.admin.ttl").Return(2)
+	s.mockConfig.EXPECT().GetInt("auth.guards.admin.ttl").Return(2)
 	s.mockConfig.EXPECT().GetString("auth.guards.admin.secret").Return("a").Once()
 	s.mockConfig.EXPECT().GetInt("auth.guards.admin.refresh_ttl").Return(0).Once()
 	s.mockConfig.EXPECT().GetInt("jwt.refresh_ttl").Return(2).Once()
@@ -422,7 +422,7 @@ func (s *JwtGuardTestSuite) TestLogout_SetDisabledCacheError() {
 func (s *JwtGuardTestSuite) TestMakeAuthContext() {
 	testAdminGuard := "admin"
 
-	s.mockConfig.EXPECT().Get("auth.guards.admin.ttl").Return(2)
+	s.mockConfig.EXPECT().GetInt("auth.guards.admin.ttl").Return(2)
 	s.mockConfig.EXPECT().GetString("auth.guards.admin.secret").Return("").Once()
 	s.mockConfig.EXPECT().GetString("jwt.secret").Return("a").Once()
 	s.mockConfig.EXPECT().GetInt("auth.guards.admin.refresh_ttl").Return(2).Once()
@@ -446,7 +446,7 @@ func (s *JwtGuardTestSuite) TestMakeAuthContext() {
 func (s *JwtGuardTestSuite) TestRefressTtl() {
 	testAdminGuard := "admin"
 
-	s.mockConfig.EXPECT().Get("auth.guards.admin.ttl").Return(2)
+	s.mockConfig.EXPECT().GetInt("auth.guards.admin.ttl").Return(2)
 	s.mockConfig.EXPECT().GetString("auth.guards.admin.secret").Return("").Once()
 	s.mockConfig.EXPECT().GetString("jwt.secret").Return("a").Once()
 	s.mockConfig.EXPECT().GetInt("auth.guards.admin.refresh_ttl").Return(0).Once()
@@ -546,57 +546,5 @@ func Background() http.Context {
 		request:  nil,
 		response: nil,
 		values:   make(map[any]any),
-	}
-}
-
-func TestGetTtl(t *testing.T) {
-	var mockConfig *mocksconfig.Config
-
-	tests := []struct {
-		name     string
-		setup    func()
-		expected int
-	}{
-		{
-			name: "GuardTtlIsNil",
-			setup: func() {
-				mockConfig.EXPECT().Get("auth.guards.user.ttl").Return(nil).Once()
-				mockConfig.EXPECT().GetInt("jwt.ttl").Return(2).Once()
-			},
-			expected: 2,
-		},
-		{
-			name: "GuardTtlIsNotNil",
-			setup: func() {
-				mockConfig.EXPECT().Get("auth.guards.user.ttl").Return(1).Once()
-			},
-			expected: 1,
-		},
-		{
-			name: "GuardTtlIsZero",
-			setup: func() {
-				mockConfig.EXPECT().Get("auth.guards.user.ttl").Return(0).Once()
-			},
-			expected: 60 * 24 * 365 * 100,
-		},
-		{
-			name: "JwtTtlIsZero",
-			setup: func() {
-				mockConfig.EXPECT().Get("auth.guards.user.ttl").Return(nil).Once()
-				mockConfig.EXPECT().GetInt("jwt.ttl").Return(0).Once()
-			},
-			expected: 60 * 24 * 365 * 100,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			mockConfig = mocksconfig.NewConfig(t)
-
-			test.setup()
-
-			ttl := getTtl(mockConfig, testUserGuard)
-			assert.Equal(t, test.expected, ttl)
-		})
 	}
 }

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -159,7 +159,7 @@ func (s *ApplicationTestSuite) TestMakeAuth() {
 	mockConfig.EXPECT().GetString("auth.guards.user.provider").Return("user").Once()
 	mockConfig.EXPECT().GetString("auth.providers.user.driver").Return("orm").Once()
 	mockConfig.EXPECT().GetString("auth.guards.user.secret").Return("secret").Once()
-	mockConfig.EXPECT().Get("auth.guards.user.ttl").Return(100).Once()
+	mockConfig.EXPECT().GetInt("auth.guards.user.ttl").Return(100).Once()
 	mockConfig.EXPECT().GetInt("auth.guards.user.refresh_ttl").Return(100).Once()
 
 	s.app.Singleton(binding.Config, func(app foundation.Application) (any, error) {


### PR DESCRIPTION
## 📑 Description

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request refactors how the TTL (time-to-live) configuration is handled in the JWT authentication system. The changes focus on removing the `getTtl` helper function and replacing its usage with direct calls to `GetInt` on the configuration object. Additionally, redundant test cases for `getTtl` have been removed.

### Refactoring TTL Handling:
* Replaced calls to `getTtl` with direct usage of `configFacade.GetInt` in `auth/jwt_guard.go`. Added fallback logic to ensure a default TTL of 100 years if no value is configured. (`[[1]](diffhunk://#diff-3e8e8c158483b45ef7d8c8fa7167074502a65962cf0a8bcd5abb5d4be828ec90L67-R75)`, `[[2]](diffhunk://#diff-3e8e8c158483b45ef7d8c8fa7167074502a65962cf0a8bcd5abb5d4be828ec90L309-L325)`)

### Test Updates:
* Updated test cases in `auth/auth_test.go` and `auth/jwt_guard_test.go` to use `GetInt` instead of `Get` for TTL configuration. (`[[1]](diffhunk://#diff-b06746870e62f95017714121be6134cffdc4bd1d46dd21f8cae8c484e3e2829dL49-R49)`, `[[2]](diffhunk://#diff-9278dec93b140b3a9a2aa1bae735a89ca38035fba7532983c925a98f53804e51L55-R55)`, `[[3]](diffhunk://#diff-9278dec93b140b3a9a2aa1bae735a89ca38035fba7532983c925a98f53804e51L337-R337)`, `[[4]](diffhunk://#diff-9278dec93b140b3a9a2aa1bae735a89ca38035fba7532983c925a98f53804e51L425-R425)`, `[[5]](diffhunk://#diff-9278dec93b140b3a9a2aa1bae735a89ca38035fba7532983c925a98f53804e51L449-R449)`)
* Removed the `TestGetTtl` test suite as it is no longer relevant after the removal of the `getTtl` function. (`[auth/jwt_guard_test.goL551-L602](diffhunk://#diff-9278dec93b140b3a9a2aa1bae735a89ca38035fba7532983c925a98f53804e51L551-L602)`)

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
