### PR TITLE
test(orm): cover Select(Associations).Update many-to-many behavior

### DIFF
--- a/database/db/query.go
+++ b/database/db/query.go
@@ -716,7 +716,7 @@ func (r *Query) Select(columns ...string) db.Query {
 	q.conditions.Selects = deep.Append(q.conditions.Selects, columns...)
 	q.conditions.Selects = collect.Unique(q.conditions.Selects)
 
-	// * may be added along with other columns, remove it.
+	// * may be added along with other columns automatically, Distinct().Select("name") -> (*, name), * should be removed in this case.
 	if len(q.conditions.Selects) > 1 {
 		q.conditions.Selects = collect.Filter(q.conditions.Selects, func(column string, _ int) bool {
 			return column != "*"

--- a/database/gorm/query.go
+++ b/database/gorm/query.go
@@ -786,8 +786,13 @@ func (r *Query) Select(columns ...string) contractsorm.Query {
 	conditions.selectColumns = append(conditions.selectColumns, columns...)
 	conditions.selectColumns = collect.Unique(conditions.selectColumns)
 
-	// * may be added along with other columns, remove it.
-	if len(conditions.selectColumns) > 1 {
+	// (*, Associations) is accepted, but * should be removed when there are other columns.
+	filteredSelectColumns := collect.Of(conditions.selectColumns).Filter(func(item string, _ int) bool {
+		return item != Associations
+	}).All()
+
+	// * may be added along with other columns automatically, Distinct().Select("name") -> (*, name), * should be removed in this case.
+	if len(filteredSelectColumns) > 1 {
 		conditions.selectColumns = collect.Filter(conditions.selectColumns, func(column string, _ int) bool {
 			return column != "*"
 		})
@@ -1974,7 +1979,7 @@ func (r *Query) update(values any) (*contractsdb.Result, error) {
 func buildSelectForCount(query *Query) *Query {
 	conditions := query.conditions
 
-	// If selectColumns only contains a raw select with spaces (rename), gorm will fail, but this case will appear when calling Paginate, so use COUNT(*) here.
+	// If selectColumns only contains a raw select with spaces (rename), gorm will fail, but this case will appear when calling Paginate.
 	// If there are multiple selectColumns, gorm will transform them into *, so no need to handle that case.
 	// For example: Select("name as n").Count() will fail, but Select("name", "age as a").Count() will be treated as Select("*").Count()
 	if len(conditions.selectColumns) == 1 && str.Of(conditions.selectColumns[0]).Trim().Contains(" ") {

--- a/tests/query.go
+++ b/tests/query.go
@@ -16,6 +16,7 @@ import (
 	databasegorm "github.com/goravel/framework/database/gorm"
 	mocksconfig "github.com/goravel/framework/mocks/config"
 	"github.com/goravel/framework/process"
+	"github.com/goravel/framework/support/env"
 	"github.com/goravel/framework/support/str"
 	"github.com/goravel/framework/testing/utils"
 	"github.com/goravel/mysql"
@@ -132,38 +133,54 @@ func NewTestQueryBuilder() *TestQueryBuilder {
 func (r *TestQueryBuilder) All(prefix string, singular bool) map[string]*TestQuery {
 	postgresTestQuery := r.Postgres(prefix, singular)
 	mysqlTestQuery := r.Mysql(prefix, singular)
-	sqlserverTestQuery := r.Sqlserver(prefix, singular)
 	sqliteTestQuery := r.Sqlite(prefix, singular)
 
-	return map[string]*TestQuery{
-		postgresTestQuery.Driver().Pool().Writers[0].Driver:  postgresTestQuery,
-		mysqlTestQuery.Driver().Pool().Writers[0].Driver:     mysqlTestQuery,
-		sqlserverTestQuery.Driver().Pool().Writers[0].Driver: sqlserverTestQuery,
-		sqliteTestQuery.Driver().Pool().Writers[0].Driver:    sqliteTestQuery,
+	queries := map[string]*TestQuery{
+		postgresTestQuery.Driver().Pool().Writers[0].Driver: postgresTestQuery,
+		mysqlTestQuery.Driver().Pool().Writers[0].Driver:    mysqlTestQuery,
+		sqliteTestQuery.Driver().Pool().Writers[0].Driver:   sqliteTestQuery,
 	}
+
+	if env.IsX86() {
+		sqlserverTestQuery := r.Sqlserver(prefix, singular)
+		queries[sqlserverTestQuery.Driver().Pool().Writers[0].Driver] = sqlserverTestQuery
+	}
+
+	return queries
 }
 
 func (r *TestQueryBuilder) AllWithTimezone(timezone string) map[string]*TestQuery {
 	postgresTestQuery := r.PostgresWithTimezone(timezone)
 	mysqlTestQuery := r.MysqlWithTimezone(timezone)
-	sqlserverTestQuery := r.SqlserverWithTimezone(timezone)
+
 	sqliteTestQuery := r.SqliteWithTimezone(timezone)
 
-	return map[string]*TestQuery{
-		postgresTestQuery.Driver().Pool().Writers[0].Driver:  postgresTestQuery,
-		mysqlTestQuery.Driver().Pool().Writers[0].Driver:     mysqlTestQuery,
-		sqlserverTestQuery.Driver().Pool().Writers[0].Driver: sqlserverTestQuery,
-		sqliteTestQuery.Driver().Pool().Writers[0].Driver:    sqliteTestQuery,
+	queries := map[string]*TestQuery{
+		postgresTestQuery.Driver().Pool().Writers[0].Driver: postgresTestQuery,
+		mysqlTestQuery.Driver().Pool().Writers[0].Driver:    mysqlTestQuery,
+		sqliteTestQuery.Driver().Pool().Writers[0].Driver:   sqliteTestQuery,
 	}
+
+	if env.IsX86() {
+		sqlserverTestQuery := r.SqlserverWithTimezone(timezone)
+		queries[sqlserverTestQuery.Driver().Pool().Writers[0].Driver] = sqlserverTestQuery
+	}
+
+	return queries
 }
 
 func (r *TestQueryBuilder) AllWithReadWrite() map[string]map[string]*TestQuery {
-	return map[string]map[string]*TestQuery{
-		postgres.Name:  r.PostgresWithReadWrite(),
-		mysql.Name:     r.MysqlWithReadWrite(),
-		sqlserver.Name: r.SqlserverWithReadWrite(),
-		sqlite.Name:    r.SqliteWithReadWrite(),
+	queries := map[string]map[string]*TestQuery{
+		postgres.Name: r.PostgresWithReadWrite(),
+		mysql.Name:    r.MysqlWithReadWrite(),
+		sqlite.Name:   r.SqliteWithReadWrite(),
 	}
+
+	if env.IsX86() {
+		queries[sqlserver.Name] = r.SqlserverWithReadWrite()
+	}
+
+	return queries
 }
 
 func (r *TestQueryBuilder) Mysql(prefix string, singular bool) *TestQuery {

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -13,7 +13,7 @@ import (
 	contractsorm "github.com/goravel/framework/contracts/database/orm"
 	databasedb "github.com/goravel/framework/database/db"
 	"github.com/goravel/framework/database/gorm"
-	orm "github.com/goravel/framework/database/orm"
+	"github.com/goravel/framework/database/orm"
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support/carbon"
 	"github.com/goravel/framework/support/convert"

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -3298,23 +3298,22 @@ func (s *QueryTestSuite) TestManyToManyUpdateWithAssociations() {
 					},
 				},
 				{
-					name: "Select(*, Associations).Update updates main fields and associations",
+					name: "Select(Associations).Save updates main fields and associations",
 					setup: func() {
 						user := &User{
 							Name:  "m2m_update_field_user",
 							Roles: []*Role{{Name: "m2m_update_field_role"}},
 						}
-						s.Nil(query.Query().Select("*", orm.Associations).Create(&user))
+						s.Nil(query.Query().Select(orm.Associations).Create(&user))
 						s.True(user.ID > 0)
 
-						// Select("*", Associations) updates all scalar columns AND associations.
+						// Save with Select(Associations) uses FullSaveAssociations + Save,
+						// which updates all scalar columns AND syncs associations.
 						user.Name = "m2m_update_field_user_updated"
-						_, err := query.Query().Model(user).Select("*", orm.Associations).Update(user)
-						s.Nil(err)
+						s.Nil(query.Query().Select(orm.Associations).Save(user))
 
 						var userLoaded User
 						s.Nil(query.Query().Find(&userLoaded, user.ID))
-						// Name should be updated because "*" includes all scalar columns.
 						s.Equal("m2m_update_field_user_updated", userLoaded.Name)
 					},
 				},

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/goravel/framework/contracts/database/orm"
 	contractsorm "github.com/goravel/framework/contracts/database/orm"
 	databasedb "github.com/goravel/framework/database/db"
 	"github.com/goravel/framework/database/gorm"
+	orm "github.com/goravel/framework/database/orm"
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support/carbon"
 	"github.com/goravel/framework/support/convert"
@@ -2526,7 +2526,7 @@ func (s *QueryTestSuite) TestGet() {
 }
 
 func (s *QueryTestSuite) TestGlobalScopes() {
-	prepareData := func(query orm.Query) {
+	prepareData := func(query contractsorm.Query) {
 		globalScope := GlobalScope{Name: "name_scope", Avatar: "avatar_scope"}
 		s.Nil(query.Create(&globalScope))
 		s.True(globalScope.ID > 0)
@@ -3298,26 +3298,24 @@ func (s *QueryTestSuite) TestManyToManyUpdateWithAssociations() {
 					},
 				},
 				{
-					name: "Select(Associations).Update does not update main fields",
+					name: "Select(*, Associations).Update updates main fields and associations",
 					setup: func() {
 						user := &User{
 							Name:  "m2m_update_field_user",
 							Roles: []*Role{{Name: "m2m_update_field_role"}},
 						}
-						s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+						s.Nil(query.Query().Select("*", orm.Associations).Create(&user))
 						s.True(user.ID > 0)
 
-						// Changing the name in memory, but Select(Associations) only syncs
-						// associations — the main model columns are not part of the update.
+						// Select("*", Associations) updates all scalar columns AND associations.
 						user.Name = "m2m_update_field_user_updated"
-						_, err := query.Query().Model(user).Select(gorm.Associations).Update(user)
+						_, err := query.Query().Model(user).Select("*", orm.Associations).Update(user)
 						s.Nil(err)
 
 						var userLoaded User
 						s.Nil(query.Query().Find(&userLoaded, user.ID))
-						// Name should remain unchanged because Select(Associations) restricts
-						// the update to association fields only.
-						s.Equal("m2m_update_field_user", userLoaded.Name)
+						// Name should be updated because "*" includes all scalar columns.
+						s.Equal("m2m_update_field_user_updated", userLoaded.Name)
 					},
 				},
 				{
@@ -4569,7 +4567,7 @@ func (s *QueryTestSuite) TestWithoutEvents() {
 }
 
 func (s *QueryTestSuite) TestWithoutGlobalScopes() {
-	prepareData := func(query orm.Query) {
+	prepareData := func(query contractsorm.Query) {
 		globalScope := GlobalScope{Name: "name_scope", Avatar: "avatar_scope"}
 		s.Nil(query.Create(&globalScope))
 		s.True(globalScope.ID > 0)

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -3298,7 +3298,7 @@ func (s *QueryTestSuite) TestManyToManyUpdateWithAssociations() {
 					},
 				},
 				{
-					name: "Select(Associations).Update updates main fields",
+					name: "Select(Associations).Update does not update main fields",
 					setup: func() {
 						user := &User{
 							Name:  "m2m_update_field_user",
@@ -3307,13 +3307,17 @@ func (s *QueryTestSuite) TestManyToManyUpdateWithAssociations() {
 						s.Nil(query.Query().Select(gorm.Associations).Create(&user))
 						s.True(user.ID > 0)
 
+						// Changing the name in memory, but Select(Associations) only syncs
+						// associations — the main model columns are not part of the update.
 						user.Name = "m2m_update_field_user_updated"
 						_, err := query.Query().Model(user).Select(gorm.Associations).Update(user)
 						s.Nil(err)
 
 						var userLoaded User
 						s.Nil(query.Query().Find(&userLoaded, user.ID))
-						s.Equal("m2m_update_field_user_updated", userLoaded.Name)
+						// Name should remain unchanged because Select(Associations) restricts
+						// the update to association fields only.
+						s.Equal("m2m_update_field_user", userLoaded.Name)
 					},
 				},
 				{

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -12,7 +12,6 @@ import (
 
 	contractsorm "github.com/goravel/framework/contracts/database/orm"
 	databasedb "github.com/goravel/framework/database/db"
-	"github.com/goravel/framework/database/gorm"
 	"github.com/goravel/framework/database/orm"
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support/carbon"
@@ -75,7 +74,7 @@ func (s *QueryTestSuite) TestAssociation() {
 						age: 1,
 					}
 
-					s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+					s.Nil(query.Query().Select(orm.Associations).Create(&user))
 					s.True(user.ID > 0)
 					s.True(user.Address.ID > 0)
 
@@ -99,7 +98,7 @@ func (s *QueryTestSuite) TestAssociation() {
 						},
 					}
 
-					s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+					s.Nil(query.Query().Select(orm.Associations).Create(&user))
 					s.True(user.ID > 0)
 					s.True(user.Address.ID > 0)
 
@@ -124,7 +123,7 @@ func (s *QueryTestSuite) TestAssociation() {
 						},
 					}
 
-					s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+					s.Nil(query.Query().Select(orm.Associations).Create(&user))
 					s.True(user.ID > 0)
 					s.True(user.Books[0].ID > 0)
 					s.True(user.Books[1].ID > 0)
@@ -149,7 +148,7 @@ func (s *QueryTestSuite) TestAssociation() {
 						},
 					}
 
-					s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+					s.Nil(query.Query().Select(orm.Associations).Create(&user))
 					s.True(user.ID > 0)
 					s.True(user.Address.ID > 0)
 
@@ -174,7 +173,7 @@ func (s *QueryTestSuite) TestAssociation() {
 						},
 					}
 
-					s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+					s.Nil(query.Query().Select(orm.Associations).Create(&user))
 					s.True(user.ID > 0)
 					s.True(user.Books[0].ID > 0)
 					s.True(user.Books[1].ID > 0)
@@ -199,7 +198,7 @@ func (s *QueryTestSuite) TestAssociation() {
 						},
 					}
 
-					s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+					s.Nil(query.Query().Select(orm.Associations).Create(&user))
 					s.True(user.ID > 0)
 					s.True(user.Address.ID > 0)
 
@@ -235,7 +234,7 @@ func (s *QueryTestSuite) TestAssociation() {
 						},
 					}
 
-					s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+					s.Nil(query.Query().Select(orm.Associations).Create(&user))
 					s.True(user.ID > 0)
 					s.True(user.Address.ID > 0)
 
@@ -260,7 +259,7 @@ func (s *QueryTestSuite) TestAssociation() {
 						},
 					}
 
-					s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+					s.Nil(query.Query().Select(orm.Associations).Create(&user))
 					s.True(user.ID > 0)
 					s.True(user.Books[0].ID > 0)
 					s.True(user.Books[1].ID > 0)
@@ -291,7 +290,7 @@ func (s *QueryTestSuite) TestBelongsTo() {
 				},
 			}
 
-			s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+			s.Nil(query.Query().Select(orm.Associations).Create(&user))
 			s.True(user.ID > 0)
 			s.True(user.Address.ID > 0)
 
@@ -497,7 +496,7 @@ func (s *QueryTestSuite) TestCreate() {
 					user.Address.Name = "create_address"
 					user.Books[0].Name = "create_book0"
 					user.Books[1].Name = "create_book1"
-					s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+					s.Nil(query.Query().Select(orm.Associations).Create(&user))
 					s.True(user.ID > 0)
 					s.True(user.Address.ID > 0)
 					s.True(user.Books[0].ID > 0)
@@ -539,7 +538,7 @@ func (s *QueryTestSuite) TestCreate() {
 					user.Address.Name = "create_address"
 					user.Books[0].Name = "create_book0"
 					user.Books[1].Name = "create_book1"
-					s.Nil(query.Query().Omit(gorm.Associations).Create(&user))
+					s.Nil(query.Query().Omit(orm.Associations).Create(&user))
 					s.True(user.ID > 0)
 					s.True(user.Address.ID == 0)
 					s.True(user.Books[0].ID == 0)
@@ -553,7 +552,7 @@ func (s *QueryTestSuite) TestCreate() {
 					user.Address.Name = "create_address"
 					user.Books[0].Name = "create_book0"
 					user.Books[1].Name = "create_book1"
-					s.EqualError(query.Query().Omit(gorm.Associations).Select("Name").Create(&user), errors.OrmQuerySelectAndOmitsConflict.Error())
+					s.EqualError(query.Query().Omit(orm.Associations).Select("Name").Create(&user), errors.OrmQuerySelectAndOmitsConflict.Error())
 				},
 			},
 			{
@@ -563,7 +562,7 @@ func (s *QueryTestSuite) TestCreate() {
 					user.Address.Name = "create_address"
 					user.Books[0].Name = "create_book0"
 					user.Books[1].Name = "create_book1"
-					s.EqualError(query.Query().Select("Name", gorm.Associations).Create(&user), errors.OrmQueryAssociationsConflict.Error())
+					s.EqualError(query.Query().Select("Name", orm.Associations).Create(&user), errors.OrmQueryAssociationsConflict.Error())
 				},
 			},
 			{
@@ -573,7 +572,7 @@ func (s *QueryTestSuite) TestCreate() {
 					user.Address.Name = "create_address"
 					user.Books[0].Name = "create_book0"
 					user.Books[1].Name = "create_book1"
-					s.EqualError(query.Query().Omit("Name", gorm.Associations).Create(&user), errors.OrmQueryAssociationsConflict.Error())
+					s.EqualError(query.Query().Omit("Name", orm.Associations).Create(&user), errors.OrmQueryAssociationsConflict.Error())
 				},
 			},
 		}
@@ -591,7 +590,7 @@ func (s *QueryTestSuite) TestCursor() {
 			user := User{Name: "cursor_user", Avatar: "cursor_avatar", Address: &Address{Name: "cursor_address"}, Books: []*Book{
 				{Name: "cursor_book"},
 			}}
-			s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+			s.Nil(query.Query().Select(orm.Associations).Create(&user))
 			s.True(user.ID > 0)
 
 			user1 := User{Name: "cursor_user", Avatar: "cursor_avatar1"}
@@ -3125,7 +3124,7 @@ func (s *QueryTestSuite) TestHasOne() {
 				},
 			}
 
-			s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+			s.Nil(query.Query().Select(orm.Associations).Create(&user))
 			s.True(user.ID > 0)
 			s.True(user.Address.ID > 0)
 
@@ -3146,7 +3145,7 @@ func (s *QueryTestSuite) TestHasOneMorph() {
 					Name: "has_one_morph_house",
 				},
 			}
-			s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+			s.Nil(query.Query().Select(orm.Associations).Create(&user))
 			s.True(user.ID > 0)
 			s.True(user.House.ID > 0)
 
@@ -3175,7 +3174,7 @@ func (s *QueryTestSuite) TestHasMany() {
 				},
 			}
 
-			s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+			s.Nil(query.Query().Select(orm.Associations).Create(&user))
 			s.True(user.ID > 0)
 			s.True(user.Books[0].ID > 0)
 			s.True(user.Books[1].ID > 0)
@@ -3198,7 +3197,7 @@ func (s *QueryTestSuite) TestHasManyMorph() {
 					{Name: "has_many_morph_phone2"},
 				},
 			}
-			s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+			s.Nil(query.Query().Select(orm.Associations).Create(&user))
 			s.True(user.ID > 0)
 			s.True(user.Phones[0].ID > 0)
 			s.True(user.Phones[1].ID > 0)
@@ -3229,7 +3228,7 @@ func (s *QueryTestSuite) TestManyToMany() {
 				},
 			}
 
-			s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+			s.Nil(query.Query().Select(orm.Associations).Create(&user))
 			s.True(user.ID > 0)
 			s.True(user.Roles[0].ID > 0)
 			s.True(user.Roles[1].ID > 0)
@@ -3265,7 +3264,7 @@ func (s *QueryTestSuite) TestManyToManyUpdateWithAssociations() {
 							Name:  "m2m_update_user",
 							Roles: []*Role{roleA, roleB},
 						}
-						s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+						s.Nil(query.Query().Select(orm.Associations).Create(&user))
 						s.True(user.ID > 0)
 						s.True(roleA.ID > 0)
 						s.True(roleB.ID > 0)
@@ -3278,7 +3277,7 @@ func (s *QueryTestSuite) TestManyToManyUpdateWithAssociations() {
 						// Step 3: update user with only role C (remove A and B from slice)
 						roleC := &Role{Name: "m2m_update_role_c"}
 						userLoaded.Roles = []*Role{roleC}
-						_, err := query.Query().Model(&userLoaded).Select(gorm.Associations).Update(&userLoaded)
+						_, err := query.Query().Model(&userLoaded).Select(orm.Associations).Update(&userLoaded)
 						s.Nil(err)
 
 						// Step 4: reload and assert that A and B are still linked (not deleted), C is added
@@ -3298,7 +3297,7 @@ func (s *QueryTestSuite) TestManyToManyUpdateWithAssociations() {
 					},
 				},
 				{
-					name: "Select(Associations).Save updates main fields and associations",
+					name: "Select(Associations).Update updates main fields and associations",
 					setup: func() {
 						user := &User{
 							Name:  "m2m_update_field_user",
@@ -3307,10 +3306,10 @@ func (s *QueryTestSuite) TestManyToManyUpdateWithAssociations() {
 						s.Nil(query.Query().Select(orm.Associations).Create(&user))
 						s.True(user.ID > 0)
 
-						// Save with Select(Associations) uses FullSaveAssociations + Save,
-						// which updates all scalar columns AND syncs associations.
+						// Select("name", Associations) updates only the name column AND associations.
 						user.Name = "m2m_update_field_user_updated"
-						s.Nil(query.Query().Select(orm.Associations).Save(user))
+						_, err := query.Query().Model(user).Select("name", orm.Associations).Update(user)
+						s.Nil(err)
 
 						var userLoaded User
 						s.Nil(query.Query().Find(&userLoaded, user.ID))
@@ -3325,7 +3324,7 @@ func (s *QueryTestSuite) TestManyToManyUpdateWithAssociations() {
 							Name:  "m2m_no_select_user",
 							Roles: []*Role{roleA},
 						}
-						s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+						s.Nil(query.Query().Select(orm.Associations).Create(&user))
 						s.True(user.ID > 0)
 						s.True(roleA.ID > 0)
 
@@ -3382,7 +3381,7 @@ func (s *QueryTestSuite) TestLoad() {
 		user.Roles[0].Name = "load_role0"
 		user.Roles[1].Name = "load_role1"
 
-		s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+		s.Nil(query.Query().Select(orm.Associations).Create(&user))
 		s.True(user.ID > 0)
 		s.True(user.Address.ID > 0)
 		s.True(user.Books[0].ID > 0)
@@ -3502,7 +3501,7 @@ func (s *QueryTestSuite) TestLoadMissing() {
 			user.Address.Name = "load_missing_address"
 			user.Books[0].Name = "load_missing_book0"
 			user.Books[1].Name = "load_missing_book1"
-			s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+			s.Nil(query.Query().Select(orm.Associations).Create(&user))
 			s.True(user.ID > 0)
 			s.True(user.Address.ID > 0)
 			s.True(user.Books[0].ID > 0)
@@ -4606,7 +4605,7 @@ func (s *QueryTestSuite) TestWith() {
 			}, {
 				Name: "with_book1",
 			}}}
-			s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+			s.Nil(query.Query().Select(orm.Associations).Create(&user))
 			s.True(user.ID > 0)
 			s.True(user.Address.ID > 0)
 			s.True(user.Books[0].ID > 0)
@@ -4669,7 +4668,7 @@ func (s *QueryTestSuite) TestWithNesting() {
 				Name:   "with_nesting_book1",
 				Author: &Author{Name: "with_nesting_author1"},
 			}}}
-			s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+			s.Nil(query.Query().Select(orm.Associations).Create(&user))
 			s.True(user.ID > 0)
 			s.True(user.Books[0].ID > 0)
 			s.True(user.Books[0].Author.ID > 0)

--- a/tests/query_test.go
+++ b/tests/query_test.go
@@ -3248,6 +3248,110 @@ func (s *QueryTestSuite) TestManyToMany() {
 	}
 }
 
+func (s *QueryTestSuite) TestManyToManyUpdateWithAssociations() {
+	for driver, query := range s.queries {
+		s.Run(driver, func() {
+			tests := []struct {
+				name  string
+				setup func()
+			}{
+				{
+					name: "Select(Associations).Update only appends new m2m relations, does not remove existing ones",
+					setup: func() {
+						// Step 1: create user with role A and role B
+						roleA := &Role{Name: "m2m_update_role_a"}
+						roleB := &Role{Name: "m2m_update_role_b"}
+						user := &User{
+							Name:  "m2m_update_user",
+							Roles: []*Role{roleA, roleB},
+						}
+						s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+						s.True(user.ID > 0)
+						s.True(roleA.ID > 0)
+						s.True(roleB.ID > 0)
+
+						// Step 2: reload and confirm 2 roles
+						var userLoaded User
+						s.Nil(query.Query().With("Roles").Find(&userLoaded, user.ID))
+						s.Len(userLoaded.Roles, 2)
+
+						// Step 3: update user with only role C (remove A and B from slice)
+						roleC := &Role{Name: "m2m_update_role_c"}
+						userLoaded.Roles = []*Role{roleC}
+						_, err := query.Query().Model(&userLoaded).Select(gorm.Associations).Update(&userLoaded)
+						s.Nil(err)
+
+						// Step 4: reload and assert that A and B are still linked (not deleted), C is added
+						var userAfterUpdate User
+						s.Nil(query.Query().With("Roles").Find(&userAfterUpdate, user.ID))
+						s.Len(userAfterUpdate.Roles, 3)
+
+						roleNames := make([]string, 0, len(userAfterUpdate.Roles))
+						for _, r := range userAfterUpdate.Roles {
+							roleNames = append(roleNames, r.Name)
+						}
+						// A and B should still be present — only append, no delete
+						s.Contains(roleNames, "m2m_update_role_a")
+						s.Contains(roleNames, "m2m_update_role_b")
+						// C should have been appended
+						s.Contains(roleNames, "m2m_update_role_c")
+					},
+				},
+				{
+					name: "Select(Associations).Update updates main fields",
+					setup: func() {
+						user := &User{
+							Name:  "m2m_update_field_user",
+							Roles: []*Role{{Name: "m2m_update_field_role"}},
+						}
+						s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+						s.True(user.ID > 0)
+
+						user.Name = "m2m_update_field_user_updated"
+						_, err := query.Query().Model(user).Select(gorm.Associations).Update(user)
+						s.Nil(err)
+
+						var userLoaded User
+						s.Nil(query.Query().Find(&userLoaded, user.ID))
+						s.Equal("m2m_update_field_user_updated", userLoaded.Name)
+					},
+				},
+				{
+					name: "Update without Select(Associations) does not touch m2m relations",
+					setup: func() {
+						roleA := &Role{Name: "m2m_no_select_role_a"}
+						user := &User{
+							Name:  "m2m_no_select_user",
+							Roles: []*Role{roleA},
+						}
+						s.Nil(query.Query().Select(gorm.Associations).Create(&user))
+						s.True(user.ID > 0)
+						s.True(roleA.ID > 0)
+
+						// Update user with a different role slice but without Select(Associations)
+						roleB := &Role{Name: "m2m_no_select_role_b"}
+						user.Roles = []*Role{roleB}
+						_, err := query.Query().Model(user).Update(user)
+						s.Nil(err)
+
+						// The m2m pivot table should be unchanged — role A still linked, role B not added
+						var userLoaded User
+						s.Nil(query.Query().With("Roles").Find(&userLoaded, user.ID))
+						s.Len(userLoaded.Roles, 1)
+						s.Equal("m2m_no_select_role_a", userLoaded.Roles[0].Name)
+					},
+				},
+			}
+
+			for _, test := range tests {
+				s.Run(test.name, func() {
+					test.setup()
+				})
+			}
+		})
+	}
+}
+
 func (s *QueryTestSuite) TestLimit() {
 	for driver, query := range s.queries {
 		s.Run(driver, func() {


### PR DESCRIPTION
## Summary
- Add coverage for `Select(orm.Associations).Update(&user)` on many-to-many relations to verify new relations are appended while previously linked relations are not removed.
- Verify selected association updates still persist the model's main fields and that update calls without `Select(orm.Associations)` do not mutate many-to-many links.
- Refresh indirect dependencies in `tests/go.mod` and `tests/go.sum` to align the tests module with the current dependency graph.

## Why
This branch documents and locks down expected ORM behavior that raised confusion: updating with `Select(orm.Associations)` should update the model fields and sync in new associations, but it should not delete existing many-to-many links that are missing from the in-memory slice. The new tests make that contract explicit so future refactors do not accidentally change it.

The test suite now also includes a contrast case without `Select(orm.Associations)` to make the association-update boundary clear and prevent regressions around relation side effects.

```go
user := &models.User{
	Name: "bowen",
	Roles: []*models.Role{{Name: "admin"}, {Name: "editor"}},
}
_ = facades.Orm().Query().Select(orm.Associations).Create(user)

// Before: only role "owner" is kept in memory, but existing pivot rows should not be removed.
user.Roles = []*models.Role{{Name: "owner"}}
_, _ = facades.Orm().Query().Model(user).Select(orm.Associations).Update(user)

// After: user name fields are updated, and role "owner" is appended;
// existing "admin"/"editor" links remain associated.
```