### PR TITLE
fix: [#762] handle panic when using transaction

### DIFF
--- a/database/db/db.go
+++ b/database/db/db.go
@@ -98,10 +98,9 @@ func (r *DB) Transaction(callback func(tx contractsdb.Tx) error) (err error) {
 
 	defer func() {
 		if re := recover(); re != nil {
+			err = fmt.Errorf("panic: %v", re)
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				err = rollbackErr
-			} else {
-				err = fmt.Errorf("panic: %v", re)
+				err = errors.Join(err, rollbackErr)
 			}
 		}
 	}()

--- a/database/orm/orm.go
+++ b/database/orm/orm.go
@@ -3,6 +3,7 @@ package orm
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -151,10 +152,9 @@ func (r *Orm) Transaction(txFunc func(tx contractsorm.Query) error) (err error) 
 
 	defer func() {
 		if re := recover(); re != nil {
+			err = fmt.Errorf("panic: %v", re)
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				err = rollbackErr
-			} else {
-				err = fmt.Errorf("panic: %v", re)
+				err = errors.Join(err, rollbackErr)
 			}
 		}
 	}()

--- a/database/orm/orm.go
+++ b/database/orm/orm.go
@@ -3,6 +3,7 @@ package orm
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"sync"
 
 	"github.com/goravel/framework/contracts/binding"
@@ -142,11 +143,21 @@ func (r *Orm) Fresh() {
 	r.fresh(binding.Orm)
 }
 
-func (r *Orm) Transaction(txFunc func(tx contractsorm.Query) error) error {
+func (r *Orm) Transaction(txFunc func(tx contractsorm.Query) error) (err error) {
 	tx, err := r.Query().Begin()
 	if err != nil {
 		return err
 	}
+
+	defer func() {
+		if re := recover(); re != nil {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				err = rollbackErr
+			} else {
+				err = fmt.Errorf("panic: %v", re)
+			}
+		}
+	}()
 
 	if err := txFunc(tx); err != nil {
 		if err := tx.Rollback(); err != nil {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -65,3 +65,7 @@ func Unwrap(err error) error {
 func Ignore(fn func() error) {
 	_ = fn()
 }
+
+func Join(errs ...error) error {
+	return errors.Join(errs...)
+}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/dave/dst v0.27.3
 	github.com/dromara/carbon/v2 v2.6.11
 	github.com/gabriel-vasile/mimetype v1.4.9
-	github.com/go-viper/mapstructure/v2 v2.3.0
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/goforj/godump v1.5.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -634,8 +634,8 @@ github.com/go-sql-driver/mysql v1.9.0 h1:Y0zIbQXhQKmQgTp44Y1dp3wTXcn804QoTptLZT1
 github.com/go-sql-driver/mysql v1.9.0/go.mod h1:pDetrLJeA3oMujJuvXc8RJoasr589B6A9fwzD3QMrqw=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
-github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
-github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=

--- a/support/constant.go
+++ b/support/constant.go
@@ -1,7 +1,7 @@
 package support
 
 const (
-	Version = "v1.16.1"
+	Version = "v1.16.2"
 
 	RuntimeArtisan = "artisan"
 	RuntimeTest    = "test"


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/762

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request improves the transaction handling logic in both the database and ORM layers to ensure that panics within transaction callbacks are safely caught and handled. Now, if a panic occurs during a transaction, the transaction will be rolled back and an error will be returned, preventing partial writes and improving reliability. The change is validated by new and updated tests for both layers.

**Transaction error handling improvements:**

* Updated `Transaction` methods in `database/db/db.go` and `database/orm/orm.go` to catch panics, rollback the transaction, and return a formatted error if a panic occurs. [[1]](diffhunk://#diff-116badc4071402f3e8ccbe2cbbc17c2954ad60d78fdf7e4bb0887a5b4ee3bf33L93-R109) [[2]](diffhunk://#diff-d28ed4142ca25a217a478930ffeb0d157af0ee79f6612cec1636e55d339fa505L145-R161)
* Added `fmt` import statements to support error formatting in transaction error handling. [[1]](diffhunk://#diff-d28ed4142ca25a217a478930ffeb0d157af0ee79f6612cec1636e55d339fa505R6) [[2]](diffhunk://#diff-0f947c1cc37c4d76f6cc055536b2b37f53143066eb32a698c1e912067f7eef5eR8) [[3]](diffhunk://#diff-c42b0424071d220071601d88e30d3a9d9555448fa8df936e7c47e7db8064e174R6)

**Testing enhancements:**

* Added new test cases in `tests/db_test.go` and `tests/orm_test.go` to verify that panics in transaction callbacks result in rollbacks and return the expected error. [[1]](diffhunk://#diff-0f947c1cc37c4d76f6cc055536b2b37f53143066eb32a698c1e912067f7eef5eR1123-R1138) [[2]](diffhunk://#diff-c42b0424071d220071601d88e30d3a9d9555448fa8df936e7c47e7db8064e174R173-R192)

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
