### PR TITLE
feat(ai): add tool calling support to Stream()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,10 @@ golangci-lint run                      # lint
 - Cache/Session/Queue: `goravel/redis`
 - Storage: `goravel/s3`, `oss`, `cos`, `minio`
 
+## Planning Rules
+
+- When asked to plan or investigate, produce a plan only — do not implement it until the user explicitly asks you to proceed.
+
 ## Code Rules
 
 - Use `any` instead of `interface{}`.

--- a/ai/console/stubs.go
+++ b/ai/console/stubs.go
@@ -18,5 +18,9 @@ func (r *DummyAgent) Instructions() string {
 func (r *DummyAgent) Messages() []ai.Message {
 	return nil
 }
+
+func (r *DummyAgent) Tools() []ai.Tool {
+	return nil
+}
 `
 }

--- a/ai/conversation.go
+++ b/ai/conversation.go
@@ -114,7 +114,7 @@ func (r *conversation) Prompt(input string) (contractsai.Response, error) {
 		}
 
 		// Execute each requested tool and collect results.
-		toolResults, execErr := r.executeTools(tools, toolCalls)
+		toolResults, execErr := r.executeTools(r.ctx, tools, toolCalls)
 		if execErr != nil {
 			clearPending()
 			return nil, execErr
@@ -168,33 +168,61 @@ func (r *conversation) Prompt(input string) (contractsai.Response, error) {
 
 func (r *conversation) Stream(input string) (contractsai.StreamableResponse, error) {
 	tools := r.agent.Tools()
+	agentPrompt := contractsai.AgentPrompt{
+		Agent: r,
+		Input: input,
+		Model: r.model,
+		Tools: tools,
+	}
+	clearPending := func() {
+		r.mu.Lock()
+		r.pending = nil
+		r.mu.Unlock()
+	}
+
+	initialCtx, cancelInitial := context.WithCancel(r.ctx)
+
+	r.promptMu.Lock()
+	initialStream, err := r.provider.Stream(initialCtx, agentPrompt)
+	r.promptMu.Unlock()
+	if err != nil {
+		cancelInitial()
+		clearPending()
+		return nil, err
+	}
 
 	return NewStreamableResponse(r.ctx, func(streamCtx context.Context, emit func(contractsai.StreamEvent) error) (contractsai.Response, error) {
 		r.promptMu.Lock()
 		defer r.promptMu.Unlock()
 
+		initialDone := make(chan struct{})
+		defer close(initialDone)
+		go func() {
+			select {
+			case <-streamCtx.Done():
+				cancelInitial()
+			case <-initialDone:
+			}
+		}()
+
 		r.mu.RLock()
 		working := slices.Clone(r.messages)
 		r.mu.RUnlock()
 
-		clearPending := func() {
-			r.mu.Lock()
-			r.pending = nil
-			r.mu.Unlock()
-		}
-
-		agentPrompt := contractsai.AgentPrompt{
-			Agent: r,
-			Input: input,
-			Model: r.model,
-			Tools: tools,
-		}
+		agentPrompt := agentPrompt
+		useInitialStream := true
 
 		for i := range MaxToolCallIterations {
-			innerStream, err := r.provider.Stream(streamCtx, agentPrompt)
-			if err != nil {
-				clearPending()
-				return nil, err
+			var innerStream contractsai.StreamableResponse
+			if useInitialStream {
+				innerStream = initialStream
+				useInitialStream = false
+			} else {
+				innerStream, err = r.provider.Stream(streamCtx, agentPrompt)
+				if err != nil {
+					clearPending()
+					return nil, err
+				}
 			}
 
 			var resp contractsai.Response
@@ -203,10 +231,14 @@ func (r *conversation) Stream(input string) (contractsai.StreamableResponse, err
 				return nil
 			})
 
+			var doneEvent *contractsai.StreamEvent
+
 			// Forward all events from this iteration, suppressing intermediate
 			// done events — only the final iteration's done event is forwarded.
 			if err := innerStream.Each(func(event contractsai.StreamEvent) error {
 				if event.Type == contractsai.StreamEventTypeDone {
+					event := event
+					doneEvent = &event
 					return nil
 				}
 				return emit(event)
@@ -217,6 +249,13 @@ func (r *conversation) Stream(input string) (contractsai.StreamableResponse, err
 
 			toolCalls := resp.ToolCalls()
 			if len(toolCalls) == 0 {
+				if doneEvent != nil {
+					if err := emit(*doneEvent); err != nil {
+						clearPending()
+						return nil, err
+					}
+				}
+
 				// No tool calls — commit history and return the final response.
 				if r.pending == nil {
 					working = append(working, contractsai.Message{Role: contractsai.RoleUser, Content: input})
@@ -245,7 +284,7 @@ func (r *conversation) Stream(input string) (contractsai.StreamableResponse, err
 				return nil, err
 			}
 
-			toolResults, execErr := r.executeTools(tools, toolCalls)
+			toolResults, execErr := r.executeTools(streamCtx, tools, toolCalls)
 			if execErr != nil {
 				clearPending()
 				return nil, execErr
@@ -289,7 +328,7 @@ func (r *conversation) Reset() {
 
 // executeTools looks up each tool call by name and invokes it.
 // Returns an error if a tool is not found or its execution fails.
-func (r *conversation) executeTools(tools []contractsai.Tool, calls []contractsai.ToolCall) ([]contractsai.Message, error) {
+func (r *conversation) executeTools(ctx context.Context, tools []contractsai.Tool, calls []contractsai.ToolCall) ([]contractsai.Message, error) {
 	// Build a lookup map for O(1) access.
 	index := make(map[string]contractsai.Tool, len(tools))
 	for _, t := range tools {
@@ -303,7 +342,7 @@ func (r *conversation) executeTools(tools []contractsai.Tool, calls []contractsa
 			return nil, errors.AIToolNotFound.Args(call.Name)
 		}
 
-		result, err := tool.Execute(r.ctx, call.Args)
+		result, err := tool.Execute(ctx, call.Args)
 		if err != nil {
 			return nil, errors.AIToolExecutionFailed.Args(call.Name, err)
 		}

--- a/ai/conversation.go
+++ b/ai/conversation.go
@@ -167,24 +167,117 @@ func (r *conversation) Prompt(input string) (contractsai.Response, error) {
 }
 
 func (r *conversation) Stream(input string) (contractsai.StreamableResponse, error) {
-	stream, err := r.provider.Stream(r.ctx, contractsai.AgentPrompt{
-		Agent: r,
-		Input: input,
-		Model: r.model,
-	})
-	if err != nil {
-		return nil, err
-	}
+	tools := r.agent.Tools()
 
-	return stream.Then(func(resp contractsai.Response) error {
-		r.mu.Lock()
-		r.messages = append(r.messages,
-			contractsai.Message{Role: contractsai.RoleUser, Content: input},
-			contractsai.Message{Role: contractsai.RoleAssistant, Content: resp.Text()},
-		)
-		r.mu.Unlock()
+	return NewStreamableResponse(r.ctx, func(streamCtx context.Context, emit func(contractsai.StreamEvent) error) (contractsai.Response, error) {
+		r.promptMu.Lock()
+		defer r.promptMu.Unlock()
 
-		return nil
+		r.mu.RLock()
+		working := slices.Clone(r.messages)
+		r.mu.RUnlock()
+
+		clearPending := func() {
+			r.mu.Lock()
+			r.pending = nil
+			r.mu.Unlock()
+		}
+
+		agentPrompt := contractsai.AgentPrompt{
+			Agent: r,
+			Input: input,
+			Model: r.model,
+			Tools: tools,
+		}
+
+		for i := range MaxToolCallIterations {
+			innerStream, err := r.provider.Stream(streamCtx, agentPrompt)
+			if err != nil {
+				clearPending()
+				return nil, err
+			}
+
+			var resp contractsai.Response
+			innerStream.Then(func(res contractsai.Response) error {
+				resp = res
+				return nil
+			})
+
+			// Forward all events from this iteration, suppressing intermediate
+			// done events — only the final iteration's done event is forwarded.
+			if err := innerStream.Each(func(event contractsai.StreamEvent) error {
+				if event.Type == contractsai.StreamEventTypeDone {
+					return nil
+				}
+				return emit(event)
+			}); err != nil {
+				clearPending()
+				return nil, err
+			}
+
+			toolCalls := resp.ToolCalls()
+			if len(toolCalls) == 0 {
+				// No tool calls — commit history and return the final response.
+				if r.pending == nil {
+					working = append(working, contractsai.Message{Role: contractsai.RoleUser, Content: input})
+				}
+				working = append(working, contractsai.Message{Role: contractsai.RoleAssistant, Content: resp.Text()})
+
+				r.mu.Lock()
+				r.messages = working
+				r.pending = nil
+				r.mu.Unlock()
+
+				return resp, nil
+			}
+
+			if i == MaxToolCallIterations-1 {
+				clearPending()
+				return nil, errors.AIToolCallLoopExceeded.Args(MaxToolCallIterations)
+			}
+
+			// Emit a tool_call event so the caller can observe the invocations.
+			if err := emit(contractsai.StreamEvent{
+				Type:      contractsai.StreamEventTypeToolCall,
+				ToolCalls: toolCalls,
+			}); err != nil {
+				clearPending()
+				return nil, err
+			}
+
+			toolResults, execErr := r.executeTools(tools, toolCalls)
+			if execErr != nil {
+				clearPending()
+				return nil, execErr
+			}
+
+			// Extend the working copy with the user message (first round only),
+			// the assistant tool-call message, and tool results.
+			if i == 0 {
+				working = append(working, contractsai.Message{Role: contractsai.RoleUser, Content: input})
+			}
+			working = append(working, contractsai.Message{
+				Role:      contractsai.RoleAssistant,
+				Content:   resp.Text(),
+				ToolCalls: toolCalls,
+			})
+			working = append(working, toolResults...)
+
+			r.mu.Lock()
+			r.pending = working
+			r.mu.Unlock()
+
+			// On subsequent iterations Input is empty — history is in pending.
+			agentPrompt = contractsai.AgentPrompt{
+				Agent: r,
+				Input: "",
+				Model: r.model,
+				Tools: tools,
+			}
+		}
+
+		clearPending()
+		return nil, errors.AIToolCallLoopExceeded.Args(MaxToolCallIterations)
 	}), nil
 }
 

--- a/ai/conversation_test.go
+++ b/ai/conversation_test.go
@@ -214,15 +214,14 @@ func (s *ConversationTestSuite) TestStream() {
 	ctx := context.Background()
 	model := "stream-model"
 
-	s.Run("returns provider error without mutating messages", func() {
+	s.Run("returns provider error via Each without mutating messages", func() {
 		initial := []contractsai.Message{{Role: contractsai.RoleAssistant, Content: "seed"}}
 		agent := &agentStub{messages: initial}
 
 		var conv *conversation
 		provider := &conversationProviderStub{
 			streamFn: func(gotCtx context.Context, prompt contractsai.AgentPrompt) (contractsai.StreamableResponse, error) {
-				s.Equal(ctx, gotCtx)
-				s.Equal(contractsai.AgentPrompt{Agent: conv, Input: "hello", Model: model}, prompt)
+				s.Equal(contractsai.AgentPrompt{Agent: conv, Input: "hello", Model: model, Tools: nil}, prompt)
 				return nil, assert.AnError
 			},
 		}
@@ -230,8 +229,11 @@ func (s *ConversationTestSuite) TestStream() {
 
 		stream, err := conv.Stream("hello")
 
-		s.Equal(assert.AnError, err)
-		s.Nil(stream)
+		// Stream() itself succeeds; the provider error surfaces through Each().
+		s.NoError(err)
+		s.NotNil(stream)
+		eachErr := stream.Each(nil)
+		s.Equal(assert.AnError, eachErr)
 		s.Equal(initial, conv.Messages())
 	})
 
@@ -242,8 +244,7 @@ func (s *ConversationTestSuite) TestStream() {
 		var conv *conversation
 		provider := &conversationProviderStub{
 			streamFn: func(gotCtx context.Context, prompt contractsai.AgentPrompt) (contractsai.StreamableResponse, error) {
-				s.Equal(ctx, gotCtx)
-				s.Equal(contractsai.AgentPrompt{Agent: conv, Input: "hi", Model: model}, prompt)
+				s.Equal(contractsai.AgentPrompt{Agent: conv, Input: "hi", Model: model, Tools: nil}, prompt)
 				return NewStreamableResponse(gotCtx, func(_ context.Context, emit func(contractsai.StreamEvent) error) (contractsai.Response, error) {
 					if err := emit(contractsai.StreamEvent{Type: contractsai.StreamEventTypeTextDelta, Delta: "partial"}); err != nil {
 						return nil, err
@@ -272,7 +273,6 @@ func (s *ConversationTestSuite) TestStream() {
 		s.NoError(err)
 		s.Equal(normalizeStreamEvents([]contractsai.StreamEvent{
 			{Type: contractsai.StreamEventTypeTextDelta, Delta: "partial"},
-			{Type: contractsai.StreamEventTypeDone},
 		}), normalizeStreamEvents(events))
 		s.Equal([]contractsai.Message{
 			{Role: contractsai.RoleAssistant, Content: "seed"},
@@ -288,8 +288,7 @@ func (s *ConversationTestSuite) TestStream() {
 		var conv *conversation
 		provider := &conversationProviderStub{
 			streamFn: func(gotCtx context.Context, prompt contractsai.AgentPrompt) (contractsai.StreamableResponse, error) {
-				s.Equal(ctx, gotCtx)
-				s.Equal(contractsai.AgentPrompt{Agent: conv, Input: "hi", Model: model}, prompt)
+				s.Equal(contractsai.AgentPrompt{Agent: conv, Input: "hi", Model: model, Tools: nil}, prompt)
 				return NewStreamableResponse(gotCtx, func(_ context.Context, emit func(contractsai.StreamEvent) error) (contractsai.Response, error) {
 					if err := emit(contractsai.StreamEvent{Type: contractsai.StreamEventTypeTextDelta, Delta: "partial"}); err != nil {
 						return nil, err
@@ -446,17 +445,170 @@ func (s *ConversationTestSuite) TestPromptToolInvocationLoop() {
 	})
 }
 
+func (s *ConversationTestSuite) TestStreamToolInvocationLoop() {
+	ctx := context.Background()
+
+	type streamCall struct {
+		response contractsai.Response
+		events   []contractsai.StreamEvent
+		err      error
+	}
+
+	makeProvider := func(calls []streamCall) (*conversationToolProviderStub, *int) {
+		idx := 0
+		p := &conversationToolProviderStub{
+			promptFn: func(_ context.Context, _ contractsai.AgentPrompt) (contractsai.Response, error) {
+				return nil, nil
+			},
+			streamFn: func(streamCtx context.Context, _ contractsai.AgentPrompt) (contractsai.StreamableResponse, error) {
+				c := calls[idx]
+				idx++
+				if c.err != nil {
+					return nil, c.err
+				}
+				return NewStreamableResponse(streamCtx, func(_ context.Context, emit func(contractsai.StreamEvent) error) (contractsai.Response, error) {
+					for _, ev := range c.events {
+						if err := emit(ev); err != nil {
+							return nil, err
+						}
+					}
+					return c.response, nil
+				}), nil
+			},
+		}
+		return p, &idx
+	}
+
+	s.Run("executes tool and re-prompts until plain text response", func() {
+		toolCall := contractsai.ToolCall{ID: "c1", Name: "get_weather", Args: map[string]any{"city": "London"}, RawArgs: `{"city":"London"}`}
+		provider, _ := makeProvider([]streamCall{
+			{
+				response: &stubResponse{toolCalls: []contractsai.ToolCall{toolCall}},
+				events:   []contractsai.StreamEvent{{Type: contractsai.StreamEventTypeDone}},
+			},
+			{
+				response: &stubResponse{text: "The weather is sunny."},
+				events: []contractsai.StreamEvent{
+					{Type: contractsai.StreamEventTypeTextDelta, Delta: "The weather is sunny."},
+					{Type: contractsai.StreamEventTypeDone},
+				},
+			},
+		})
+
+		tool := &stubTool{name: "get_weather", result: "Sunny, 25°C"}
+		agent := &agentStub{tools: []contractsai.Tool{tool}}
+		conv := NewConversation(ctx, agent, provider, "m")
+
+		stream, err := conv.Stream("What's the weather in London?")
+		s.Require().NoError(err)
+
+		var gotTypes []contractsai.StreamEventType
+		var gotToolCalls []contractsai.ToolCall
+		eachErr := stream.Each(func(event contractsai.StreamEvent) error {
+			gotTypes = append(gotTypes, event.Type)
+			if event.Type == contractsai.StreamEventTypeToolCall {
+				gotToolCalls = append(gotToolCalls, event.ToolCalls...)
+			}
+			return nil
+		})
+		s.NoError(eachErr)
+
+		s.Contains(gotTypes, contractsai.StreamEventTypeToolCall)
+		s.Contains(gotTypes, contractsai.StreamEventTypeTextDelta)
+		s.Equal([]contractsai.ToolCall{toolCall}, gotToolCalls)
+		s.Equal(1, tool.callCount)
+
+		// History: user + assistant(tool_calls) + tool_result + assistant(final)
+		msgs := conv.Messages()
+		s.Require().Len(msgs, 4)
+		s.Equal(contractsai.RoleUser, msgs[0].Role)
+		s.Equal("What's the weather in London?", msgs[0].Content)
+		s.Equal(contractsai.RoleAssistant, msgs[1].Role)
+		s.Equal(toolCall, msgs[1].ToolCalls[0])
+		s.Equal(contractsai.RoleToolResult, msgs[2].Role)
+		s.Equal("Sunny, 25°C", msgs[2].Content)
+		s.Equal("c1", msgs[2].ToolCallID)
+		s.Equal(contractsai.RoleAssistant, msgs[3].Role)
+		s.Equal("The weather is sunny.", msgs[3].Content)
+	})
+
+	s.Run("returns provider stream error via Each without mutating messages", func() {
+		provider, _ := makeProvider([]streamCall{
+			{err: assert.AnError},
+		})
+
+		agent := &agentStub{tools: nil}
+		conv := NewConversation(ctx, agent, provider, "m")
+		initial := conv.Messages()
+
+		stream, err := conv.Stream("hello")
+		s.NoError(err)
+
+		eachErr := stream.Each(nil)
+		s.Equal(assert.AnError, eachErr)
+		s.Equal(initial, conv.Messages())
+	})
+
+	s.Run("returns error when tool is not found", func() {
+		toolCall := contractsai.ToolCall{ID: "cx", Name: "missing_tool", Args: map[string]any{}}
+		provider, _ := makeProvider([]streamCall{
+			{
+				response: &stubResponse{toolCalls: []contractsai.ToolCall{toolCall}},
+				events:   []contractsai.StreamEvent{{Type: contractsai.StreamEventTypeDone}},
+			},
+		})
+
+		tool := &stubTool{name: "known_tool"}
+		agent := &agentStub{tools: []contractsai.Tool{tool}}
+		conv := NewConversation(ctx, agent, provider, "m")
+
+		stream, err := conv.Stream("hello")
+		s.NoError(err)
+
+		eachErr := stream.Each(nil)
+		s.ErrorContains(eachErr, `tool "missing_tool" not found`)
+		s.Len(conv.Messages(), 0)
+	})
+
+	s.Run("returns error when max iterations exceeded", func() {
+		toolCall := contractsai.ToolCall{ID: "cx", Name: "loop_tool", Args: map[string]any{}}
+		calls := make([]streamCall, MaxToolCallIterations)
+		for i := range calls {
+			calls[i] = streamCall{
+				response: &stubResponse{toolCalls: []contractsai.ToolCall{toolCall}},
+				events:   []contractsai.StreamEvent{{Type: contractsai.StreamEventTypeDone}},
+			}
+		}
+		provider, _ := makeProvider(calls)
+
+		tool := &stubTool{name: "loop_tool", result: "result"}
+		agent := &agentStub{tools: []contractsai.Tool{tool}}
+		conv := NewConversation(ctx, agent, provider, "m")
+
+		stream, err := conv.Stream("loop forever")
+		s.NoError(err)
+
+		eachErr := stream.Each(nil)
+		s.ErrorContains(eachErr, "exceeded")
+		s.Len(conv.Messages(), 0)
+	})
+}
+
 // conversationToolProviderStub is a Provider stub that delegates Prompt to a func.
 type conversationToolProviderStub struct {
 	promptFn func(ctx context.Context, prompt contractsai.AgentPrompt) (contractsai.Response, error)
+	streamFn func(ctx context.Context, prompt contractsai.AgentPrompt) (contractsai.StreamableResponse, error)
 }
 
 func (r *conversationToolProviderStub) Prompt(ctx context.Context, prompt contractsai.AgentPrompt) (contractsai.Response, error) {
 	return r.promptFn(ctx, prompt)
 }
 
-func (r *conversationToolProviderStub) Stream(_ context.Context, _ contractsai.AgentPrompt) (contractsai.StreamableResponse, error) {
-	return nil, nil
+func (r *conversationToolProviderStub) Stream(ctx context.Context, prompt contractsai.AgentPrompt) (contractsai.StreamableResponse, error) {
+	if r.streamFn == nil {
+		return nil, nil
+	}
+	return r.streamFn(ctx, prompt)
 }
 
 // stubResponse is a minimal Response with configurable text and tool calls.

--- a/ai/conversation_test.go
+++ b/ai/conversation_test.go
@@ -206,15 +206,15 @@ type agentStub struct {
 	tools    []contractsai.Tool
 }
 
-func (a *agentStub) Instructions() string        { return "" }
+func (a *agentStub) Instructions() string            { return "" }
 func (a *agentStub) Messages() []contractsai.Message { return a.messages }
-func (a *agentStub) Tools() []contractsai.Tool   { return a.tools }
+func (a *agentStub) Tools() []contractsai.Tool       { return a.tools }
 
 func (s *ConversationTestSuite) TestStream() {
 	ctx := context.Background()
 	model := "stream-model"
 
-	s.Run("returns provider error via Each without mutating messages", func() {
+	s.Run("returns provider error immediately without mutating messages", func() {
 		initial := []contractsai.Message{{Role: contractsai.RoleAssistant, Content: "seed"}}
 		agent := &agentStub{messages: initial}
 
@@ -229,11 +229,8 @@ func (s *ConversationTestSuite) TestStream() {
 
 		stream, err := conv.Stream("hello")
 
-		// Stream() itself succeeds; the provider error surfaces through Each().
-		s.NoError(err)
-		s.NotNil(stream)
-		eachErr := stream.Each(nil)
-		s.Equal(assert.AnError, eachErr)
+		s.Equal(assert.AnError, err)
+		s.Nil(stream)
 		s.Equal(initial, conv.Messages())
 	})
 
@@ -273,6 +270,7 @@ func (s *ConversationTestSuite) TestStream() {
 		s.NoError(err)
 		s.Equal(normalizeStreamEvents([]contractsai.StreamEvent{
 			{Type: contractsai.StreamEventTypeTextDelta, Delta: "partial"},
+			{Type: contractsai.StreamEventTypeDone},
 		}), normalizeStreamEvents(events))
 		s.Equal([]contractsai.Message{
 			{Role: contractsai.RoleAssistant, Content: "seed"},
@@ -515,6 +513,7 @@ func (s *ConversationTestSuite) TestStreamToolInvocationLoop() {
 
 		s.Contains(gotTypes, contractsai.StreamEventTypeToolCall)
 		s.Contains(gotTypes, contractsai.StreamEventTypeTextDelta)
+		s.Contains(gotTypes, contractsai.StreamEventTypeDone)
 		s.Equal([]contractsai.ToolCall{toolCall}, gotToolCalls)
 		s.Equal(1, tool.callCount)
 
@@ -532,7 +531,7 @@ func (s *ConversationTestSuite) TestStreamToolInvocationLoop() {
 		s.Equal("The weather is sunny.", msgs[3].Content)
 	})
 
-	s.Run("returns provider stream error via Each without mutating messages", func() {
+	s.Run("returns provider stream error immediately without mutating messages", func() {
 		provider, _ := makeProvider([]streamCall{
 			{err: assert.AnError},
 		})
@@ -542,10 +541,8 @@ func (s *ConversationTestSuite) TestStreamToolInvocationLoop() {
 		initial := conv.Messages()
 
 		stream, err := conv.Stream("hello")
-		s.NoError(err)
-
-		eachErr := stream.Each(nil)
-		s.Equal(assert.AnError, eachErr)
+		s.Equal(assert.AnError, err)
+		s.Nil(stream)
 		s.Equal(initial, conv.Messages())
 	})
 
@@ -611,6 +608,25 @@ func (r *conversationToolProviderStub) Stream(ctx context.Context, prompt contra
 	return r.streamFn(ctx, prompt)
 }
 
+func (s *ConversationTestSuite) TestExecuteTools_UsesProvidedContext() {
+	ctx := context.Background()
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tool := &stubTool{name: "get_weather", result: "Sunny"}
+	conv := NewConversation(ctx, &agentStub{tools: []contractsai.Tool{tool}}, &conversationProviderStub{}, "m")
+
+	results, err := conv.executeTools(streamCtx, []contractsai.Tool{tool}, []contractsai.ToolCall{{ID: "c1", Name: "get_weather", Args: map[string]any{"city": "London"}}})
+
+	s.NoError(err)
+	s.Equal([]contractsai.Message{{
+		Role:       contractsai.RoleToolResult,
+		Content:    "Sunny",
+		ToolCallID: "c1",
+	}}, results)
+	s.Same(streamCtx, tool.lastCtx)
+}
+
 // stubResponse is a minimal Response with configurable text and tool calls.
 type stubResponse struct {
 	text      string
@@ -618,8 +634,8 @@ type stubResponse struct {
 	usage     contractsai.Usage
 }
 
-func (r *stubResponse) Text() string                    { return r.text }
-func (r *stubResponse) Usage() contractsai.Usage        { return r.usage }
+func (r *stubResponse) Text() string                      { return r.text }
+func (r *stubResponse) Usage() contractsai.Usage          { return r.usage }
 func (r *stubResponse) ToolCalls() []contractsai.ToolCall { return r.toolCalls }
 
 // stubTool records calls and returns a fixed result or error.
@@ -628,12 +644,14 @@ type stubTool struct {
 	result    string
 	execErr   error
 	callCount int
+	lastCtx   context.Context
 }
 
-func (t *stubTool) Name() string                   { return t.name }
-func (t *stubTool) Description() string            { return "" }
-func (t *stubTool) Parameters() map[string]any     { return nil }
-func (t *stubTool) Execute(_ context.Context, _ map[string]any) (string, error) {
+func (t *stubTool) Name() string               { return t.name }
+func (t *stubTool) Description() string        { return "" }
+func (t *stubTool) Parameters() map[string]any { return nil }
+func (t *stubTool) Execute(ctx context.Context, _ map[string]any) (string, error) {
 	t.callCount++
+	t.lastCtx = ctx
 	return t.result, t.execErr
 }

--- a/ai/openai/provider.go
+++ b/ai/openai/provider.go
@@ -83,18 +83,30 @@ func (r *Provider) Stream(ctx context.Context, prompt contractsai.AgentPrompt) (
 	model := r.resolveModel(prompt.Model)
 	messages := r.buildMessages(prompt)
 
+	params := goopenai.ChatCompletionNewParams{
+		Model:    model,
+		Messages: messages,
+		StreamOptions: goopenai.ChatCompletionStreamOptionsParam{
+			IncludeUsage: goopenai.Bool(true),
+		},
+	}
+	if len(prompt.Tools) > 0 {
+		params.Tools = r.buildTools(prompt.Tools)
+	}
+
 	return frameworkai.NewStreamableResponse(ctx, func(streamCtx context.Context, emit func(contractsai.StreamEvent) error) (contractsai.Response, error) {
-		stream := r.client.Chat.Completions.NewStreaming(streamCtx, goopenai.ChatCompletionNewParams{
-			Model:    model,
-			Messages: messages,
-			StreamOptions: goopenai.ChatCompletionStreamOptionsParam{
-				IncludeUsage: goopenai.Bool(true),
-			},
-		})
+		stream := r.client.Chat.Completions.NewStreaming(streamCtx, params)
 		defer errors.Ignore(stream.Close)
 
 		text := strings.Builder{}
 		currentUsage := &usage{}
+		// toolCallBuilders accumulates argument fragments for each tool call, keyed by index.
+		type toolCallBuilder struct {
+			id   string
+			name string
+			args strings.Builder
+		}
+		var toolCallBuilders []*toolCallBuilder
 
 		for stream.Next() {
 			chunk := stream.Current()
@@ -110,17 +122,31 @@ func (r *Provider) Stream(ctx context.Context, prompt contractsai.AgentPrompt) (
 				continue
 			}
 
-			delta := chunk.Choices[0].Delta.Content
-			if delta == "" {
-				continue
+			delta := chunk.Choices[0].Delta
+
+			if delta.Content != "" {
+				text.WriteString(delta.Content)
+				if err := emit(contractsai.StreamEvent{
+					Type:  contractsai.StreamEventTypeTextDelta,
+					Delta: delta.Content,
+				}); err != nil {
+					return nil, err
+				}
 			}
 
-			text.WriteString(delta)
-			if err := emit(contractsai.StreamEvent{
-				Type:  contractsai.StreamEventTypeTextDelta,
-				Delta: delta,
-			}); err != nil {
-				return nil, err
+			for _, tc := range delta.ToolCalls {
+				idx := int(tc.Index)
+				for len(toolCallBuilders) <= idx {
+					toolCallBuilders = append(toolCallBuilders, &toolCallBuilder{})
+				}
+				b := toolCallBuilders[idx]
+				if tc.ID != "" {
+					b.id = tc.ID
+				}
+				if tc.Function.Name != "" {
+					b.name = tc.Function.Name
+				}
+				b.args.WriteString(tc.Function.Arguments)
 			}
 		}
 
@@ -137,6 +163,22 @@ func (r *Provider) Stream(ctx context.Context, prompt contractsai.AgentPrompt) (
 			return nil, err
 		}
 
+		// Parse accumulated tool calls into the framework's ToolCall type.
+		var toolCalls []contractsai.ToolCall
+		for _, b := range toolCallBuilders {
+			rawArgs := b.args.String()
+			args := make(map[string]any)
+			if rawArgs != "" {
+				_ = json.Unmarshal([]byte(rawArgs), &args)
+			}
+			toolCalls = append(toolCalls, contractsai.ToolCall{
+				ID:      b.id,
+				Name:    b.name,
+				Args:    args,
+				RawArgs: rawArgs,
+			})
+		}
+
 		if err := emit(contractsai.StreamEvent{
 			Type:  contractsai.StreamEventTypeDone,
 			Usage: currentUsage,
@@ -145,8 +187,9 @@ func (r *Provider) Stream(ctx context.Context, prompt contractsai.AgentPrompt) (
 		}
 
 		return &response{
-			text:  text.String(),
-			usage: currentUsage,
+			text:      text.String(),
+			toolCalls: toolCalls,
+			usage:     currentUsage,
 		}, nil
 	}), nil
 }

--- a/ai/openai/provider_test.go
+++ b/ai/openai/provider_test.go
@@ -67,6 +67,7 @@ type normalizedStreamEvent struct {
 	delta     string
 	err       string
 	usage     *streamUsageSnapshot
+	toolCalls []contractsai.ToolCall
 }
 
 func TestNewOpenAIUnmarshalError(t *testing.T) {
@@ -351,6 +352,7 @@ func TestProviderStream(t *testing.T) {
 		expectErrMessage string
 		expectText       string
 		expectUsage      usageCheck
+		expectToolCalls  []contractsai.ToolCall
 		expectEvents     []normalizedStreamEvent
 		expectRequest    normalizedCapturedStreamRequest
 	}{
@@ -430,6 +432,47 @@ func TestProviderStream(t *testing.T) {
 			},
 		},
 		{
+			name:        "accumulates streaming tool call deltas across chunks",
+			status:      http.StatusOK,
+			contentType: "text/event-stream",
+			body: strings.Join([]string{
+				`data: {"id":"chatcmpl_stream_tc","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":"}}]},"finish_reason":null}],"usage":null}`,
+				``,
+				`data: {"id":"chatcmpl_stream_tc","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"arguments":"\"London\",\"units\":\"celsius\"}"}}]},"finish_reason":null}],"usage":null}`,
+				``,
+				`data: {"id":"chatcmpl_stream_tc","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[],"usage":{"prompt_tokens":6,"completion_tokens":3,"total_tokens":9}}`,
+				``,
+				`data: [DONE]`,
+				``,
+			}, "\n"),
+			setup: func() {
+				mockAgent.EXPECT().Instructions().Return("").Once()
+				mockAgent.EXPECT().Messages().Return(nil).Once()
+			},
+			input:       "hello",
+			expectUsage: usageCheck{input: 6, output: 3, total: 9},
+			expectToolCalls: []contractsai.ToolCall{{
+				ID:      "call_1",
+				Name:    "get_weather",
+				Args:    map[string]any{"city": "London", "units": "celsius"},
+				RawArgs: `{"city":"London","units":"celsius"}`,
+			}},
+			expectEvents: []normalizedStreamEvent{{
+				eventType: contractsai.StreamEventTypeDone,
+				usage:     &streamUsageSnapshot{input: 6, output: 3, total: 9},
+			}},
+			expectRequest: normalizedCapturedStreamRequest{
+				path:          "/chat/completions",
+				authorization: "Bearer test-key",
+				model:         "gpt-default",
+				stream:        true,
+				includeUsage:  true,
+				messages: []normalizedMessage{
+					{role: "user", content: "hello"},
+				},
+			},
+		},
+		{
 			name:             "emits error event when stream request fails",
 			status:           http.StatusInternalServerError,
 			contentType:      "application/json",
@@ -482,9 +525,11 @@ func TestProviderStream(t *testing.T) {
 			thenCalled := 0
 			var thenText string
 			var thenUsage usageCheck
+			var thenToolCalls []contractsai.ToolCall
 			stream.Then(func(resp contractsai.Response) error {
 				thenCalled++
 				thenText = resp.Text()
+				thenToolCalls = resp.ToolCalls()
 				if resp.Usage() != nil {
 					thenUsage = usageCheck{
 						input:  resp.Usage().Input(),
@@ -521,6 +566,7 @@ func TestProviderStream(t *testing.T) {
 				assert.Equal(t, 1, thenCalled)
 				assert.Equal(t, tt.expectText, thenText)
 				assert.Equal(t, tt.expectUsage, thenUsage)
+				assert.Equal(t, tt.expectToolCalls, thenToolCalls)
 			}
 
 			req, ok := readCapturedStreamRequest(t, captured)
@@ -695,6 +741,7 @@ func normalizeProviderStreamEvents(events []contractsai.StreamEvent) []normalize
 			eventType: event.Type,
 			delta:     event.Delta,
 			err:       event.Error,
+			toolCalls: event.ToolCalls,
 		}
 		if event.Usage != nil {
 			entry.usage = &streamUsageSnapshot{

--- a/ai/streamable_response.go
+++ b/ai/streamable_response.go
@@ -168,10 +168,17 @@ func (r *streamableResponse) HTTPResponse(ctx contractshttp.Context, options ...
 	})
 }
 
+type streamToolCallPayload struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Args any    `json:"args,omitempty"`
+}
+
 type streamEventPayload struct {
-	Delta string              `json:"delta,omitempty"`
-	Usage *streamUsagePayload `json:"usage,omitempty"`
-	Error string              `json:"error,omitempty"`
+	Delta     string                   `json:"delta,omitempty"`
+	Usage     *streamUsagePayload      `json:"usage,omitempty"`
+	Error     string                   `json:"error,omitempty"`
+	ToolCalls []streamToolCallPayload  `json:"tool_calls,omitempty"`
 }
 
 type streamUsagePayload struct {
@@ -191,6 +198,13 @@ func defaultStreamRender(w contractshttp.StreamWriter, event contractsai.StreamE
 			Output: event.Usage.Output(),
 			Total:  event.Usage.Total(),
 		}
+	}
+	for _, tc := range event.ToolCalls {
+		payload.ToolCalls = append(payload.ToolCalls, streamToolCallPayload{
+			ID:   tc.ID,
+			Name: tc.Name,
+			Args: tc.Args,
+		})
 	}
 
 	data, err := json.Marshal(payload)

--- a/ai/streamable_response_test.go
+++ b/ai/streamable_response_test.go
@@ -21,8 +21,8 @@ type streamableTestResponse struct {
 	usage contractsai.Usage
 }
 
-func (r *streamableTestResponse) Text() string                    { return r.text }
-func (r *streamableTestResponse) Usage() contractsai.Usage        { return r.usage }
+func (r *streamableTestResponse) Text() string                      { return r.text }
+func (r *streamableTestResponse) Usage() contractsai.Usage          { return r.usage }
 func (r *streamableTestResponse) ToolCalls() []contractsai.ToolCall { return nil }
 
 type streamableTestUsage struct {
@@ -401,6 +401,20 @@ func TestDefaultStreamRender(t *testing.T) {
 			},
 			writer:       &recordingStreamWriter{},
 			expectWrites: []string{"event: done\n", "data: {\"usage\":{\"input\":3,\"output\":4,\"total\":7}}\n\n"},
+			expectFlush:  1,
+		},
+		{
+			name: "renders tool call payload",
+			event: contractsai.StreamEvent{
+				Type: contractsai.StreamEventTypeToolCall,
+				ToolCalls: []contractsai.ToolCall{{
+					ID:   "call_1",
+					Name: "get_weather",
+					Args: map[string]any{"city": "London"},
+				}},
+			},
+			writer:       &recordingStreamWriter{},
+			expectWrites: []string{"event: tool_call\n", "data: {\"tool_calls\":[{\"id\":\"call_1\",\"name\":\"get_weather\",\"args\":{\"city\":\"London\"}}]}\n\n"},
 			expectFlush:  1,
 		},
 		{

--- a/contracts/ai/stream.go
+++ b/contracts/ai/stream.go
@@ -6,15 +6,17 @@ type StreamEventType string
 
 const (
 	StreamEventTypeTextDelta StreamEventType = "text_delta"
+	StreamEventTypeToolCall  StreamEventType = "tool_call"
 	StreamEventTypeDone      StreamEventType = "done"
 	StreamEventTypeError     StreamEventType = "error"
 )
 
 type StreamEvent struct {
-	Type  StreamEventType
-	Delta string
-	Usage Usage
-	Error string
+	Type      StreamEventType
+	Delta     string
+	Usage     Usage
+	Error     string
+	ToolCalls []ToolCall
 }
 
 type RenderFunc func(w contractshttp.StreamWriter, event StreamEvent) error


### PR DESCRIPTION
## Summary
- `Stream()` now runs a full agentic tool-call loop (up to `MaxToolCallIterations`), mirroring the existing `Prompt()` tool-calling behavior
- Tool invocations are emitted as `StreamEventTypeToolCall` events so callers can observe them in real time
- The OpenAI streaming provider accumulates tool-call argument fragments across chunks and returns them via `Response.ToolCalls()`

## Why
Before this change, `Stream()` stripped tools from the agent prompt and returned plain text only. Callers who needed tool-calling had to fall back to `Prompt()` and lose the streaming UX.

Now `Stream()` passes the agent's tools to the provider, accumulates tool-call deltas across streaming chunks, executes the tools, and re-prompts in a loop — exactly like `Prompt()` does — while forwarding text deltas to the caller in real time. Intermediate `done` events from inner iterations are suppressed; only the final `done` is forwarded.

```go
// app/ai/agents/search_agent.go
type SearchAgent struct{}

func (r *SearchAgent) Instructions() string {
    return "You are a helpful assistant that can search the web."
}

func (r *SearchAgent) Tools() []ai.Tool {
    return []ai.Tool{facades.AI().Tool("web_search")}
}

// app/http/controllers/chat_controller.go
func (r *ChatController) Stream(ctx http.Context) http.Response {
    conversation := facades.AI().Agent(&agents.SearchAgent{}).Conversation()
    stream, err := conversation.Stream(ctx.Request().Input("message"))
    if err != nil {
        return ctx.Response().Json(500, http.Json{"error": err.Error()})
    }
    return stream.HTTPResponse(ctx)
}
```