### PR TITLE
feat: [#770] Add a SelectRaw function for the ORM

### DIFF
--- a/contracts/database/orm/orm.go
+++ b/contracts/database/orm/orm.go
@@ -162,6 +162,8 @@ type Query interface {
 	Scopes(funcs ...func(Query) Query) Query
 	// Select specifies fields that should be retrieved from the database.
 	Select(columns ...string) Query
+	// SelectRaw specifies a raw SQL query for selecting fields.
+	SelectRaw(query any, args ...any) Query
 	// SharedLock locks the selected rows in the table.
 	SharedLock() Query
 	// Sum calculates the sum of a column's values and populates the destination object.

--- a/database/gorm/conditions.go
+++ b/database/gorm/conditions.go
@@ -18,6 +18,7 @@ type Conditions struct {
 	order         []any
 	scopes        []func(contractsorm.Query) contractsorm.Query
 	selectColumns []string
+	selectRaw     *Select
 	where         []contractsdriver.Where
 	with          []With
 	distinct      bool
@@ -25,6 +26,11 @@ type Conditions struct {
 	sharedLock    bool
 	withoutEvents bool
 	withTrashed   bool
+}
+
+type Select struct {
+	query any
+	args  []any
 }
 
 type Table struct {

--- a/mocks/database/orm/Query.go
+++ b/mocks/database/orm/Query.go
@@ -3183,6 +3183,65 @@ func (_c *Query_Select_Call) RunAndReturn(run func(...string) orm.Query) *Query_
 	return _c
 }
 
+// SelectRaw provides a mock function with given fields: query, args
+func (_m *Query) SelectRaw(query interface{}, args ...interface{}) orm.Query {
+	var _ca []interface{}
+	_ca = append(_ca, query)
+	_ca = append(_ca, args...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SelectRaw")
+	}
+
+	var r0 orm.Query
+	if rf, ok := ret.Get(0).(func(interface{}, ...interface{}) orm.Query); ok {
+		r0 = rf(query, args...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(orm.Query)
+		}
+	}
+
+	return r0
+}
+
+// Query_SelectRaw_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SelectRaw'
+type Query_SelectRaw_Call struct {
+	*mock.Call
+}
+
+// SelectRaw is a helper method to define mock.On call
+//   - query interface{}
+//   - args ...interface{}
+func (_e *Query_Expecter) SelectRaw(query interface{}, args ...interface{}) *Query_SelectRaw_Call {
+	return &Query_SelectRaw_Call{Call: _e.mock.On("SelectRaw",
+		append([]interface{}{query}, args...)...)}
+}
+
+func (_c *Query_SelectRaw_Call) Run(run func(query interface{}, args ...interface{})) *Query_SelectRaw_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]interface{}, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(interface{})
+			}
+		}
+		run(args[0].(interface{}), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Query_SelectRaw_Call) Return(_a0 orm.Query) *Query_SelectRaw_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Query_SelectRaw_Call) RunAndReturn(run func(interface{}, ...interface{}) orm.Query) *Query_SelectRaw_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SharedLock provides a mock function with no fields
 func (_m *Query) SharedLock() orm.Query {
 	ret := _m.Called()

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/dromara/carbon/v2 v2.6.11 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
-	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/gookit/color v1.5.4 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -63,8 +63,8 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
-github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
-github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/770

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request adds support for raw SQL selection in the ORM query interface, allowing more flexible and complex queries. The main changes include introducing a new `SelectRaw` method to the query interface and its implementation, updating the internal conditions structure to support raw selects, and adding corresponding tests and mocks.

**Raw SQL selection support:**
* Added `SelectRaw` method to the `Query` interface in `orm.go`, enabling users to specify raw SQL queries for field selection.
* Implemented the `SelectRaw` method in `query.go`, updated the `Conditions` struct to include the new `selectRaw` field, and added the `Select` struct to hold the query and its arguments. [[1]](diffhunk://#diff-593fc8c604e317bb29693277734166d37aa3cf9027e09a66ecabfae6b2220e0bR21) [[2]](diffhunk://#diff-593fc8c604e317bb29693277734166d37aa3cf9027e09a66ecabfae6b2220e0bR31-R35) [[3]](diffhunk://#diff-6624e6c943a77210e64b35b68412fabeb3756e6ea0a265269355ccb4ad7a6caeR782-R791)
* Modified the `buildSelectColumns` function to handle both regular column selection and raw SQL selection, ensuring only one selection mode is active per query.

**Testing and mocking:**
* Added a new test case `TestSelectRaw` in `query_test.go` to verify the functionality of raw SQL selection with various inputs.
* Updated the ORM query mocks in `Query.go` to support the new `SelectRaw` method, including helper and expectation methods for testing.

**Dependency update:**
* Updated the `github.com/go-viper/mapstructure/v2` dependency from v2.3.0 to v2.4.0 in `tests/go.mod`.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
