### PR TITLE
fix: [#762] handle panic when using transaction

### DIFF
--- a/support/constant.go
+++ b/support/constant.go
@@ -1,6 +1,6 @@
 package support
 
-const Version string = "v1.15.11"
+const Version string = "v1.15.12"
 
 const (
 	EnvRuntime = "runtime"


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/762

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request improves the reliability of transaction handling in the ORM package by ensuring that panics within transactions are properly caught and handled, preventing partial data writes and making error reporting more robust. Additionally, a new test is added to verify this behavior, and the package version is incremented.

**Transaction reliability improvements:**

* Updated the `Transaction` method in `orm.go` to catch panics, roll back the transaction, and return a formatted error, ensuring that panics do not leave the database in an inconsistent state.
* Imported the `errors` package in `orm.go` to support error joining for rollback failures during panic handling.

**Testing enhancements:**

* Added `TestTransactionPanic` in `orm_test.go` to verify that panics during a transaction are handled correctly, the transaction is rolled back, and no data is written.
* Imported the `fmt` package in `orm_test.go` to support formatted error comparisons in tests.

**Version update:**

* Bumped the package version in `support/constant.go` from `v1.15.11` to `v1.15.12` to reflect these improvements.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
