### PR TITLE
chore: add solve-pr-comments agent skill

### DIFF
--- a/.agents/skills/solve-pr-comments/SKILL.md
+++ b/.agents/skills/solve-pr-comments/SKILL.md
@@ -103,7 +103,10 @@ when Y?", "Is this thread-safe?". These need an answer, not a code change.
        }
      }'
    ```
-   To get thread node IDs: `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --jq '.[].node_id'`
+   To get thread node IDs (type `PRRT_...`, not comment IDs):
+   ```bash
+   gh pr view {pr_number} --json reviewThreads --jq '.reviewThreads[].id'
+   ```
    Alternatively, resolve threads directly in the GitHub UI.
 
 6. **Push the updated branch** if any code changed:

--- a/.agents/skills/solve-pr-comments/SKILL.md
+++ b/.agents/skills/solve-pr-comments/SKILL.md
@@ -80,7 +80,7 @@ when Y?", "Is this thread-safe?". These need an answer, not a code change.
 
 1. **Fetch comments**
    ```bash
-   gh pr view --json comments,reviewThreads
+   gh pr view {pr_number} --json comments,reviewThreads
    # or for inline review comments:
    gh api repos/{owner}/{repo}/pulls/{pr_number}/comments
    ```

--- a/.agents/skills/solve-pr-comments/SKILL.md
+++ b/.agents/skills/solve-pr-comments/SKILL.md
@@ -93,11 +93,18 @@ when Y?", "Is this thread-safe?". These need an answer, not a code change.
 4. **Reply to every comment** — resolved or not. Leaving a comment without a
    reply signals that it was missed.
 
-5. **Mark threads resolved** after replying:
+5. **Mark threads resolved** after replying, using the GitHub GraphQL
+   `resolveReviewThread` mutation (requires the thread node ID):
    ```bash
-   gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
-     --method POST --field body="" --field event="COMMENT"
+   gh api graphql -f query='
+     mutation {
+       resolveReviewThread(input: {threadId: "<thread_node_id>"}) {
+         thread { isResolved }
+       }
+     }'
    ```
+   To get thread node IDs: `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --jq '.[].node_id'`
+   Alternatively, resolve threads directly in the GitHub UI.
 
 6. **Push the updated branch** if any code changed:
    ```bash

--- a/.agents/skills/solve-pr-comments/SKILL.md
+++ b/.agents/skills/solve-pr-comments/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: solve-pr-comments
+description: >
+  Workflow for addressing pull request review comments. Covers when to change
+  code, when to push back on incorrect feedback, and when to answer questions
+  without modifying code. Use this skill whenever the user asks to resolve,
+  address, or respond to PR review comments.
+---
+
+# Solve PR Comments
+
+A PR review comment is not an order — it is input. Your job is to evaluate
+each comment with the same rigor you apply to code, then take the right action:
+change, decline, or answer.
+
+## Decision tree
+
+For every comment, determine which category it falls into before acting:
+
+```
+Is the comment technically correct?
+├── No  → Decline and explain (no code change)
+└── Yes → Is it a question or a request for clarification?
+          ├── Yes → Answer in a reply (no code change)
+          └── No  → Apply the change
+```
+
+---
+
+## 1. Apply the change
+
+Change code when the comment identifies a real problem: a bug, a violation of
+project conventions, a clarity issue, or a missed edge case.
+
+**Rules:**
+- Apply the minimal fix that addresses the concern. Do not refactor unrelated code.
+- After applying, reply to the comment with a one-sentence summary of what changed.
+- If the fix is non-trivial, briefly explain the approach taken.
+
+---
+
+## 2. Decline and explain
+
+Not every comment is correct. Push back when:
+
+- The suggestion introduces a bug or regression.
+- The suggestion contradicts an established pattern in this codebase (point to the location).
+- The suggestion is a matter of style preference with no objective benefit, and the existing code
+  already follows a consistent convention.
+- The suggestion is based on a misunderstanding of the code's intent.
+
+**Rules:**
+- Always reply with a clear, respectful explanation. Never silently ignore a comment.
+- State the specific reason: wrong behavior, conflicts with `file:line`, performance trade-off, etc.
+- If appropriate, offer a counter-proposal.
+- Do not change the code to pacify a reviewer when you believe the original is correct.
+
+**Example reply:**
+> This change would bypass the nil-check on line 42 and cause a panic when the
+> cache is cold. The current guard is intentional — I'd rather keep it as-is.
+> Happy to add a comment if the intent is unclear.
+
+---
+
+## 3. Answer the question
+
+Some comments are genuine questions: "Why did you do X?", "What does this return
+when Y?", "Is this thread-safe?". These need an answer, not a code change.
+
+**Rules:**
+- Reply with a direct answer.
+- If the question reveals that the code is genuinely confusing, consider adding a
+  comment or renaming — but only if it actually improves clarity, not just to
+  satisfy the reviewer.
+- Never change code solely to signal that you read the comment.
+
+---
+
+## Workflow
+
+1. **Fetch comments**
+   ```bash
+   gh pr view --json comments,reviewThreads
+   # or for inline review comments:
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/comments
+   ```
+
+2. **Triage each comment** using the decision tree above.
+
+3. **Group related changes** — if multiple comments touch the same file or
+   function, batch the edits together before replying.
+
+4. **Reply to every comment** — resolved or not. Leaving a comment without a
+   reply signals that it was missed.
+
+5. **Mark threads resolved** after replying:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
+     --method POST --field body="" --field event="COMMENT"
+   ```
+
+6. **Push the updated branch** if any code changed:
+   ```bash
+   git push
+   ```
+
+---
+
+## Guardrails
+
+- Never mark a comment as resolved without either applying the change or
+  explaining why you did not.
+- Never apply a change you believe is wrong just to close a thread.
+- Never reply with vague acknowledgements ("Sure!", "Done") — every reply
+  must state what was done or why nothing was done.
+- Never open a PR comment thread with a different concern from the original;
+  raise separate issues separately.


### PR DESCRIPTION
## Summary
- Adds a new `solve-pr-comments` agent skill to `.agents/skills/`
- Defines a decision tree for triaging PR comments into three actions: apply, decline, or answer
- Establishes guardrails that prevent silently ignoring comments or applying changes believed to be wrong

## Why
PR review comments are not always correct, and treating every comment as an order leads to worse code. Agents (and humans) need a clear framework for deciding when to change code, when to respectfully push back with a technical explanation, and when a comment is just a question that needs an answer — not a code change.

The skill introduces a decision tree that asks two questions in sequence: is the comment correct, and is it a question? This produces three distinct action paths, each with explicit rules for how to reply. The guardrails section forbids vague acknowledgements and silent resolution, ensuring every comment gets a substantive response.