### PR TITLE
fix: [#749] The path is incorrect when publishing package files

### DIFF
--- a/foundation/console/package_make_command_stubs.go
+++ b/foundation/console/package_make_command_stubs.go
@@ -161,7 +161,6 @@ func main() {
 		).
 		Execute()
 }
-
 `
 	content = strings.ReplaceAll(content, "DummyName", r.name)
 

--- a/foundation/console/vendor_publish_command.go
+++ b/foundation/console/vendor_publish_command.go
@@ -4,7 +4,6 @@ import (
 	"go/build"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/console/command"
@@ -79,7 +78,6 @@ func (r *VendorPublishCommand) Handle(ctx console.Context) error {
 	}
 
 	for sourcePath, targetValue := range paths {
-		targetValue = strings.TrimPrefix(strings.TrimPrefix(targetValue, "/"), "./")
 		packagePath := filepath.Join(packageDir, sourcePath)
 
 		res, err := r.publish(packagePath, targetValue, ctx.OptionBool("existing"), ctx.OptionBool("force"))

--- a/foundation/console/vendor_publish_command_test.go
+++ b/foundation/console/vendor_publish_command_test.go
@@ -6,9 +6,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goravel/framework/contracts/console/command"
+	mocksconsole "github.com/goravel/framework/mocks/console"
 	"github.com/goravel/framework/support/file"
 )
 
@@ -421,4 +423,37 @@ func (s *VendorPublishCommandTestSuite) TestPublishFile() {
 	// Clean up test files
 	s.Nil(os.Remove(sourceFile))
 	s.Nil(os.Remove(targetFile))
+}
+
+func (s *VendorPublishCommandTestSuite) TestHandle() {
+	s.Run("should return error when no vendor found", func() {
+		cmd := NewVendorPublishCommand(map[string]map[string]string{}, map[string]map[string]string{})
+		mockCtx := mocksconsole.NewContext(s.T())
+
+		mockCtx.EXPECT().Option("package").Return("").Once()
+		mockCtx.EXPECT().Option("tag").Return("").Once()
+		mockCtx.EXPECT().Error("no vendor found").Return().Once()
+
+		err := cmd.Handle(mockCtx)
+
+		s.Nil(err)
+	})
+
+	s.Run("should return error when package directory not found", func() {
+		publishes := map[string]map[string]string{
+			"github.com/goravel/sms": {
+				"config.go": "config.go",
+			},
+		}
+		cmd := NewVendorPublishCommand(publishes, map[string]map[string]string{})
+		mockCtx := mocksconsole.NewContext(s.T())
+
+		mockCtx.EXPECT().Option("package").Return("github.com/goravel/sms").Once()
+		mockCtx.EXPECT().Option("tag").Return("").Once()
+		mockCtx.EXPECT().Error(mock.AnythingOfType("string")).Return().Once()
+
+		err := cmd.Handle(mockCtx)
+
+		s.Nil(err)
+	})
 }


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/749

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request introduces improvements to the vendor publish command and its test coverage, along with minor code cleanups. The main changes include refining path handling logic, enhancing test coverage for error scenarios, and cleaning up unused imports.

**Vendor publish command improvements:**

* Removed redundant path normalization logic from the `Handle` method in `vendor_publish_command.go`, simplifying how target paths are processed.

**Test coverage enhancements:**

* Added new tests to `vendor_publish_command_test.go` to verify error handling when no vendor is found and when the package directory does not exist. These tests use a mock context to simulate command execution and error reporting.
* Integrated `github.com/stretchr/testify/mock` and a new mock context (`mocksconsole`) to facilitate more robust and isolated testing of command behavior.

**Code cleanup:**

* Removed the unused `strings` import from `vendor_publish_command.go`, reflecting the simplification of path handling logic.
* Minor formatting cleanup in `package_make_command_stubs.go` for improved readability.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
