### PR TITLE
ci: add workflow to test in goravel/example

### DIFF
--- a/.github/workflows/test_example.yml
+++ b/.github/workflows/test_example.yml
@@ -1,0 +1,68 @@
+name: Test In Example
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_ACCESS_KEY_SECRET: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
+  AWS_URL: ${{ secrets.AWS_URL }}
+  ALIYUN_ACCESS_KEY_ID: ${{ secrets.ALIYUN_ACCESS_KEY_ID }}
+  ALIYUN_ACCESS_KEY_SECRET: ${{ secrets.ALIYUN_ACCESS_KEY_SECRET }}
+  ALIYUN_BUCKET: ${{ secrets.ALIYUN_BUCKET }}
+  ALIYUN_URL: ${{ secrets.ALIYUN_URL }}
+  ALIYUN_ENDPOINT: ${{ secrets.ALIYUN_ENDPOINT }}
+  TENCENT_ACCESS_KEY_ID: ${{ secrets.TENCENT_ACCESS_KEY_ID }}
+  TENCENT_ACCESS_KEY_SECRET: ${{ secrets.TENCENT_ACCESS_KEY_SECRET }}
+  TENCENT_URL: ${{ secrets.TENCENT_URL }}
+  MINIO_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY_ID }}
+  MINIO_ACCESS_KEY_SECRET: ${{ secrets.MINIO_ACCESS_KEY_SECRET }}
+  MINIO_BUCKET: ${{ secrets.MINIO_BUCKET }}
+
+jobs:
+  test-in-example:
+    strategy:
+      matrix:
+        go: [ "1.25", "1.26" ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout framework
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: framework
+
+      - name: Checkout goravel/example
+        uses: actions/checkout@v6
+        with:
+          repository: goravel/example
+          path: example
+
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Go mod cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('example/**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Replace framework with local checkout
+        working-directory: example
+        run: |
+          go mod edit -replace github.com/goravel/framework=../framework
+          go mod tidy
+
+      - name: Run tests
+        working-directory: example
+        run: go test -timeout 10m -p 1 ./...

--- a/.github/workflows/test_example.yml
+++ b/.github/workflows/test_example.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 
 permissions:
+  actions: write
   contents: read
 
 env:

--- a/.github/workflows/test_example.yml
+++ b/.github/workflows/test_example.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: goravel/example
+          ref: master
           path: example
 
       - name: Set up Go ${{ matrix.go }}
@@ -56,9 +57,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('example/**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('example/**/go.sum', 'framework/**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go-${{ matrix.go }}-
 
       - name: Replace framework with local checkout
         working-directory: example

--- a/.github/workflows/test_example.yml
+++ b/.github/workflows/test_example.yml
@@ -9,24 +9,6 @@ permissions:
   actions: write
   contents: read
 
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_ACCESS_KEY_SECRET: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
-  AWS_REGION: ${{ secrets.AWS_REGION }}
-  AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
-  AWS_URL: ${{ secrets.AWS_URL }}
-  ALIYUN_ACCESS_KEY_ID: ${{ secrets.ALIYUN_ACCESS_KEY_ID }}
-  ALIYUN_ACCESS_KEY_SECRET: ${{ secrets.ALIYUN_ACCESS_KEY_SECRET }}
-  ALIYUN_BUCKET: ${{ secrets.ALIYUN_BUCKET }}
-  ALIYUN_URL: ${{ secrets.ALIYUN_URL }}
-  ALIYUN_ENDPOINT: ${{ secrets.ALIYUN_ENDPOINT }}
-  TENCENT_ACCESS_KEY_ID: ${{ secrets.TENCENT_ACCESS_KEY_ID }}
-  TENCENT_ACCESS_KEY_SECRET: ${{ secrets.TENCENT_ACCESS_KEY_SECRET }}
-  TENCENT_URL: ${{ secrets.TENCENT_URL }}
-  MINIO_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY_ID }}
-  MINIO_ACCESS_KEY_SECRET: ${{ secrets.MINIO_ACCESS_KEY_SECRET }}
-  MINIO_BUCKET: ${{ secrets.MINIO_BUCKET }}
-
 jobs:
   test-in-example:
     strategy:

--- a/.github/workflows/test_example.yml
+++ b/.github/workflows/test_example.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_ACCESS_KEY_SECRET: ${{ secrets.AWS_ACCESS_KEY_SECRET }}

--- a/.github/workflows/test_example.yml
+++ b/.github/workflows/test_example.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout framework
         uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           path: framework
 

--- a/.github/workflows/test_example.yml
+++ b/.github/workflows/test_example.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
 
 permissions:
-  actions: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary
- Add a new CI workflow that checks out `goravel/example` alongside the framework and runs its full test suite
- Replace the example's framework dependency with the local checkout so pull requests are validated end-to-end
- Run the tests against multiple Go versions in a matrix

## Why
The framework currently has no automated check that verifies changes don't break the companion `goravel/example` application. Breakage is only discovered after a PR is merged, requiring a separate fix cycle.

This workflow triggers on every push to `master` and on every pull request. It checks out both `goravel/framework` and `goravel/example`, rewires the example's `go.mod` to point at the local framework tree, and executes `go test ./...` inside the example. This gives maintainers confidence that in-flight framework changes stay compatible with the canonical application scaffold.

```yaml
# .github/workflows/test_example.yml
- name: Replace framework with local checkout
  working-directory: example
  run: |
    go mod edit -replace github.com/goravel/framework=../framework
    go mod tidy

- name: Run tests
  working-directory: example
  run: go test -timeout 10m -p 1 ./...
```
