### PR TITLE
fix: [#738] The Orm Creating event can be triggered when the query with the Model method

### DIFF
--- a/config/application_test.go
+++ b/config/application_test.go
@@ -23,24 +23,25 @@ APP_DEBUG=true
 DB_PORT=3306
 `))
 	temp, err := os.CreateTemp("", "goravel.env")
-	assert.Nil(t, err)
-	defer temp.Close()
-	defer os.Remove(temp.Name())
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, temp.Close())
+		assert.NoError(t, os.Remove(temp.Name()))
+	}()
 
 	_, err = temp.Write([]byte(`
 APP_KEY=12345678901234567890123456789012
 APP_DEBUG=true
 DB_PORT=3306
 `))
-	assert.Nil(t, err)
-	assert.Nil(t, temp.Close())
+	assert.NoError(t, err)
 
 	suite.Run(t, &ApplicationTestSuite{
 		config:       NewApplication(".env"),
 		customConfig: NewApplication(temp.Name()),
 	})
 
-	assert.Nil(t, file.Remove(".env"))
+	assert.NoError(t, file.Remove(".env"))
 }
 
 func (s *ApplicationTestSuite) SetupTest() {

--- a/console/cli_helper.go
+++ b/console/cli_helper.go
@@ -72,7 +72,7 @@ func subtract(a, b int) int {
 
 func indent(spaces int, v string) string {
 	pad := strings.Repeat(" ", spaces)
-	return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+	return pad + strings.ReplaceAll(v, "\n", "\n"+pad)
 }
 
 func wrap(input string, offset int) string {
@@ -181,7 +181,7 @@ func capitalize(s string) string {
 // support style tags like <fg=red>text</>
 // more details in https://gookit.github.io/color/#/?id=tag-attributes
 func colorize(text string) string {
-    return color.Default().Sprint(text)
+	return color.Default().Sprint(text)
 
 }
 

--- a/console/console/build_command.go
+++ b/console/console/build_command.go
@@ -111,9 +111,9 @@ func (receiver *BuildCommand) Handle(ctx console.Context) error {
 }
 
 func (receiver *BuildCommand) build(system string, command []string) error {
-	os.Setenv("CGO_ENABLED", "0")
-	os.Setenv("GOOS", system)
-	os.Setenv("GOARCH", "amd64")
+	_ = os.Setenv("CGO_ENABLED", "0")
+	_ = os.Setenv("GOOS", system)
+	_ = os.Setenv("GOARCH", "amd64")
 
 	cmd := exec.Command(command[0], command[1:]...)
 	_, err := cmd.Output()

--- a/database/gorm/event.go
+++ b/database/gorm/event.go
@@ -65,7 +65,7 @@ func (e *Event) IsDirty(columns ...string) bool {
 
 	if len(columns) == 0 {
 		for destColumn, destValue := range destOfMap {
-			if !(e.validColumn(destColumn) && e.validValue(destColumn, destValue)) {
+			if !e.validColumn(destColumn) || !e.validValue(destColumn, destValue) {
 				continue
 			}
 			if e.dirty(destColumn, destValue) {
@@ -78,7 +78,7 @@ func (e *Event) IsDirty(columns ...string) bool {
 				continue
 			}
 			for destColumn, destValue := range destOfMap {
-				if !(e.validColumn(destColumn) && e.validValue(destColumn, destValue)) {
+				if !e.validColumn(destColumn) || !e.validValue(destColumn, destValue) {
 					continue
 				}
 				if e.equalColumnName(column, destColumn) && e.dirty(destColumn, destValue) {

--- a/database/gorm/query.go
+++ b/database/gorm/query.go
@@ -1356,10 +1356,18 @@ func (r *Query) create(dest any) error {
 }
 
 func (r *Query) created(dest any) error {
+	if isSlice(dest) {
+		return nil
+	}
+
 	return r.event(contractsorm.EventCreated, r.instance.Statement.Model, dest)
 }
 
 func (r *Query) creating(dest any) error {
+	if isSlice(dest) {
+		return nil
+	}
+
 	return r.event(contractsorm.EventCreating, r.instance.Statement.Model, dest)
 }
 
@@ -1412,18 +1420,34 @@ func (r *Query) event(event contractsorm.EventType, model, dest any) error {
 }
 
 func (r *Query) deleting(dest any) error {
+	if !hasID(dest) {
+		return nil
+	}
+
 	return r.event(contractsorm.EventDeleting, r.instance.Statement.Model, dest)
 }
 
 func (r *Query) deleted(dest any) error {
+	if !hasID(dest) {
+		return nil
+	}
+
 	return r.event(contractsorm.EventDeleted, r.instance.Statement.Model, dest)
 }
 
 func (r *Query) forceDeleting(dest any) error {
+	if !hasID(dest) {
+		return nil
+	}
+
 	return r.event(contractsorm.EventForceDeleting, r.instance.Statement.Model, dest)
 }
 
 func (r *Query) forceDeleted(dest any) error {
+	if !hasID(dest) {
+		return nil
+	}
+
 	return r.event(contractsorm.EventForceDeleted, r.instance.Statement.Model, dest)
 }
 
@@ -1537,6 +1561,10 @@ func (r *Query) restoring(dest any) error {
 }
 
 func (r *Query) retrieved(dest any) error {
+	if isSlice(dest) {
+		return nil
+	}
+
 	return r.event(contractsorm.EventRetrieved, nil, dest)
 }
 
@@ -1545,10 +1573,18 @@ func (r *Query) save(value any) error {
 }
 
 func (r *Query) saved(dest any) error {
+	if isSlice(dest) {
+		return nil
+	}
+
 	return r.event(contractsorm.EventSaved, r.instance.Statement.Model, dest)
 }
 
 func (r *Query) saving(dest any) error {
+	if isSlice(dest) {
+		return nil
+	}
+
 	return r.event(contractsorm.EventSaving, r.instance.Statement.Model, dest)
 }
 
@@ -1608,10 +1644,18 @@ func (r *Query) setConditions(conditions Conditions) *Query {
 }
 
 func (r *Query) updating(dest any) error {
+	if isSlice(dest) {
+		return nil
+	}
+
 	return r.event(contractsorm.EventUpdating, r.instance.Statement.Model, dest)
 }
 
 func (r *Query) updated(dest any) error {
+	if isSlice(dest) {
+		return nil
+	}
+
 	return r.event(contractsorm.EventUpdated, r.instance.Statement.Model, dest)
 }
 
@@ -1801,4 +1845,14 @@ func getObserverEvent(event contractsorm.EventType, observer contractsorm.Observ
 	}
 
 	return nil
+}
+
+func isSlice(dest any) bool {
+	destType := reflect.Indirect(reflect.ValueOf(dest)).Type()
+	return destType.Kind() == reflect.Slice
+}
+
+func hasID(dest any) bool {
+	id := database.GetID(dest)
+	return id != nil
 }

--- a/database/gorm/query.go
+++ b/database/gorm/query.go
@@ -1850,8 +1850,11 @@ func getObserverEvent(event contractsorm.EventType, observer contractsorm.Observ
 }
 
 func isSlice(dest any) bool {
-	destKind := reflect.Indirect(reflect.ValueOf(dest)).Type().Kind()
+	if dest == nil {
+		return false
+	}
 
+	destKind := reflect.Indirect(reflect.ValueOf(dest)).Type().Kind()
 	return destKind == reflect.Slice || destKind == reflect.Array
 }
 

--- a/database/gorm/query.go
+++ b/database/gorm/query.go
@@ -224,7 +224,9 @@ func (r *Query) Cursor() (chan contractsorm.Cursor, error) {
 		if err != nil {
 			return
 		}
-		defer rows.Close()
+		defer func() {
+			_ = rows.Close()
+		}()
 
 		for rows.Next() {
 			val := make(map[string]any)
@@ -284,7 +286,7 @@ func (r *Query) Distinct(args ...any) contractsorm.Query {
 }
 
 func (r *Query) Driver() contractsdatabase.Driver {
-	return contractsdatabase.Driver(r.instance.Dialector.Name())
+	return contractsdatabase.Driver(r.instance.Name())
 }
 
 func (r *Query) Exec(sql string, values ...any) (*contractsorm.Result, error) {
@@ -1848,8 +1850,9 @@ func getObserverEvent(event contractsorm.EventType, observer contractsorm.Observ
 }
 
 func isSlice(dest any) bool {
-	destType := reflect.Indirect(reflect.ValueOf(dest)).Type()
-	return destType.Kind() == reflect.Slice
+	destKind := reflect.Indirect(reflect.ValueOf(dest)).Type().Kind()
+
+	return destKind == reflect.Slice || destKind == reflect.Array
 }
 
 func hasID(dest any) bool {

--- a/database/gorm/query_test.go
+++ b/database/gorm/query_test.go
@@ -873,6 +873,33 @@ func (s *QueryTestSuite) TestEvent_Creating() {
 					s.Equal("event_creating_save_avatar", user.Avatar)
 				},
 			},
+			{
+				name: "not trigger when creating by slice struct",
+				setup: func() {
+					users := []User{{Name: "event_creating_slice_name"}, {Name: "event_creating_slice_name1"}}
+					s.Nil(query.Query().Model(&User{}).Create(users))
+				},
+			},
+			{
+				name: "not trigger when creating by slice map",
+				setup: func() {
+					users := []map[string]any{
+						{
+							"Name":      "event_creating_slice_name",
+							"Avatar":    "event_creating_slice_avatar",
+							"CreatedAt": carbon.Now(),
+							"UpdatedAt": carbon.Now(),
+						},
+						{
+							"Name":      "event_creating_slice_name1",
+							"Avatar":    "event_creating_slice_avatar1",
+							"CreatedAt": carbon.Now(),
+							"UpdatedAt": carbon.Now(),
+						},
+					}
+					s.Nil(query.Query().Model(&User{}).Create(&users))
+				},
+			},
 		}
 		for _, test := range tests {
 			s.Run(test.name, func() {
@@ -986,6 +1013,33 @@ func (s *QueryTestSuite) TestEvent_Created() {
 					s.Nil(query.Query().Find(&user1, user.ID))
 					s.Equal("event_created_save_name", user1.Name)
 					s.Empty(user1.Avatar)
+				},
+			},
+			{
+				name: "not trigger when creating by slice struct",
+				setup: func() {
+					users := []User{{Name: "event_creating_slice_name"}, {Name: "event_creating_slice_name1"}}
+					s.Nil(query.Query().Model(&User{}).Create(users))
+				},
+			},
+			{
+				name: "not trigger when creating by slice map",
+				setup: func() {
+					users := []map[string]any{
+						{
+							"Name":      "event_creating_slice_name",
+							"Avatar":    "event_creating_slice_avatar",
+							"CreatedAt": carbon.Now(),
+							"UpdatedAt": carbon.Now(),
+						},
+						{
+							"Name":      "event_creating_slice_name1",
+							"Avatar":    "event_creating_slice_avatar1",
+							"CreatedAt": carbon.Now(),
+							"UpdatedAt": carbon.Now(),
+						},
+					}
+					s.Nil(query.Query().Model(&User{}).Create(&users))
 				},
 			},
 		}
@@ -1107,6 +1161,33 @@ func (s *QueryTestSuite) TestEvent_Saving() {
 					s.Nil(query.Query().Find(&user1, user.ID))
 					s.Equal("event_saving_single_update_name", user1.Name)
 					s.Equal("event_saving_single_update_avatar1", user1.Avatar)
+				},
+			},
+			{
+				name: "not trigger when creating by slice struct",
+				setup: func() {
+					users := []User{{Name: "event_creating_slice_name"}, {Name: "event_creating_slice_name1"}}
+					s.Nil(query.Query().Model(&User{}).Create(users))
+				},
+			},
+			{
+				name: "not trigger when creating by slice map",
+				setup: func() {
+					users := []map[string]any{
+						{
+							"Name":      "event_creating_slice_name",
+							"Avatar":    "event_creating_slice_avatar",
+							"CreatedAt": carbon.Now(),
+							"UpdatedAt": carbon.Now(),
+						},
+						{
+							"Name":      "event_creating_slice_name1",
+							"Avatar":    "event_creating_slice_avatar1",
+							"CreatedAt": carbon.Now(),
+							"UpdatedAt": carbon.Now(),
+						},
+					}
+					s.Nil(query.Query().Model(&User{}).Create(&users))
 				},
 			},
 		}
@@ -1238,6 +1319,33 @@ func (s *QueryTestSuite) TestEvent_Saved() {
 					s.Nil(query.Query().Find(&user1, user.ID))
 					s.Equal("event_saved_map_update_name", user1.Name)
 					s.Equal("event_saved_map_update_avatar", user1.Avatar)
+				},
+			},
+			{
+				name: "not trigger when creating by slice struct",
+				setup: func() {
+					users := []User{{Name: "event_creating_slice_name"}, {Name: "event_creating_slice_name1"}}
+					s.Nil(query.Query().Model(&User{}).Create(users))
+				},
+			},
+			{
+				name: "not trigger when creating by slice map",
+				setup: func() {
+					users := []map[string]any{
+						{
+							"Name":      "event_creating_slice_name",
+							"Avatar":    "event_creating_slice_avatar",
+							"CreatedAt": carbon.Now(),
+							"UpdatedAt": carbon.Now(),
+						},
+						{
+							"Name":      "event_creating_slice_name1",
+							"Avatar":    "event_creating_slice_avatar1",
+							"CreatedAt": carbon.Now(),
+							"UpdatedAt": carbon.Now(),
+						},
+					}
+					s.Nil(query.Query().Model(&User{}).Create(&users))
 				},
 			},
 		}
@@ -1387,61 +1495,96 @@ func (s *QueryTestSuite) TestEvent_Updated() {
 
 func (s *QueryTestSuite) TestEvent_Deleting() {
 	for _, query := range s.queries {
-		user := User{Name: "event_deleting_name", Avatar: "event_deleting_avatar"}
-		s.Nil(query.Query().Create(&user))
+		s.Run("trigger", func() {
+			user := User{Name: "event_deleting_name", Avatar: "event_deleting_avatar"}
+			s.Nil(query.Query().Create(&user))
 
-		res, err := query.Query().Delete(&user)
-		s.EqualError(err, "deleting error")
-		s.Nil(res)
+			res, err := query.Query().Delete(&user)
+			s.EqualError(err, "deleting error")
+			s.Nil(res)
 
-		var user1 User
-		s.Nil(query.Query().Find(&user1, user.ID))
-		s.True(user1.ID > 0)
+			var user1 User
+			s.Nil(query.Query().Find(&user1, user.ID))
+			s.True(user1.ID > 0)
+		})
+
+		s.Run("not trigger when deleting mass records", func() {
+			res, err := query.Query().Where("name", "event_deleting_name").Delete(&User{})
+			s.NoError(err)
+			s.Equal(int64(0), res.RowsAffected)
+		})
 	}
 }
 
 func (s *QueryTestSuite) TestEvent_Deleted() {
 	for _, query := range s.queries {
-		user := User{Name: "event_deleted_name", Avatar: "event_deleted_avatar"}
-		s.Nil(query.Query().Create(&user))
+		s.Run("trigger", func() {
+			user := User{Name: "event_deleted_name", Avatar: "event_deleted_avatar"}
+			s.Nil(query.Query().Create(&user))
 
-		res, err := query.Query().Delete(&user)
-		s.EqualError(err, "deleted error")
-		s.Nil(res)
+			res, err := query.Query().Delete(&user)
+			s.EqualError(err, "deleted error")
+			s.Nil(res)
 
-		var user1 User
-		s.Nil(query.Query().Find(&user1, user.ID))
-		s.True(user1.ID == 0)
+			var user1 User
+			s.Nil(query.Query().Find(&user1, user.ID))
+			s.True(user1.ID == 0)
+		})
+
+		s.Run("not trigger when deleting mass records", func() {
+			res, err := query.Query().Where("name", "event_deleted_name").Delete(&User{})
+			s.NoError(err)
+			s.Equal(int64(0), res.RowsAffected)
+		})
 	}
 }
 
 func (s *QueryTestSuite) TestEvent_ForceDeleting() {
 	for _, query := range s.queries {
-		user := User{Name: "event_force_deleting_name", Avatar: "event_force_deleting_avatar"}
-		s.Nil(query.Query().Create(&user))
+		s.Run("trigger", func() {
+			user := User{Name: "event_force_deleting_name", Avatar: "event_force_deleting_avatar"}
+			s.Nil(query.Query().Create(&user))
 
-		res, err := query.Query().ForceDelete(&user)
-		s.EqualError(err, "force deleting error")
-		s.Nil(res)
+			res, err := query.Query().ForceDelete(&user)
+			s.EqualError(err, "force deleting error")
+			s.Nil(res)
 
-		var user1 User
-		s.Nil(query.Query().Find(&user1, user.ID))
-		s.True(user1.ID > 0)
+			var user1 User
+			s.Nil(query.Query().Find(&user1, user.ID))
+			s.True(user1.ID > 0)
+		})
+
+		s.Run("not trigger when force deleting mass records", func() {
+			res, err := query.Query().Where("name", "event_force_deleting_name").ForceDelete(&User{})
+			s.NoError(err)
+			s.Equal(int64(1), res.RowsAffected)
+		})
 	}
 }
 
 func (s *QueryTestSuite) TestEvent_ForceDeleted() {
 	for _, query := range s.queries {
-		user := User{Name: "event_force_deleted_name", Avatar: "event_force_deleted_avatar"}
-		s.Nil(query.Query().Create(&user))
+		s.Run("trigger", func() {
+			user := User{Name: "event_force_deleted_name", Avatar: "event_force_deleted_avatar"}
+			s.Nil(query.Query().Create(&user))
 
-		res, err := query.Query().ForceDelete(&user)
-		s.EqualError(err, "force deleted error")
-		s.Nil(res)
+			res, err := query.Query().ForceDelete(&user)
+			s.EqualError(err, "force deleted error")
+			s.Nil(res)
 
-		var user1 User
-		s.Nil(query.Query().Find(&user1, user.ID))
-		s.True(user1.ID == 0)
+			var user1 User
+			s.Nil(query.Query().Find(&user1, user.ID))
+			s.True(user1.ID == 0)
+		})
+
+		s.Run("not trigger when force deleting mass records", func() {
+			user := User{Name: "event_force_deleted_name", Avatar: "event_force_deleted_avatar"}
+			s.Nil(query.Query().Create(&user))
+
+			res, err := query.Query().Where("name", "event_force_deleted_name").ForceDelete(&User{})
+			s.NoError(err)
+			s.Equal(int64(1), res.RowsAffected)
+		})
 	}
 }
 
@@ -1491,6 +1634,10 @@ func (s *QueryTestSuite) TestEvent_Restoring() {
 
 func (s *QueryTestSuite) TestEvent_Retrieved() {
 	for _, query := range s.queries {
+		user := User{Name: "event_retrieved_name"}
+		s.Nil(query.Query().Create(&user))
+		s.True(user.ID > 0)
+
 		tests := []struct {
 			name  string
 			setup func()
@@ -1502,6 +1649,16 @@ func (s *QueryTestSuite) TestEvent_Retrieved() {
 					s.Nil(query.Query().Where("name", "event_retrieved_name").Find(&user1))
 					s.True(user1.ID > 0)
 					s.Equal("event_retrieved_name1", user1.Name)
+				},
+			},
+			{
+				name: "not trigger when Find by slice struct",
+				setup: func() {
+					var users []User
+					s.Nil(query.Query().Model(&User{}).Where("name", "event_retrieved_name").Find(&users))
+					s.Equal(1, len(users))
+					s.True(users[0].ID > 0)
+					s.Equal("event_retrieved_name", users[0].Name)
 				},
 			},
 			{
@@ -1564,12 +1721,9 @@ func (s *QueryTestSuite) TestEvent_Retrieved() {
 				},
 			},
 		}
+
 		for _, test := range tests {
 			s.Run(test.name, func() {
-				user := User{Name: "event_retrieved_name"}
-				s.Nil(query.Query().Create(&user))
-				s.True(user.ID > 0)
-
 				test.setup()
 			})
 		}

--- a/database/gorm/query_test.go
+++ b/database/gorm/query_test.go
@@ -1511,7 +1511,7 @@ func (s *QueryTestSuite) TestEvent_Deleting() {
 		s.Run("not trigger when deleting mass records", func() {
 			res, err := query.Query().Where("name", "event_deleting_name").Delete(&User{})
 			s.NoError(err)
-			s.Equal(int64(0), res.RowsAffected)
+			s.Equal(int64(1), res.RowsAffected)
 		})
 	}
 }

--- a/database/gorm/test_models.go
+++ b/database/gorm/test_models.go
@@ -45,6 +45,11 @@ type User struct {
 func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Event) error {
 	return map[ormcontract.EventType]func(ormcontract.Event) error{
 		ormcontract.EventCreating: func(event ormcontract.Event) error {
+			eventImpl := event.(*Event)
+			if isSlice(eventImpl.dest) {
+				panic("dest is slice when creating")
+			}
+
 			name := event.GetAttribute("name")
 			if name != nil {
 				if name.(string) == "event_creating_name" {
@@ -82,6 +87,11 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 			return nil
 		},
 		ormcontract.EventCreated: func(event ormcontract.Event) error {
+			eventImpl := event.(*Event)
+			if isSlice(eventImpl.dest) {
+				panic("dest is slice when created")
+			}
+
 			name := event.GetAttribute("name")
 			if name != nil {
 				if name.(string) == "event_created_name" {
@@ -112,6 +122,11 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 			return nil
 		},
 		ormcontract.EventSaving: func(event ormcontract.Event) error {
+			eventImpl := event.(*Event)
+			if isSlice(eventImpl.dest) {
+				panic("dest is slice when saving")
+			}
+
 			name := event.GetAttribute("name")
 			switch name.(type) {
 			case string:
@@ -154,6 +169,11 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 			return nil
 		},
 		ormcontract.EventSaved: func(event ormcontract.Event) error {
+			eventImpl := event.(*Event)
+			if isSlice(eventImpl.dest) {
+				panic("dest is slice when saved")
+			}
+
 			name := event.GetAttribute("name")
 			switch name.(type) {
 			case string:
@@ -191,6 +211,11 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 			return nil
 		},
 		ormcontract.EventUpdating: func(event ormcontract.Event) error {
+			eventImpl := event.(*Event)
+			if isSlice(eventImpl.dest) {
+				panic("dest is slice when updating")
+			}
+
 			name := event.GetAttribute("name")
 			switch name.(type) {
 			case string:
@@ -243,6 +268,11 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 			return nil
 		},
 		ormcontract.EventUpdated: func(event ormcontract.Event) error {
+			eventImpl := event.(*Event)
+			if isSlice(eventImpl.dest) {
+				panic("dest is slice when updated")
+			}
+
 			name := event.GetAttribute("name")
 			switch name.(type) {
 			case string:
@@ -267,6 +297,11 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 			return nil
 		},
 		ormcontract.EventDeleting: func(event ormcontract.Event) error {
+			eventImpl := event.(*Event)
+			if !hasID(eventImpl.dest) {
+				panic("dest has no id when deleting")
+			}
+
 			name := event.GetAttribute("name")
 			if name != nil && name.(string) == "event_deleting_name" {
 				return errors.New("deleting error")
@@ -275,6 +310,11 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 			return nil
 		},
 		ormcontract.EventDeleted: func(event ormcontract.Event) error {
+			eventImpl := event.(*Event)
+			if !hasID(eventImpl.dest) {
+				panic("dest has no id when deleted")
+			}
+
 			name := event.GetAttribute("name")
 			if name != nil && name.(string) == "event_deleted_name" {
 				return errors.New("deleted error")
@@ -283,6 +323,11 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 			return nil
 		},
 		ormcontract.EventForceDeleting: func(event ormcontract.Event) error {
+			eventImpl := event.(*Event)
+			if !hasID(eventImpl.dest) {
+				panic("dest has no id when force deleting")
+			}
+
 			name := event.GetAttribute("name")
 			if name != nil && name.(string) == "event_force_deleting_name" {
 				return errors.New("force deleting error")
@@ -291,6 +336,11 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 			return nil
 		},
 		ormcontract.EventForceDeleted: func(event ormcontract.Event) error {
+			eventImpl := event.(*Event)
+			if !hasID(eventImpl.dest) {
+				panic("dest has no id when force deleted")
+			}
+
 			name := event.GetAttribute("name")
 			if name != nil && name.(string) == "event_force_deleted_name" {
 				return errors.New("force deleted error")
@@ -299,6 +349,11 @@ func (u *User) DispatchesEvents() map[ormcontract.EventType]func(ormcontract.Eve
 			return nil
 		},
 		ormcontract.EventRetrieved: func(event ormcontract.Event) error {
+			eventImpl := event.(*Event)
+			if isSlice(eventImpl.dest) {
+				panic("dest is slice when retrieved")
+			}
+
 			name := event.GetAttribute("name")
 			if name != nil && name.(string) == "event_retrieved_name" {
 				event.SetAttribute("name", "event_retrieved_name1")

--- a/database/schema/schema_test.go
+++ b/database/schema/schema_test.go
@@ -2126,11 +2126,12 @@ func (s *SchemaSuite) TestIndexMethods() {
 				if index.Name == "goravel_indexes_id_name_index" {
 					s.ElementsMatch(index.Columns, []string{"id", "name"})
 					s.False(index.Primary)
-					if driver == database.DriverSqlite {
+					switch driver {
+					case database.DriverSqlite:
 						s.Empty(index.Type)
-					} else if driver == database.DriverSqlserver {
+					case database.DriverSqlserver:
 						s.Equal("nonclustered", index.Type)
-					} else {
+					default:
 						s.Equal("btree", index.Type)
 					}
 					s.False(index.Unique)
@@ -2138,11 +2139,12 @@ func (s *SchemaSuite) TestIndexMethods() {
 				if index.Name == "name_index" {
 					s.ElementsMatch(index.Columns, []string{"name"})
 					s.False(index.Primary)
-					if driver == database.DriverSqlite {
+					switch driver {
+					case database.DriverSqlite:
 						s.Empty(index.Type)
-					} else if driver == database.DriverSqlserver {
+					case database.DriverSqlserver:
 						s.Equal("nonclustered", index.Type)
-					} else {
+					default:
 						s.Equal("btree", index.Type)
 					}
 					s.False(index.Unique)

--- a/database/service_provider.go
+++ b/database/service_provider.go
@@ -86,16 +86,17 @@ func (r *ServiceProvider) registerCommands(app foundation.Application) {
 		var migrator contractsmigration.Migrator
 
 		driver := config.GetString("database.migrations.driver")
-		if driver == contractsmigration.MigratorDefault {
+		switch driver {
+		case contractsmigration.MigratorDefault:
 			migrator = migration.NewDefaultMigrator(artisan, schema, config.GetString("database.migrations.table"))
-		} else if driver == contractsmigration.MigratorSql {
+		case contractsmigration.MigratorSql:
 			var err error
 			migrator, err = migration.NewSqlMigrator(config)
 			if err != nil {
 				log.Error(errors.MigrationSqlMigratorInit.Args(err).SetModule(errors.ModuleMigration))
 				return
 			}
-		} else {
+		default:
 			log.Error(errors.MigrationUnsupportedDriver.Args(driver).SetModule(errors.ModuleMigration))
 			return
 		}

--- a/filesystem/local.go
+++ b/filesystem/local.go
@@ -192,7 +192,9 @@ func (r *Local) Put(file, content string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	if _, err = f.WriteString(content); err != nil {
 		return err

--- a/log/formatter/general.go
+++ b/log/formatter/general.go
@@ -51,7 +51,7 @@ func (general *General) Format(entry *logrus.Entry) ([]byte, error) {
 	}
 
 	timestamp := entry.Time.In(cstSh).Format("2006-01-02 15:04:05")
-	b.WriteString(fmt.Sprintf("[%s] %s.%s: %s\n", timestamp, general.config.GetString("app.env"), entry.Level, entry.Message))
+	fmt.Fprintf(b, "[%s] %s.%s: %s\n", timestamp, general.config.GetString("app.env"), entry.Level, entry.Message)
 	data := entry.Data
 	if len(data) > 0 {
 		formattedData, err := general.formatData(data)

--- a/log/utils.go
+++ b/log/utils.go
@@ -30,11 +30,12 @@ func getContextValues(ctx any, values map[any]any) {
 		reflectValue = reflect.NewAt(reflectValue.Type(), unsafe.Pointer(reflectValue.UnsafeAddr())).Elem()
 		reflectField := contextKeys.Field(i)
 
-		if reflectField.Name == "Context" {
+		switch reflectField.Name {
+		case "Context":
 			getContextValues(reflectValue.Interface(), values)
-		} else if reflectField.Name == "key" {
+		case "key":
 			value.Key = reflectValue.Interface()
-		} else if reflectField.Name == "val" {
+		case "val":
 			value.Val = reflectValue.Interface()
 		}
 	}

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -173,10 +173,10 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 				continue
 			}
 		}
-		switch {
-		case ct == "text/plain":
+		switch ct {
+		case "text/plain":
 			e.Text = p.body
-		case ct == "text/html":
+		case "text/html":
 			e.HTML = p.body
 		}
 	}
@@ -475,7 +475,7 @@ func (e *Email) Bytes() ([]byte, error) {
 				}
 
 				if isMixed || isAlternative {
-					relatedWriter.Close()
+					_ = relatedWriter.Close()
 				}
 			}
 		}
@@ -585,7 +585,9 @@ func (e *Email) SendWithTLS(addr string, a smtp.Auth, t *tls.Config) error {
 	if err != nil {
 		return err
 	}
-	defer c.Close()
+	defer func() {
+		_ = c.Close()
+	}()
 	if err = c.Hello("localhost"); err != nil {
 		return err
 	}
@@ -654,7 +656,9 @@ func (e *Email) SendWithStartTLS(addr string, a smtp.Auth, t *tls.Config) error 
 	if err != nil {
 		return err
 	}
-	defer c.Close()
+	defer func() {
+		_ = c.Close()
+	}()
 	if err = c.Hello("localhost"); err != nil {
 		return err
 	}

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -31,10 +31,10 @@ const (
 )
 
 // ErrMissingBoundary is returned when there is no boundary given for a multipart entity
-var ErrMissingBoundary = errors.New("No boundary found for multipart entity")
+var ErrMissingBoundary = errors.New("no boundary found for multipart entity")
 
 // ErrMissingContentType is returned when there is no "Content-Type" header for a MIME entity
-var ErrMissingContentType = errors.New("No Content-Type found for MIME entity")
+var ErrMissingContentType = errors.New("no Content-Type found for MIME entity")
 
 // Email is the type used for email messages
 type Email struct {
@@ -284,7 +284,9 @@ func (e *Email) AttachFile(filename string) (a *Attachment, err error) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	ct := mime.TypeByExtension(filepath.Ext(filename))
 	basename := filepath.Base(filename)
@@ -518,7 +520,7 @@ func (e *Email) Send(addr string, a smtp.Auth) error {
 	}
 	// Check to make sure there is at least one recipient and one "From" address
 	if e.From == "" || len(to) == 0 {
-		return errors.New("Must specify at least one From address and one To address")
+		return errors.New("must specify at least one from address and one to address")
 	}
 	sender, err := e.parseSender()
 	if err != nil {
@@ -565,7 +567,7 @@ func (e *Email) SendWithTLS(addr string, a smtp.Auth, t *tls.Config) error {
 	}
 	// Check to make sure there is at least one recipient and one "From" address
 	if e.From == "" || len(to) == 0 {
-		return errors.New("Must specify at least one From address and one To address")
+		return errors.New("must specify at least one from address and one to address")
 	}
 	sender, err := e.parseSender()
 	if err != nil {
@@ -639,7 +641,7 @@ func (e *Email) SendWithStartTLS(addr string, a smtp.Auth, t *tls.Config) error 
 	}
 	// Check to make sure there is at least one recipient and one "From" address
 	if e.From == "" || len(to) == 0 {
-		return errors.New("Must specify at least one From address and one To address")
+		return errors.New("must specify at least one from address and one to address")
 	}
 	sender, err := e.parseSender()
 	if err != nil {
@@ -763,10 +765,10 @@ func headerToBytes(buff io.Writer, header textproto.MIMEHeader) {
 			_, _ = io.WriteString(buff, field)
 			_, _ = io.WriteString(buff, ": ")
 			// Write the encoded header if needed
-			switch {
-			case field == "Content-Type" || field == "Content-Disposition":
+			switch field {
+			case "Content-Type", "Content-Disposition":
 				_, _ = buff.Write([]byte(subval))
-			case field == "From" || field == "To" || field == "Cc" || field == "Bcc":
+			case "From", "To", "Cc", "Bcc":
 				participants := strings.Split(subval, ",")
 				for i, v := range participants {
 					addr, err := mail.ParseAddress(v)

--- a/support/debug/dump_test.go
+++ b/support/debug/dump_test.go
@@ -13,8 +13,10 @@ func redirectStdout(fn func()) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(f.Name())
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+	}()
 
 	orig := os.Stdout
 	os.Stdout = f

--- a/support/docker/container_manager.go
+++ b/support/docker/container_manager.go
@@ -124,7 +124,9 @@ func (r *ContainerManager) add(containerType ContainerType, databaseDriver testi
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	content, err := json.NewJson().Marshal(containerTypeToDatabaseConfig)
 	if err != nil {
@@ -149,7 +151,9 @@ func (r *ContainerManager) all() (map[ContainerType]testing.DatabaseConfig, erro
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	content, err := io.ReadAll(f)
 	if err != nil {

--- a/support/docker/container_manager.go
+++ b/support/docker/container_manager.go
@@ -190,10 +190,7 @@ func (r *ContainerManager) databaseConfigToDatabaseDriver(containerType Containe
 }
 
 func (r *ContainerManager) lock() {
-	for {
-		if !file.Exists(r.lockFile) {
-			break
-		}
+	for file.Exists(r.lockFile) {
 		time.Sleep(1 * time.Second)
 	}
 	if err := file.Create(r.lockFile, ""); err != nil {

--- a/support/docker/docker.go
+++ b/support/docker/docker.go
@@ -17,7 +17,7 @@ const (
 	TestModelNormal
 
 	// Switch this value to control the test model.
-	TestModel = TestModelMinimum
+	TestModel = TestModelNormal
 )
 
 func Mysql() testing.DatabaseDriver {

--- a/support/docker/docker.go
+++ b/support/docker/docker.go
@@ -17,7 +17,7 @@ const (
 	TestModelNormal
 
 	// Switch this value to control the test model.
-	TestModel = TestModelNormal
+	TestModel = TestModelMinimum
 )
 
 func Mysql() testing.DatabaseDriver {

--- a/support/docker/utils.go
+++ b/support/docker/utils.go
@@ -24,7 +24,7 @@ func isPortUsing(port int) bool {
 
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if l != nil {
-		l.Close()
+		_ = l.Close()
 	}
 
 	return err != nil
@@ -51,7 +51,9 @@ func getValidPort() int {
 		if err != nil {
 			continue
 		}
-		defer l.Close()
+		defer func() {
+			_ = l.Close()
+		}()
 
 		return random
 	}

--- a/support/file/file.go
+++ b/support/file/file.go
@@ -37,7 +37,9 @@ func Create(file string, content string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	if _, err = f.WriteString(content); err != nil {
 		return err
@@ -112,7 +114,9 @@ func Size(file string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer fileInfo.Close()
+	defer func() {
+		_ = fileInfo.Close()
+	}()
 
 	fi, err := fileInfo.Stat()
 	if err != nil {

--- a/support/http/body.go
+++ b/support/http/body.go
@@ -148,7 +148,9 @@ func (r *BodyImpl) addFile(writer *multipart.Writer, fieldName, filePath string)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	part, err := writer.CreateFormFile(fieldName, filepath.Base(file.Name()))
 	if err != nil {

--- a/support/http/body_test.go
+++ b/support/http/body_test.go
@@ -74,10 +74,12 @@ func TestBuildFormBody(t *testing.T) {
 func TestBuildMultipartBody(t *testing.T) {
 	file, err := os.CreateTemp("", "example.txt")
 	assert.NoError(t, err)
-	defer os.Remove(file.Name())
+	defer func() {
+		_ = os.Remove(file.Name())
+	}()
 	_, err = file.WriteString("file content")
 	assert.NoError(t, err)
-	file.Close()
+	_ = file.Close()
 
 	body := NewBody().
 		SetField("name", "krishan").
@@ -106,7 +108,9 @@ func TestBuildMultipartBody(t *testing.T) {
 	assert.True(t, ok)
 	fileReader, err := fileHeaders[0].Open()
 	assert.NoError(t, err)
-	defer fileReader.Close()
+	defer func() {
+		_ = fileReader.Close()
+	}()
 	fileContent, err := io.ReadAll(fileReader)
 	assert.NoError(t, err)
 	assert.Equal(t, "file content", string(fileContent))

--- a/testing/file/file.go
+++ b/testing/file/file.go
@@ -24,7 +24,9 @@ func GetLineNum(file string) int {
 		}
 	}
 
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	return total
 }

--- a/testing/file/file_test.go
+++ b/testing/file/file_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestGetLineNum(t *testing.T) {
-	assert.Equal(t, 31, GetLineNum("file.go"))
+	assert.Equal(t, 33, GetLineNum("file.go"))
 }

--- a/testing/test_response.go
+++ b/testing/test_response.go
@@ -406,7 +406,9 @@ func (r *TestResponseImpl) getContent() (string, error) {
 		return r.content, nil
 	}
 
-	defer r.response.Body.Close()
+	defer func() {
+		_ = r.response.Body.Close()
+	}()
 
 	content, err := io.ReadAll(r.response.Body)
 	if err != nil {

--- a/validation/validator_test.go
+++ b/validation/validator_test.go
@@ -1079,7 +1079,9 @@ func buildRequest(t *testing.T) *http.Request {
 	logo, err := os.Open("../logo.png")
 	assert.Nil(t, err)
 
-	defer logo.Close()
+	defer func() {
+		_ = logo.Close()
+	}()
 	part1, err := writer.CreateFormFile("file", filepath.Base("../logo.png"))
 	assert.Nil(t, err)
 


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/738

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request refines how ORM lifecycle events are triggered in the GORM query logic, especially for batch operations involving slices and mass deletes. The core improvement is to prevent event hooks from being triggered when the destination is a slice (for create, update, save, retrieve events) or when deleting/force-deleting mass records without a specific ID. This ensures event handlers only run for single-record operations, improving correctness and preventing unintended side effects. The test suite has been expanded to cover these new behaviors, and the event handler code has been updated to panic if the new constraints are violated, aiding debugging.

**Event Handling Logic Improvements:**

* Updated `database/gorm/query.go` so that lifecycle event hooks (`creating`, `created`, `saving`, `saved`, `updating`, `updated`, `retrieved`) return early and do not trigger when the destination is a slice, preventing events from firing on batch operations. [[1]](diffhunk://#diff-6624e6c943a77210e64b35b68412fabeb3756e6ea0a265269355ccb4ad7a6caeR1359-R1370) [[2]](diffhunk://#diff-6624e6c943a77210e64b35b68412fabeb3756e6ea0a265269355ccb4ad7a6caeR1564-R1567) [[3]](diffhunk://#diff-6624e6c943a77210e64b35b68412fabeb3756e6ea0a265269355ccb4ad7a6caeR1576-R1587) [[4]](diffhunk://#diff-6624e6c943a77210e64b35b68412fabeb3756e6ea0a265269355ccb4ad7a6caeR1647-R1658)
* For delete-related events (`deleting`, `deleted`, `forceDeleting`, `forceDeleted`), hooks now only trigger if the destination has an ID, ensuring events are not fired for mass deletes.

**Helper Functions:**

* Added `isSlice` and `hasID` helper functions in `database/gorm/query.go` to support the new event logic, checking if a destination is a slice or has an ID.

**Test Coverage Enhancements:**

* Expanded the test suite in `database/gorm/query_test.go` to verify that events are not triggered for slice-based operations and mass deletes, including new test cases for create, save, retrieve, and delete scenarios. [[1]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR876-R902) [[2]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR1018-R1044) [[3]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR1166-R1192) [[4]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR1324-R1350) [[5]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR1637-R1640) [[6]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR1654-R1663) [[7]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR1498) [[8]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR1509-R1521) [[9]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR1532-R1544) [[10]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR1555-R1567) [[11]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR1578-R1587) [[12]](diffhunk://#diff-2b29ebbc65cf5bd0f8d321d710fe27145f7531188d18d7172860969d0e9c3c0cR1724-L1572)

**Event Handler Safety:**

* Updated `User.DispatchesEvents` in `database/gorm/test_models.go` to panic if event hooks are called with a slice destination or without an ID, enforcing the new contract and surfacing violations during testing. [[1]](diffhunk://#diff-df9b472c0883ab9c3085e188219adb0d8c12f0bd822e1a1f993f23dae6789945R48-R52) [[2]](diffhunk://#diff-df9b472c0883ab9c3085e188219adb0d8c12f0bd822e1a1f993f23dae6789945R90-R94) [[3]](diffhunk://#diff-df9b472c0883ab9c3085e188219adb0d8c12f0bd822e1a1f993f23dae6789945R125-R129) [[4]](diffhunk://#diff-df9b472c0883ab9c3085e188219adb0d8c12f0bd822e1a1f993f23dae6789945R172-R176) [[5]](diffhunk://#diff-df9b472c0883ab9c3085e188219adb0d8c12f0bd822e1a1f993f23dae6789945R214-R218) [[6]](diffhunk://#diff-df9b472c0883ab9c3085e188219adb0d8c12f0bd822e1a1f993f23dae6789945R271-R275) [[7]](diffhunk://#diff-df9b472c0883ab9c3085e188219adb0d8c12f0bd822e1a1f993f23dae6789945R300-R304) [[8]](diffhunk://#diff-df9b472c0883ab9c3085e188219adb0d8c12f0bd822e1a1f993f23dae6789945R313-R317) [[9]](diffhunk://#diff-df9b472c0883ab9c3085e188219adb0d8c12f0bd822e1a1f993f23dae6789945R326-R330) [[10]](diffhunk://#diff-df9b472c0883ab9c3085e188219adb0d8c12f0bd822e1a1f993f23dae6789945R339-R343) [[11]](diffhunk://#diff-df9b472c0883ab9c3085e188219adb0d8c12f0bd822e1a1f993f23dae6789945R352-R356)

These changes collectively make event triggering more robust and predictable, especially in batch operations and mass record modifications.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
