### PR TITLE
feat: [#881] add imports alias support in package setup

### DIFF
--- a/packages/modify/utils.go
+++ b/packages/modify/utils.go
@@ -436,7 +436,7 @@ func WrapNewline[T dst.Node](node T) T {
 }
 
 // addImportsToFile adds the specified import to the file, creating the import block if needed.
-func addImportsToFile(appFilePath, pkg string) error {
+func addImportsToFile(filePath, pkg string) error {
 	importMatchers := match.Imports()
 
 	if alias, importPath, found := strings.Cut(pkg, " "); found {

--- a/packages/modify/utils.go
+++ b/packages/modify/utils.go
@@ -495,7 +495,7 @@ func isTopName(n dst.Expr, name string) bool {
 }
 
 // removeImportsFromFile removes the specified import from the file.
-func removeImportsFromFile(appFilePath, pkg string) error {
+func removeImportsFromFile(filePath, pkg string) error {
 	importMatchers := match.Imports()
 
 	if alias, importPath, found := strings.Cut(pkg, " "); found {

--- a/packages/modify/utils.go
+++ b/packages/modify/utils.go
@@ -440,10 +440,10 @@ func addImportsToFile(filePath, pkg string) error {
 	importMatchers := match.Imports()
 
 	if alias, importPath, found := strings.Cut(pkg, " "); found {
-		return GoFile(appFilePath).FindOrCreate(importMatchers, createImport).Modify(AddImport(importPath, alias)).Apply()
+		return GoFile(filePath).FindOrCreate(importMatchers, createImport).Modify(AddImport(importPath, alias)).Apply()
 	}
 
-	return GoFile(appFilePath).FindOrCreate(importMatchers, createImport).Modify(AddImport(pkg)).Apply()
+	return GoFile(filePath).FindOrCreate(importMatchers, createImport).Modify(AddImport(pkg)).Apply()
 }
 
 // isThirdParty determines if an import path refers to a third-party package.
@@ -499,8 +499,8 @@ func removeImportsFromFile(filePath, pkg string) error {
 	importMatchers := match.Imports()
 
 	if alias, importPath, found := strings.Cut(pkg, " "); found {
-		return GoFile(appFilePath).Find(importMatchers).Modify(RemoveImport(importPath, alias)).Apply()
+		return GoFile(filePath).Find(importMatchers).Modify(RemoveImport(importPath, alias)).Apply()
 	}
 
-	return GoFile(appFilePath).Find(importMatchers).Modify(RemoveImport(pkg)).Apply()
+	return GoFile(filePath).Find(importMatchers).Modify(RemoveImport(pkg)).Apply()
 }

--- a/packages/modify/utils.go
+++ b/packages/modify/utils.go
@@ -121,7 +121,7 @@ func AddProvider(pkg, provider string) error {
 func AddRoute(pkg, route string) error {
 	appFilePath := path.Bootstrap("app.go")
 
-	if err := addRouteImports(appFilePath, pkg); err != nil {
+	if err := addImportsToFile(appFilePath, pkg); err != nil {
 		return err
 	}
 
@@ -388,7 +388,11 @@ func RemoveProvider(pkg, provider string) error {
 func RemoveRoute(pkg, route string) error {
 	appFilePath := path.Bootstrap("app.go")
 
-	return GoFile(appFilePath).Find(match.FoundationSetup()).Modify(removeRouteFromSetup(route)).Find(match.Imports()).Modify(RemoveImport(pkg)).Apply()
+	if err := GoFile(appFilePath).Find(match.FoundationSetup()).Modify(removeRouteFromSetup(route)).Apply(); err != nil {
+		return err
+	}
+
+	return removeImportsFromFile(appFilePath, pkg)
 }
 
 // WrapNewline adds newline decorations to specific AST nodes for better formatting.
@@ -429,6 +433,17 @@ func WrapNewline[T dst.Node](node T) T {
 	})
 
 	return node
+}
+
+// addImportsToFile adds the specified import to the file, creating the import block if needed.
+func addImportsToFile(appFilePath, pkg string) error {
+	importMatchers := match.Imports()
+
+	if alias, importPath, found := strings.Cut(pkg, " "); found {
+		return GoFile(appFilePath).FindOrCreate(importMatchers, createImport).Modify(AddImport(importPath, alias)).Apply()
+	}
+
+	return GoFile(appFilePath).FindOrCreate(importMatchers, createImport).Modify(AddImport(pkg)).Apply()
 }
 
 // isThirdParty determines if an import path refers to a third-party package.
@@ -477,4 +492,15 @@ func isThirdParty(importPath string) bool {
 func isTopName(n dst.Expr, name string) bool {
 	id, ok := n.(*dst.Ident)
 	return ok && id.Name == name && id.Obj == nil
+}
+
+// removeImportsFromFile removes the specified import from the file.
+func removeImportsFromFile(appFilePath, pkg string) error {
+	importMatchers := match.Imports()
+
+	if alias, importPath, found := strings.Cut(pkg, " "); found {
+		return GoFile(appFilePath).Find(importMatchers).Modify(RemoveImport(importPath, alias)).Apply()
+	}
+
+	return GoFile(appFilePath).Find(importMatchers).Modify(RemoveImport(pkg)).Apply()
 }

--- a/packages/modify/utils_test.go
+++ b/packages/modify/utils_test.go
@@ -7,11 +7,11 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/dave/dst"
+	"github.com/dave/dst/decorator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dave/dst"
-	"github.com/dave/dst/decorator"
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support"
 	supportfile "github.com/goravel/framework/support/file"
@@ -1839,6 +1839,49 @@ func Providers() []foundation.ServiceProvider {
 `,
 		},
 		{
+			name: "add provider from different package with alias",
+			appContent: `package bootstrap
+
+import (
+	contractsfoundation "github.com/goravel/framework/contracts/foundation"
+	"github.com/goravel/framework/foundation"
+	"goravel/config"
+)
+
+func Boot() contractsfoundation.Application {
+	return foundation.Setup().WithConfig(config.Boot).Start()
+}
+`,
+			pkg:      "r github.com/goravel/redis",
+			provider: "&r.ServiceProvider{}",
+			expectedApp: `package bootstrap
+
+import (
+	contractsfoundation "github.com/goravel/framework/contracts/foundation"
+	"github.com/goravel/framework/foundation"
+	"goravel/config"
+)
+
+func Boot() contractsfoundation.Application {
+	return foundation.Setup().
+		WithProviders(Providers).WithConfig(config.Boot).Start()
+}
+`,
+			expectedProviders: `package bootstrap
+
+import (
+	"github.com/goravel/framework/contracts/foundation"
+	r "github.com/goravel/redis"
+)
+
+func Providers() []foundation.ServiceProvider {
+	return []foundation.ServiceProvider{
+		&r.ServiceProvider{},
+	}
+}
+`,
+		},
+		{
 			name: "add multiple providers sequentially",
 			appContent: `package bootstrap
 
@@ -3251,6 +3294,67 @@ func Providers() []foundation.ServiceProvider {
 `,
 			pkg:      "github.com/goravel/redis",
 			provider: "&redis.ServiceProvider{}",
+			expectedApp: `package bootstrap
+
+import (
+	contractsfoundation "github.com/goravel/framework/contracts/foundation"
+	"github.com/goravel/framework/foundation"
+	"goravel/config"
+)
+
+func Boot() contractsfoundation.Application {
+	return foundation.Setup().
+		WithProviders(Providers).WithConfig(config.Boot).Start()
+}
+`,
+			expectedProviders: `package bootstrap
+
+import (
+	"github.com/goravel/framework/contracts/foundation"
+
+	"goravel/app/providers"
+)
+
+func Providers() []foundation.ServiceProvider {
+	return []foundation.ServiceProvider{
+		&providers.AppServiceProvider{},
+	}
+}
+`,
+		},
+		{
+			name: "remove provider from different package with alias",
+			appContent: `package bootstrap
+
+import (
+	contractsfoundation "github.com/goravel/framework/contracts/foundation"
+	"github.com/goravel/framework/foundation"
+	"goravel/config"
+)
+
+func Boot() contractsfoundation.Application {
+	return foundation.Setup().
+		WithProviders(Providers).WithConfig(config.Boot).Start()
+}
+`,
+			providersContent: `package bootstrap
+
+import (
+	"github.com/goravel/framework/contracts/foundation"
+	r "github.com/goravel/redis"
+
+	"goravel/app/providers"
+)
+
+func Providers() []foundation.ServiceProvider {
+	return []foundation.ServiceProvider{
+		&providers.AppServiceProvider{},
+		&r.ServiceProvider{},
+	}
+}
+`,
+			pkg:      "r github.com/goravel/redis",
+			provider: "&r.ServiceProvider{}",
 			expectedApp: `package bootstrap
 
 import (

--- a/packages/modify/with_slice_actions.go
+++ b/packages/modify/with_slice_actions.go
@@ -277,14 +277,13 @@ func (r *withSliceHandler) createFile() error {
 //	    "github.com/goravel/framework/contracts/console"
 //	)
 func (r *withSliceHandler) addImports(pkg string) error {
-	importMatchers := match.Imports()
-	if err := GoFile(r.appFilePath).FindOrCreate(importMatchers, createImport).Modify(AddImport(pkg)).Apply(); err != nil {
+	if err := addImportsToFile(r.appFilePath, pkg); err != nil {
 		return err
 	}
 
 	// Skip adding type import for function slices (like routing)
 	if r.config.typeImportPath != "" {
-		return GoFile(r.appFilePath).Find(importMatchers).Modify(AddImport(r.config.typeImportPath)).Apply()
+		return addImportsToFile(r.appFilePath, r.config.typeImportPath)
 	}
 
 	return nil
@@ -311,8 +310,7 @@ func (r *withSliceHandler) addImports(pkg string) error {
 //	}
 func (r *withSliceHandler) addItemToFile(pkg, item string) error {
 	// Add the item package import
-	importMatchers := match.Imports()
-	if err := GoFile(r.filePath).FindOrCreate(importMatchers, createImport).Modify(AddImport(pkg)).Apply(); err != nil {
+	if err := addImportsToFile(r.filePath, pkg); err != nil {
 		return err
 	}
 
@@ -323,8 +321,7 @@ func (r *withSliceHandler) addItemToFile(pkg, item string) error {
 // removeImports removes the item package import if it's no longer used.
 // It checks both app.go and the helper file (if it exists) to determine if the import is still in use.
 func (r *withSliceHandler) removeImports(pkg string) error {
-	importMatchers := match.Imports()
-	return GoFile(r.appFilePath).Find(importMatchers).Modify(RemoveImport(pkg)).Apply()
+	return removeImportsFromFile(r.appFilePath, pkg)
 }
 
 // removeItemFromFile removes an item from the existing helper function in the file.
@@ -358,8 +355,7 @@ func (r *withSliceHandler) removeItemFromFile(pkg, item string) error {
 	}
 
 	// Clean up the import if it's no longer used
-	importMatchers := match.Imports()
-	return GoFile(r.filePath).Find(importMatchers).Modify(RemoveImport(pkg)).Apply()
+	return removeImportsFromFile(r.filePath, pkg)
 }
 
 // appendToExisting appends an item to an existing WithMethod call.
@@ -859,13 +855,12 @@ func addMiddlewareAppendCall(funcLit *dst.FuncLit, middlewareArg dst.Expr) {
 
 // addMiddlewareImports adds the required imports for middleware and configuration packages.
 func addMiddlewareImports(appFilePath, pkg string) error {
-	importMatchers := match.Imports()
-	if err := GoFile(appFilePath).FindOrCreate(importMatchers, createImport).Modify(AddImport(pkg)).Apply(); err != nil {
+	if err := addImportsToFile(appFilePath, pkg); err != nil {
 		return err
 	}
 
 	configImportPath := "github.com/goravel/framework/contracts/foundation/configuration"
-	return GoFile(appFilePath).Find(importMatchers).Modify(AddImport(configImportPath)).Apply()
+	return addImportsToFile(appFilePath, configImportPath)
 }
 
 // appendToExistingMiddleware appends middleware to an existing WithMiddleware call.
@@ -1084,12 +1079,6 @@ func foundationSetupMiddleware(middleware string) modify.Action {
 			createWithMiddleware(setupCall, parentOfSetup, middlewareExpr)
 		}
 	}
-}
-
-// addRouteImports adds the required imports for the route package.
-func addRouteImports(appFilePath, pkg string) error {
-	importMatchers := match.Imports()
-	return GoFile(appFilePath).FindOrCreate(importMatchers, createImport).Modify(AddImport(pkg)).Apply()
 }
 
 // foundationSetupRouting returns an action that modifies the foundation.Setup() chain to add or update WithRouting.

--- a/packages/modify/with_slice_actions.go
+++ b/packages/modify/with_slice_actions.go
@@ -319,7 +319,6 @@ func (r *withSliceHandler) addItemToFile(pkg, item string) error {
 }
 
 // removeImports removes the item package import if it's no longer used.
-// It checks both app.go and the helper file (if it exists) to determine if the import is still in use.
 func (r *withSliceHandler) removeImports(pkg string) error {
 	return removeImportsFromFile(r.appFilePath, pkg)
 }


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/881

Add support for import aliases when registering packages through the setup helpers. This allows developers to use custom package names with long import paths, improving code readability and reducing verbosity.

When registering service providers or other packages with long import paths, developers often had to use either:
- The full package name multiple times in code
- Or manually manage imports with aliases


### Example

```go
func main() {
    setup := packages.Setup(os.Args)
    serviceProvider := "&admin.ServiceProvider{}"
    moduleImport := setup.Paths().Module().Import() // e.g., github.com/some/goravel-admin
    configPath := path.Config("goravel_admin.go")

    setup.Install(
        // ✨ Register the service provider with 'admin' alias
        modify.RegisterProvider("admin "+moduleImport, serviceProvider),
        
        // Add config
        modify.File(configPath).Overwrite(config(...)),
    ).Uninstall(
        modify.File(configPath).Remove(),
        modify.UnregisterProvider("admin "+moduleImport, serviceProvider),
    ).Execute()
}
```

After installation, `bootstrap/providers.go` will contain aliased import and provider usage, for example:

```go
import (
    // ...
    admin "github.com/some/goravel-admin"
    // ...
)

func Providers() []foundation.ServiceProvider {
    return []foundation.ServiceProvider{
        // ...
        &admin.ServiceProvider{},
        // ...
    }
}
```

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

@coderabbitai summary

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
