### PR TITLE
chore: add GitHub Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,20 @@
+# GitHub Copilot Instructions
+
+This file provides rules for GitHub Copilot when reviewing pull requests in `goravel/framework`.
+
+## Go Code Style
+
+- Use `any` instead of `interface{}`.
+- Do not shadow the built-in `error` package or common variable names (`err`, `ctx`, etc.).
+- Import order: standard library → third-party → internal (`github.com/goravel/framework/...`), separated by blank lines.
+
+## Error Handling
+
+- All sentinel errors must be declared in `errors/list.go` using `errors.New(...)`. Do not create ad-hoc `fmt.Errorf` errors for domain errors.
+- Tag errors with a module via `.SetModule(errors.ModuleXxx)` when returning from a service provider or internal package.
+- Use `%s`/`%v` format verbs in error messages and supply args via `.Args(...)` — never interpolate directly into the `New` string.
+- Do not swallow errors silently; log or propagate them.
+
+## Testing
+
+See [.agents/prompts/tests.md](../.agents/prompts/tests.md) for the full testing guidelines.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,14 +5,14 @@ This file provides rules for GitHub Copilot when reviewing pull requests in `gor
 ## Go Code Style
 
 - Use `any` instead of `interface{}`.
-- Do not shadow the built-in `error` package or common variable names (`err`, `ctx`, etc.).
+- Do not shadow the built-in `error` type, the standard-library `errors` package, or common variable names (`err`, `ctx`, etc.).
 - Import order: standard library → third-party → internal (`github.com/goravel/framework/...`), separated by blank lines.
 
 ## Error Handling
 
-- All sentinel errors must be declared in `errors/list.go` using `errors.New(...)`. Do not create ad-hoc `fmt.Errorf` errors for domain errors.
+- All sentinel errors must be declared in `errors/list.go` using the framework error constructor: `github.com/goravel/framework/errors.New(...)` (or unqualified `New(...)` when inside `package errors`). Do not create ad-hoc `fmt.Errorf` errors for domain errors.
 - Tag errors with a module via `.SetModule(errors.ModuleXxx)` when returning from a service provider or internal package.
-- Use `%s`/`%v` format verbs in error messages and supply args via `.Args(...)` — never interpolate directly into the `New` string.
+- Use format verbs in error messages and supply dynamic parts via `.Args(...)` — never interpolate directly into the `New` string.
 - Do not swallow errors silently; log or propagate them.
 
 ## Testing


### PR DESCRIPTION
## Summary
- Add `.github/copilot-instructions.md` with Go code style, error handling, and testing rules for GitHub Copilot
- Enforce consistent import ordering, use of `any` over `interface{}`, and sentinel error declaration patterns
- Point to `.agents/prompts/tests.md` for the full testing guidelines

## Why
The repository had no structured file to guide GitHub Copilot when reviewing or generating code for `goravel/framework`. Without it, Copilot suggestions could diverge from the project's established conventions around error handling, code style, and testing.

Adding `.github/copilot-instructions.md` documents the key rules in one place — Go style (use `any`, import order, no variable shadowing), error handling (sentinel errors in `errors/list.go`, module tagging, no silent swallowing), and a pointer to the full testing guide — so that Copilot's review feedback and code suggestions stay consistent with project standards.
