### PR TITLE
fix: cc and bcc fields not set when sending mail due to incorrect condition in SendMail (v1.16.x)

### DIFF
--- a/mail/application.go
+++ b/mail/application.go
@@ -204,10 +204,10 @@ func SendMail(config config.Config, subject, html, fromAddress, fromName string,
 	}
 
 	e.To = to
-	if len(e.Bcc) > 0 {
+	if len(bcc) > 0 {
 		e.Bcc = bcc
 	}
-	if len(e.Cc) > 0 {
+	if len(cc) > 0 {
 		e.Cc = cc
 	}
 	e.Subject = subject


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
