### PR TITLE
fix: [#768] facades.DB will panic when migrating a new column

### DIFF
--- a/database/db/builder.go
+++ b/database/db/builder.go
@@ -27,6 +27,10 @@ func NewBuilder(gormDB *gorm.DB, driver string) (*Builder, error) {
 	}
 
 	dbx := sqlx.NewDb(db, driver)
+
+	// When running a migration to add or remove columns, sqlx will panic if the struct has or no fields that do not map to the database columns.
+	// So we need to enable Unsafe mode to avoid this error.
+	dbx = dbx.Unsafe()
 	dbx.MapperFunc(NameMapper)
 
 	return &Builder{

--- a/database/db/builder.go
+++ b/database/db/builder.go
@@ -28,7 +28,7 @@ func NewBuilder(gormDB *gorm.DB, driver string) (*Builder, error) {
 
 	dbx := sqlx.NewDb(db, driver)
 
-	// When running a migration to add or remove columns, sqlx will panic if the struct has or no fields that do not map to the database columns.
+	// When running a migration to add columns, sqlx will panic if the struct has no fields that do not map to the database columns.
 	// So we need to enable Unsafe mode to avoid this error.
 	dbx = dbx.Unsafe()
 	dbx.MapperFunc(NameMapper)

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/dromara/carbon/v2 v2.6.11 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
-	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/gookit/color v1.5.4 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -63,8 +63,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
-github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
-github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/768

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request introduces a new test case to verify database behavior when inserting and retrieving records with missing columns, and updates a dependency version in the test suite.

**Testing enhancements:**

* Added `TestInsert_First_Get_With_Missing_Columns` to `db_test.go` to ensure that inserting and retrieving a struct missing the `height` column works as expected, verifying correct handling of absent fields during database operations.

**Dependency updates:**

* Updated `github.com/go-viper/mapstructure/v2` from version `v2.3.0` to `v2.4.0` in `tests/go.mod` to bring in the latest improvements and fixes.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
