### PR TITLE
feat: refactor build command to support interactive and custom OS/arch selection

### DIFF
--- a/console/console/build_command.go
+++ b/console/console/build_command.go
@@ -3,11 +3,12 @@ package console
 import (
 	"fmt"
 	"os/exec"
-	"slices"
+	"runtime"
 
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/console/command"
+	supportconsole "github.com/goravel/framework/support/console"
 )
 
 type BuildCommand struct {
@@ -35,21 +36,25 @@ func (r *BuildCommand) Extend() command.Extend {
 	return command.Extend{
 		Flags: []command.Flag{
 			&command.StringFlag{
+				Name:    "arch",
+				Aliases: []string{"a"},
+				Usage:   "Target architecture",
+			},
+			&command.StringFlag{
 				Name:    "os",
 				Aliases: []string{"o"},
-				Value:   "",
 				Usage:   "Target os",
 			},
 			&command.BoolFlag{
-				Name:    "static",
-				Aliases: []string{"s"},
-				Value:   false,
-				Usage:   "Static compilation",
+				Name:               "static",
+				Aliases:            []string{"s"},
+				Value:              false,
+				Usage:              "Static compilation",
+				DisableDefaultText: true,
 			},
 			&command.StringFlag{
 				Name:    "name",
 				Aliases: []string{"n"},
-				Value:   "",
 				Usage:   "Output binary name",
 			},
 		},
@@ -72,53 +77,52 @@ func (r *BuildCommand) Handle(ctx console.Context) error {
 
 	os := ctx.Option("os")
 	if os == "" {
-		os, err = ctx.Choice("Select target os", []console.Choice{
+		if os, err = ctx.Choice("Select target os", []console.Choice{
 			{Key: "Linux", Value: "linux"},
 			{Key: "Windows", Value: "windows"},
 			{Key: "Darwin", Value: "darwin"},
-		})
-		if err != nil {
+		}, console.ChoiceOption{Default: runtime.GOOS}); err != nil {
 			ctx.Error(fmt.Sprintf("Select target os error: %v", err))
 			return nil
 		}
 	}
 
-	validOs := []string{"linux", "windows", "darwin"}
-	if !slices.Contains(validOs, os) {
-		ctx.Error(fmt.Sprintf("Invalid os '%s' specified. Allowed values are: %v", os, validOs))
+	arch := ctx.Option("arch")
+	if arch == "" {
+		if arch, err = ctx.Choice("Select target architecture", []console.Choice{
+			{Key: "amd64", Value: "amd64"},
+			{Key: "arm64", Value: "arm64"},
+		}, console.ChoiceOption{Default: runtime.GOARCH}); err != nil {
+			ctx.Error(fmt.Sprintf("Select target architecture error: %v", err))
+			return nil
+		}
+	}
+
+	if err = supportconsole.ExecuteCommand(ctx, generateCommand(ctx.Option("name"), os, arch, ctx.OptionBool("static")), "Building..."); err != nil {
+		ctx.Error(err.Error())
 		return nil
 	}
 
-	if err := ctx.Spinner("Building...", console.SpinnerOption{
-		Action: func() error {
-			return r.build(os, generateCommand(ctx.Option("name"), ctx.OptionBool("static")))
-		},
-	}); err != nil {
-		ctx.Error(fmt.Sprintf("Build error: %v", err))
-	} else {
-		ctx.Info("Built successfully.")
-	}
+	ctx.Info("Built successfully.")
 
 	return nil
 }
 
-func (r *BuildCommand) build(system string, command []string) error {
-	cmd := exec.Command(command[0], command[1:]...)
-	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0", "GOARCH=amd64", "GOOS="+system)
-	_, err := cmd.Output()
-	return err
-}
-
-func generateCommand(name string, static bool) []string {
-	commands := []string{"go", "build"}
+func generateCommand(name, os, arch string, static bool) *exec.Cmd {
+	args := []string{"build"}
 
 	if static {
-		commands = append(commands, "-ldflags", "-extldflags -static")
+		args = append(args, "-ldflags", "-extldflags -static")
 	}
 
 	if name != "" {
-		commands = append(commands, "-o", name)
+		args = append(args, "-o", name)
 	}
 
-	return append(commands, ".")
+	args = append(args, ".")
+
+	cmd := exec.Command("go", args...)
+	cmd.Env = append(cmd.Environ(), "CGO_ENABLED=0", "GOARCH="+arch, "GOOS="+os)
+
+	return cmd
 }

--- a/console/console/build_command.go
+++ b/console/console/build_command.go
@@ -39,6 +39,7 @@ func (r *BuildCommand) Extend() command.Extend {
 				Name:    "arch",
 				Aliases: []string{"a"},
 				Usage:   "Target architecture",
+				Value:   "amd64",
 			},
 			&command.StringFlag{
 				Name:    "os",
@@ -87,18 +88,7 @@ func (r *BuildCommand) Handle(ctx console.Context) error {
 		}
 	}
 
-	arch := ctx.Option("arch")
-	if arch == "" {
-		if arch, err = ctx.Choice("Select target architecture", []console.Choice{
-			{Key: "amd64", Value: "amd64"},
-			{Key: "arm64", Value: "arm64"},
-		}, console.ChoiceOption{Default: runtime.GOARCH}); err != nil {
-			ctx.Error(fmt.Sprintf("Select target architecture error: %v", err))
-			return nil
-		}
-	}
-
-	if err = supportconsole.ExecuteCommand(ctx, generateCommand(ctx.Option("name"), os, arch, ctx.OptionBool("static")), "Building..."); err != nil {
+	if err = supportconsole.ExecuteCommand(ctx, generateCommand(ctx.Option("name"), os, ctx.Option("arch"), ctx.OptionBool("static")), "Building..."); err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}

--- a/console/console/build_command_test.go
+++ b/console/console/build_command_test.go
@@ -67,19 +67,6 @@ func TestBuildCommand(t *testing.T) {
 			},
 		},
 		{
-			name: "Sad path - arch choice error",
-			setup: func() {
-				mockConfig.EXPECT().GetString("app.env").Return("local").Once()
-				mockContext.EXPECT().Option("os").Return("linux").Once()
-				mockContext.EXPECT().Option("arch").Return("").Once()
-				mockContext.EXPECT().Choice("Select target architecture", []console.Choice{
-					{Key: "amd64", Value: "amd64"},
-					{Key: "arm64", Value: "arm64"},
-				}, console.ChoiceOption{Default: runtime.GOARCH}).Return("", errors.New("error")).Once()
-				mockContext.EXPECT().Error("Select target architecture error: error").Once()
-			},
-		},
-		{
 			name: "Sad path - os/arch is invalid",
 			setup: func() {
 				mockConfig.EXPECT().GetString("app.env").Return("local").Once()

--- a/console/console/build_command_test.go
+++ b/console/console/build_command_test.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"errors"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,9 @@ func TestBuildCommand(t *testing.T) {
 			setup: func() {
 				mockConfig.EXPECT().GetString("app.env").Return("local").Once()
 				mockContext.EXPECT().Option("os").Return("linux").Once()
+				mockContext.EXPECT().Option("arch").Return("amd64").Once()
+				mockContext.EXPECT().Option("name").Return("").Once()
+				mockContext.EXPECT().OptionBool("static").Return(true).Once()
 				mockContext.EXPECT().Spinner("Building...", mock.Anything).Return(nil).Once()
 				mockContext.EXPECT().Info("Built successfully.").Once()
 			},
@@ -58,16 +62,35 @@ func TestBuildCommand(t *testing.T) {
 					{Key: "Linux", Value: "linux"},
 					{Key: "Windows", Value: "windows"},
 					{Key: "Darwin", Value: "darwin"},
-				}).Return("", errors.New("error")).Once()
+				}, console.ChoiceOption{Default: runtime.GOOS}).Return("", errors.New("error")).Once()
 				mockContext.EXPECT().Error("Select target os error: error").Once()
 			},
 		},
 		{
-			name: "Sad path - os is invalid",
+			name: "Sad path - arch choice error",
+			setup: func() {
+				mockConfig.EXPECT().GetString("app.env").Return("local").Once()
+				mockContext.EXPECT().Option("os").Return("linux").Once()
+				mockContext.EXPECT().Option("arch").Return("").Once()
+				mockContext.EXPECT().Choice("Select target architecture", []console.Choice{
+					{Key: "amd64", Value: "amd64"},
+					{Key: "arm64", Value: "arm64"},
+				}, console.ChoiceOption{Default: runtime.GOARCH}).Return("", errors.New("error")).Once()
+				mockContext.EXPECT().Error("Select target architecture error: error").Once()
+			},
+		},
+		{
+			name: "Sad path - os/arch is invalid",
 			setup: func() {
 				mockConfig.EXPECT().GetString("app.env").Return("local").Once()
 				mockContext.EXPECT().Option("os").Return("invalid").Once()
-				mockContext.EXPECT().Error("Invalid os 'invalid' specified. Allowed values are: [linux windows darwin]").Once()
+				mockContext.EXPECT().Option("arch").Return("invalid").Once()
+				mockContext.EXPECT().Option("name").Return("").Once()
+				mockContext.EXPECT().OptionBool("static").Return(true).Once()
+				mockContext.EXPECT().Spinner("Building...", mock.Anything).RunAndReturn(func(_ string, option console.SpinnerOption) error {
+					return option.Action()
+				}).Once()
+				mockContext.EXPECT().Error("go: unsupported GOOS/GOARCH pair invalid/invalid").Once()
 			},
 		},
 		{
@@ -75,8 +98,11 @@ func TestBuildCommand(t *testing.T) {
 			setup: func() {
 				mockConfig.EXPECT().GetString("app.env").Return("local").Once()
 				mockContext.EXPECT().Option("os").Return("linux").Once()
+				mockContext.EXPECT().Option("arch").Return("amd64").Once()
+				mockContext.EXPECT().Option("name").Return("").Once()
+				mockContext.EXPECT().OptionBool("static").Return(true).Once()
 				mockContext.EXPECT().Spinner("Building...", mock.Anything).Return(errors.New("error")).Once()
-				mockContext.EXPECT().Error("Build error: error").Once()
+				mockContext.EXPECT().Error("error").Once()
 			},
 		},
 	}
@@ -108,7 +134,6 @@ func TestGenerateCommand(t *testing.T) {
 		},
 		{
 			description: "Generate command with static without name",
-			name:        "",
 			static:      true,
 			expected:    []string{"go", "build", "-ldflags", "-extldflags -static", "."},
 		},
@@ -120,7 +145,6 @@ func TestGenerateCommand(t *testing.T) {
 		},
 		{
 			description: "Generate command without static and name",
-			name:        "",
 			static:      false,
 			expected:    []string{"go", "build", "."},
 		},
@@ -128,9 +152,9 @@ func TestGenerateCommand(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			result := generateCommand(test.name, test.static)
+			result := generateCommand(test.name, runtime.GOOS, runtime.GOARCH, test.static)
 
-			assert.Equal(t, test.expected, result)
+			assert.Equal(t, test.expected, result.Args)
 		})
 	}
 }


### PR DESCRIPTION
## 📑 Description

This update refactors the build command to provide an interactive selection for OS and architecture, limited to commonly used options for convenience. However, users can still specify any OS and architecture supported by Go via command-line arguments. The validation of os and arch values is now delegated to the Go compiler, ensuring flexibility while simplifying the command logic. This makes the build process user-friendly for most cases, while retaining full compatibility with all platforms supported by Go.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
