### PR TITLE
fix: Refactor str package methods for better Replace and case handling

### DIFF
--- a/database/gorm/event_test.go
+++ b/database/gorm/event_test.go
@@ -71,7 +71,7 @@ func TestEventTestSuite(t *testing.T) {
 
 func (s *EventTestSuite) SetupTest() {
 	s.events = []*Event{
-		NewEvent(testQuery, &testEventModel, map[string]any{"i_d": 1, "created_at": carbon.NewDateTime(carbon.FromStdTime(testNow)), "updated_at": carbon.NewDateTime(carbon.FromStdTime(testNow)), "avatar": "avatar1", "is_admin": false, "manage": 1, "admin_at": time.Now(), "manage_at": testNow}),
+		NewEvent(testQuery, &testEventModel, map[string]any{"id": 1, "created_at": carbon.NewDateTime(carbon.FromStdTime(testNow)), "updated_at": carbon.NewDateTime(carbon.FromStdTime(testNow)), "avatar": "avatar1", "is_admin": false, "manage": 1, "admin_at": time.Now(), "manage_at": testNow}),
 		NewEvent(testQuery, &testEventModel, map[string]any{"ID": 1, "CreatedAt": carbon.NewDateTime(carbon.FromStdTime(testNow)), "UpdatedAt": carbon.NewDateTime(carbon.FromStdTime(testNow)), "Avatar": "avatar1", "IsAdmin": false, "IsManage": 1, "AdminAt": time.Now(), "ManageAt": testNow}),
 		NewEvent(testQuery, &testEventModel, TestEventModel{
 			Model: Model{
@@ -327,8 +327,8 @@ func (s *EventTestSuite) TestToDBColumnName() {
 func (s *EventTestSuite) TestColumnNames() {
 	for _, event := range s.events {
 		s.Equal(map[string]string{
-			"ID":         "i_d",
-			"i_d":        "i_d",
+			"ID":         "id",
+			"id":         "id",
 			"CreatedAt":  "created_at",
 			"created_at": "created_at",
 			"UpdatedAt":  "updated_at",
@@ -377,7 +377,7 @@ func TestStructToMap(t *testing.T) {
 	}
 
 	assert.EqualValues(t, map[string]any{
-		"i_d":        testStruct.ID,
+		"id":         testStruct.ID,
 		"created_at": testStruct.CreatedAt,
 		"updated_at": testStruct.UpdatedAt,
 		"name":       testStruct.Name,

--- a/support/str/str.go
+++ b/support/str/str.go
@@ -122,8 +122,8 @@ func (s *String) ChopEnd(needle string, more ...string) *String {
 	more = append([]string{needle}, more...)
 
 	for _, v := range more {
-		if s.EndsWith(v) {
-			s.value = strings.TrimSuffix(s.value, v)
+		if after, found := strings.CutSuffix(s.value, v); found {
+			s.value = after
 			break
 		}
 	}
@@ -135,8 +135,8 @@ func (s *String) ChopStart(needle string, more ...string) *String {
 	more = append([]string{needle}, more...)
 
 	for _, v := range more {
-		if s.StartsWith(v) {
-			s.value = strings.TrimPrefix(s.value, v)
+		if after, found := strings.CutPrefix(s.value, v); found {
+			s.value = after
 			break
 		}
 	}

--- a/support/str/str.go
+++ b/support/str/str.go
@@ -555,7 +555,7 @@ func (s *String) Repeat(times int) *String {
 func (s *String) Replace(search string, replace string, caseSensitive ...bool) *String {
 	caseSensitive = append(caseSensitive, true)
 	if len(caseSensitive) > 0 && !caseSensitive[0] {
-		s.value = regexp.MustCompile("(?i)"+search).ReplaceAllString(s.value, replace)
+		s.value = regexp.MustCompile("(?i)"+regexp.QuoteMeta(search)).ReplaceAllString(s.value, replace)
 		return s
 	}
 	s.value = strings.ReplaceAll(s.value, search, replace)

--- a/support/str/str.go
+++ b/support/str/str.go
@@ -123,7 +123,7 @@ func (s *String) ChopEnd(needle string, more ...string) *String {
 
 	for _, v := range more {
 		if s.EndsWith(v) {
-			s.value = strings.TrimRight(s.value, v)
+			s.value = strings.TrimSuffix(s.value, v)
 			break
 		}
 	}
@@ -136,7 +136,7 @@ func (s *String) ChopStart(needle string, more ...string) *String {
 
 	for _, v := range more {
 		if s.StartsWith(v) {
-			s.value = strings.TrimLeft(s.value, v)
+			s.value = strings.TrimPrefix(s.value, v)
 			break
 		}
 	}

--- a/support/str/str_test.go
+++ b/support/str/str_test.go
@@ -466,6 +466,9 @@ func (s *StringTestSuite) TestReplace() {
 	s.Equal("foo/foo/foo", Of("x/x/x").Replace("X", "foo", false).String())
 	s.Equal("bar/bar", Of("?/?").Replace("?", "bar").String())
 	s.Equal("?/?/?", Of("? ? ?").Replace(" ", "/").String())
+	s.Equal("a1b2c3", Of("a1b2c3").Replace("\\d", "X", false).String())
+	s.Equal("hello-world", Of("hello.world").Replace(".", "-", false).String())
+	s.Equal("hello(world]", Of("hello[world]").Replace("[", "(", false).String())
 }
 
 func (s *StringTestSuite) TestReplaceEnd() {

--- a/support/str/str_test.go
+++ b/support/str/str_test.go
@@ -123,6 +123,9 @@ func (s *StringTestSuite) TestChopEnd() {
 	s.Equal("https://goravel", Of("https://goravel.dev").ChopEnd(".dev", ".com").String())
 	s.Equal("https://goravel", Of("https://goravel.com").ChopEnd(".dev", ".com").String())
 	s.Equal("go", Of("golaravel").ChopEnd("laravel").String())
+	s.Equal("world", Of("worldld").ChopEnd("ld").String())
+	s.Equal("helloworldld", Of("helloworldld").ChopEnd("rld").String())
+	s.Equal("helloworld", Of("helloworldrld").ChopEnd("rld").String())
 }
 
 func (s *StringTestSuite) TestChopStart() {
@@ -131,6 +134,10 @@ func (s *StringTestSuite) TestChopStart() {
 	s.Equal("goravel.dev", Of("https://goravel.dev").ChopStart("https://", "http://").String())
 	s.Equal("goravel.dev", Of("http://goravel.dev").ChopStart("https://", "http://").String())
 	s.Equal("goravel", "go"+Of("laravel").ChopStart("la").String())
+	s.Equal("he", Of("hehe").ChopStart("he").String())
+	s.Equal("ehello", Of("ehehello").ChopStart("eh").String())
+	s.Equal("helloworldld", Of("helloworldld").ChopStart("rld").String())
+	s.Equal("loworld", Of("helloworld").ChopStart("hel").String())
 }
 
 func (s *StringTestSuite) TestContains() {


### PR DESCRIPTION
## 📑 Description
- Fixed `ChopStart` and `ChopEnd` to match and remove exact strings instead of treating them as character sets (e.g., "hehe".chopStart("he") now returns "he").
- Escaped special characters in `Replace` when using case-insensitive mode to avoid incorrect regex behavior.
- Improved `Snake` case conversion to handle acronyms properly, e.g., `UserID` becomes `user_id` instead of `user_i_d`.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
