### PR TITLE
fix: The configuredServiceProviders, publishes and publishGroups are not reset when Booting

### DIFF
--- a/foundation/application.go
+++ b/foundation/application.go
@@ -58,6 +58,10 @@ func NewApplication() foundation.Application {
 }
 
 func (r *Application) Boot() {
+	r.configuredServiceProviders = make([]foundation.ServiceProvider, 0)
+	r.publishes = make(map[string]map[string]string)
+	r.publishGroups = make(map[string]map[string]string)
+
 	r.setTimezone()
 	r.registerConfiguredServiceProviders()
 	r.bootConfiguredServiceProviders()

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -58,9 +58,9 @@ func NewApplication() foundation.Application {
 }
 
 func (r *Application) Boot() {
-	r.configuredServiceProviders = make([]foundation.ServiceProvider, 0)
-	r.publishes = make(map[string]map[string]string)
-	r.publishGroups = make(map[string]map[string]string)
+	r.configuredServiceProviders = r.configuredServiceProviders[:0]
+	clear(r.publishes)
+	clear(r.publishGroups)
 
 	r.setTimezone()
 	r.registerConfiguredServiceProviders()


### PR DESCRIPTION
## 📑 Description

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

The `Refresh` function calls the `Boot` function. If the configuration `app.providers` is modified and configuredServiceProviders, etc. are not reset, the latest configuration can't be applied.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
