### PR TITLE
fix: [#925] rotate session on login and logout to prevent session fixation

### DIFF
--- a/auth/session_guard.go
+++ b/auth/session_guard.go
@@ -9,7 +9,7 @@ import (
 	"github.com/goravel/framework/contracts/http"
 	contractsession "github.com/goravel/framework/contracts/session"
 	"github.com/goravel/framework/errors"
-	"github.com/goravel/framework/support/carbon"
+	"github.com/goravel/framework/session"
 )
 
 type SessionGuard struct {
@@ -23,13 +23,13 @@ func NewSessionGuard(ctx http.Context, name string, userProvider contractsauth.U
 	if ctx == nil {
 		return nil, errors.InvalidHttpContext.SetModule(errors.ModuleAuth)
 	}
-	session := ctx.Request().Session()
-	if session == nil {
+	s := ctx.Request().Session()
+	if s == nil {
 		return nil, errors.SessionDriverIsNotSet.SetModule(errors.ModuleAuth)
 	}
 
 	return &SessionGuard{
-		session:  session,
+		session:  s,
 		ctx:      ctx,
 		guard:    name,
 		provider: userProvider,
@@ -81,7 +81,7 @@ func (r *SessionGuard) LoginUsingID(id any) (token string, err error) {
 	if err := r.session.Regenerate(true); err != nil {
 		return "", err
 	}
-	r.reissueSessionCookie()
+	session.WriteCookie(r.ctx)
 
 	r.session.Put(sessionName, key)
 
@@ -92,29 +92,9 @@ func (r *SessionGuard) Logout() error {
 	if err := r.session.Invalidate(); err != nil {
 		return err
 	}
-	r.reissueSessionCookie()
+	session.WriteCookie(r.ctx)
 
 	return nil
-}
-
-// reissueSessionCookie writes the current session ID to the response cookie.
-// Called after Regenerate/Invalidate so the rotated ID reaches the client
-// even on drivers that flush headers when the handler writes the body.
-func (r *SessionGuard) reissueSessionCookie() {
-	if configFacade == nil {
-		return
-	}
-
-	r.ctx.Response().Cookie(http.Cookie{
-		Name:     r.session.GetName(),
-		Value:    r.session.GetID(),
-		Expires:  carbon.Now().AddMinutes(configFacade.GetInt("session.lifetime", 120)).StdTime(),
-		Path:     configFacade.GetString("session.path"),
-		Domain:   configFacade.GetString("session.domain"),
-		Secure:   configFacade.GetBool("session.secure"),
-		HttpOnly: configFacade.GetBool("session.http_only"),
-		SameSite: configFacade.GetString("session.same_site"),
-	})
 }
 
 func (r *SessionGuard) Parse(token string) (*contractsauth.Payload, error) {

--- a/auth/session_guard.go
+++ b/auth/session_guard.go
@@ -9,7 +9,6 @@ import (
 	"github.com/goravel/framework/contracts/http"
 	contractsession "github.com/goravel/framework/contracts/session"
 	"github.com/goravel/framework/errors"
-	"github.com/goravel/framework/session"
 )
 
 type SessionGuard struct {
@@ -23,13 +22,13 @@ func NewSessionGuard(ctx http.Context, name string, userProvider contractsauth.U
 	if ctx == nil {
 		return nil, errors.InvalidHttpContext.SetModule(errors.ModuleAuth)
 	}
-	s := ctx.Request().Session()
-	if s == nil {
+	session := ctx.Request().Session()
+	if session == nil {
 		return nil, errors.SessionDriverIsNotSet.SetModule(errors.ModuleAuth)
 	}
 
 	return &SessionGuard{
-		session:  s,
+		session:  session,
 		ctx:      ctx,
 		guard:    name,
 		provider: userProvider,
@@ -81,7 +80,6 @@ func (r *SessionGuard) LoginUsingID(id any) (token string, err error) {
 	if err := r.session.Regenerate(true); err != nil {
 		return "", err
 	}
-	session.WriteCookie(r.ctx)
 
 	r.session.Put(sessionName, key)
 
@@ -89,12 +87,7 @@ func (r *SessionGuard) LoginUsingID(id any) (token string, err error) {
 }
 
 func (r *SessionGuard) Logout() error {
-	if err := r.session.Invalidate(); err != nil {
-		return err
-	}
-	session.WriteCookie(r.ctx)
-
-	return nil
+	return r.session.Invalidate()
 }
 
 func (r *SessionGuard) Parse(token string) (*contractsauth.Payload, error) {

--- a/auth/session_guard.go
+++ b/auth/session_guard.go
@@ -77,16 +77,17 @@ func (r *SessionGuard) LoginUsingID(id any) (token string, err error) {
 		return "", errors.AuthInvalidKey
 	}
 
+	if err := r.session.Regenerate(true); err != nil {
+		return "", err
+	}
+
 	r.session.Put(sessionName, key)
 
 	return "", nil
 }
 
 func (r *SessionGuard) Logout() error {
-	sessionName := r.getSessionName()
-	r.session.Forget(sessionName)
-
-	return nil
+	return r.session.Invalidate()
 }
 
 func (r *SessionGuard) Parse(token string) (*contractsauth.Payload, error) {

--- a/auth/session_guard.go
+++ b/auth/session_guard.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goravel/framework/contracts/http"
 	contractsession "github.com/goravel/framework/contracts/session"
 	"github.com/goravel/framework/errors"
+	"github.com/goravel/framework/support/carbon"
 )
 
 type SessionGuard struct {
@@ -80,6 +81,7 @@ func (r *SessionGuard) LoginUsingID(id any) (token string, err error) {
 	if err := r.session.Regenerate(true); err != nil {
 		return "", err
 	}
+	r.reissueSessionCookie()
 
 	r.session.Put(sessionName, key)
 
@@ -87,7 +89,32 @@ func (r *SessionGuard) LoginUsingID(id any) (token string, err error) {
 }
 
 func (r *SessionGuard) Logout() error {
-	return r.session.Invalidate()
+	if err := r.session.Invalidate(); err != nil {
+		return err
+	}
+	r.reissueSessionCookie()
+
+	return nil
+}
+
+// reissueSessionCookie writes the current session ID to the response cookie.
+// Called after Regenerate/Invalidate so the rotated ID reaches the client
+// even on drivers that flush headers when the handler writes the body.
+func (r *SessionGuard) reissueSessionCookie() {
+	if configFacade == nil {
+		return
+	}
+
+	r.ctx.Response().Cookie(http.Cookie{
+		Name:     r.session.GetName(),
+		Value:    r.session.GetID(),
+		Expires:  carbon.Now().AddMinutes(configFacade.GetInt("session.lifetime", 120)).StdTime(),
+		Path:     configFacade.GetString("session.path"),
+		Domain:   configFacade.GetString("session.domain"),
+		Secure:   configFacade.GetBool("session.secure"),
+		HttpOnly: configFacade.GetBool("session.http_only"),
+		SameSite: configFacade.GetString("session.same_site"),
+	})
 }
 
 func (r *SessionGuard) Parse(token string) (*contractsauth.Payload, error) {

--- a/auth/session_guard.go
+++ b/auth/session_guard.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goravel/framework/contracts/http"
 	contractsession "github.com/goravel/framework/contracts/session"
 	"github.com/goravel/framework/errors"
+	"github.com/goravel/framework/session"
 )
 
 type SessionGuard struct {
@@ -82,12 +83,21 @@ func (r *SessionGuard) LoginUsingID(id any) (token string, err error) {
 	}
 
 	r.session.Put(sessionName, key)
+	session.WriteCookie(r.ctx, r.session)
 
 	return "", nil
 }
 
 func (r *SessionGuard) Logout() error {
-	return r.session.Invalidate()
+	r.session.Forget(r.getSessionName())
+
+	if err := r.session.Regenerate(true); err != nil {
+		return err
+	}
+
+	session.WriteCookie(r.ctx, r.session)
+
+	return nil
 }
 
 func (r *SessionGuard) Parse(token string) (*contractsauth.Payload, error) {

--- a/auth/session_guard_test.go
+++ b/auth/session_guard_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goravel/framework/contracts/http"
@@ -24,6 +25,7 @@ type SessionGuardTestSuite struct {
 	mockCache        *mockscache.Cache
 	mockConfig       *mocksconfig.Config
 	mockContext      http.Context
+	mockResponse     *mockshttp.ContextResponse
 	mockDB           *mocksorm.Query
 	mockLog          *mockslog.Log
 	mockUserProvider *mocksauth.UserProvider
@@ -51,8 +53,10 @@ func (s *SessionGuardTestSuite) SetupTest() {
 	mockRequest := mockshttp.NewContextRequest(s.T())
 	mockRequest.EXPECT().Session().Return(s.mockSession)
 
+	s.mockResponse = mockshttp.NewContextResponse(s.T())
 	mockContext := mockshttp.NewContext(s.T())
 	mockContext.EXPECT().Request().Return(mockRequest)
+	mockContext.EXPECT().Response().Return(s.mockResponse).Maybe()
 
 	s.mockContext = mockContext
 
@@ -108,6 +112,7 @@ func (s *SessionGuardTestSuite) TestCheck_LoginUsingID_Logout() {
 	s.True(s.sessionGuard.Guest())
 
 	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
+	s.expectReissueCookie()
 	s.mockSession.EXPECT().Put("auth_user_id", "1").Return(nil).Once()
 	token, err := s.sessionGuard.LoginUsingID(1)
 	s.Nil(err)
@@ -118,6 +123,7 @@ func (s *SessionGuardTestSuite) TestCheck_LoginUsingID_Logout() {
 	s.False(s.sessionGuard.Guest())
 
 	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
+	s.expectReissueCookie()
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -135,6 +141,7 @@ func (s *SessionGuardTestSuite) Test_Login() {
 
 	s.mockUserProvider.EXPECT().GetID(&user).Return("2", nil).Once()
 	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
+	s.expectReissueCookie()
 	s.mockSession.EXPECT().Put("auth_user_id", "2").Return(nil).Once()
 	token, err := s.sessionGuard.Login(&user)
 	s.Nil(err)
@@ -145,6 +152,7 @@ func (s *SessionGuardTestSuite) Test_Login() {
 	s.False(s.sessionGuard.Guest())
 
 	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
+	s.expectReissueCookie()
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -170,6 +178,7 @@ func (s *SessionGuardTestSuite) Test_LoginFailed() {
 	s.True(s.sessionGuard.Guest())
 
 	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
+	s.expectReissueCookie()
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -232,4 +241,37 @@ func (s *SessionGuardTestSuite) Test_Logout_InvalidateError() {
 	s.mockSession.EXPECT().Invalidate().Return(assert.AnError).Once()
 
 	s.ErrorIs(s.sessionGuard.Logout(), assert.AnError)
+}
+
+func (s *SessionGuardTestSuite) Test_LoginUsingID_ReissuesCookie() {
+	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
+	s.mockSession.EXPECT().GetName().Return("goravel_session").Once()
+	s.mockSession.EXPECT().GetID().Return("new-session-id").Once()
+	s.mockSession.EXPECT().Put("auth_user_id", "1").Return(nil).Once()
+
+	s.mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
+	s.mockConfig.EXPECT().GetString("session.path").Return("/").Once()
+	s.mockConfig.EXPECT().GetString("session.domain").Return("").Once()
+	s.mockConfig.EXPECT().GetBool("session.secure").Return(false).Once()
+	s.mockConfig.EXPECT().GetBool("session.http_only").Return(true).Once()
+	s.mockConfig.EXPECT().GetString("session.same_site").Return("").Once()
+
+	s.mockResponse.EXPECT().Cookie(mock.MatchedBy(func(c http.Cookie) bool {
+		return c.Name == "goravel_session" && c.Value == "new-session-id"
+	})).Return(s.mockResponse).Once()
+
+	_, err := s.sessionGuard.LoginUsingID(1)
+	s.Nil(err)
+}
+
+func (s *SessionGuardTestSuite) expectReissueCookie() {
+	s.mockSession.EXPECT().GetName().Return("goravel_session").Once()
+	s.mockSession.EXPECT().GetID().Return("session-id").Once()
+	s.mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
+	s.mockConfig.EXPECT().GetString("session.path").Return("/").Once()
+	s.mockConfig.EXPECT().GetString("session.domain").Return("").Once()
+	s.mockConfig.EXPECT().GetBool("session.secure").Return(false).Once()
+	s.mockConfig.EXPECT().GetBool("session.http_only").Return(true).Once()
+	s.mockConfig.EXPECT().GetString("session.same_site").Return("").Once()
+	s.mockResponse.EXPECT().Cookie(mock.Anything).Return(s.mockResponse).Once()
 }

--- a/auth/session_guard_test.go
+++ b/auth/session_guard_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goravel/framework/contracts/http"
@@ -16,7 +15,6 @@ import (
 	mockshttp "github.com/goravel/framework/mocks/http"
 	mockslog "github.com/goravel/framework/mocks/log"
 	mockssession "github.com/goravel/framework/mocks/session"
-	"github.com/goravel/framework/session"
 	"github.com/goravel/framework/support/carbon"
 )
 
@@ -26,7 +24,6 @@ type SessionGuardTestSuite struct {
 	mockCache        *mockscache.Cache
 	mockConfig       *mocksconfig.Config
 	mockContext      http.Context
-	mockResponse     *mockshttp.ContextResponse
 	mockDB           *mocksorm.Query
 	mockLog          *mockslog.Log
 	mockUserProvider *mocksauth.UserProvider
@@ -54,16 +51,13 @@ func (s *SessionGuardTestSuite) SetupTest() {
 	mockRequest := mockshttp.NewContextRequest(s.T())
 	mockRequest.EXPECT().Session().Return(s.mockSession)
 
-	s.mockResponse = mockshttp.NewContextResponse(s.T())
 	mockContext := mockshttp.NewContext(s.T())
 	mockContext.EXPECT().Request().Return(mockRequest)
-	mockContext.EXPECT().Response().Return(s.mockResponse).Maybe()
 
 	s.mockContext = mockContext
 
 	cacheFacade = s.mockCache
 	configFacade = s.mockConfig
-	session.ConfigFacade = s.mockConfig
 
 	sessionGuard, err := NewSessionGuard(s.mockContext, testUserGuard, s.mockUserProvider)
 	s.Require().Nil(err)
@@ -114,7 +108,6 @@ func (s *SessionGuardTestSuite) TestCheck_LoginUsingID_Logout() {
 	s.True(s.sessionGuard.Guest())
 
 	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
-	s.expectReissueCookie()
 	s.mockSession.EXPECT().Put("auth_user_id", "1").Return(nil).Once()
 	token, err := s.sessionGuard.LoginUsingID(1)
 	s.Nil(err)
@@ -125,7 +118,6 @@ func (s *SessionGuardTestSuite) TestCheck_LoginUsingID_Logout() {
 	s.False(s.sessionGuard.Guest())
 
 	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
-	s.expectReissueCookie()
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -143,7 +135,6 @@ func (s *SessionGuardTestSuite) Test_Login() {
 
 	s.mockUserProvider.EXPECT().GetID(&user).Return("2", nil).Once()
 	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
-	s.expectReissueCookie()
 	s.mockSession.EXPECT().Put("auth_user_id", "2").Return(nil).Once()
 	token, err := s.sessionGuard.Login(&user)
 	s.Nil(err)
@@ -154,7 +145,6 @@ func (s *SessionGuardTestSuite) Test_Login() {
 	s.False(s.sessionGuard.Guest())
 
 	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
-	s.expectReissueCookie()
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -180,7 +170,6 @@ func (s *SessionGuardTestSuite) Test_LoginFailed() {
 	s.True(s.sessionGuard.Guest())
 
 	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
-	s.expectReissueCookie()
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -243,37 +232,4 @@ func (s *SessionGuardTestSuite) Test_Logout_InvalidateError() {
 	s.mockSession.EXPECT().Invalidate().Return(assert.AnError).Once()
 
 	s.ErrorIs(s.sessionGuard.Logout(), assert.AnError)
-}
-
-func (s *SessionGuardTestSuite) Test_LoginUsingID_ReissuesCookie() {
-	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
-	s.mockSession.EXPECT().GetName().Return("goravel_session").Once()
-	s.mockSession.EXPECT().GetID().Return("new-session-id").Once()
-	s.mockSession.EXPECT().Put("auth_user_id", "1").Return(nil).Once()
-
-	s.mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
-	s.mockConfig.EXPECT().GetString("session.path").Return("/").Once()
-	s.mockConfig.EXPECT().GetString("session.domain").Return("").Once()
-	s.mockConfig.EXPECT().GetBool("session.secure").Return(false).Once()
-	s.mockConfig.EXPECT().GetBool("session.http_only").Return(true).Once()
-	s.mockConfig.EXPECT().GetString("session.same_site").Return("").Once()
-
-	s.mockResponse.EXPECT().Cookie(mock.MatchedBy(func(c http.Cookie) bool {
-		return c.Name == "goravel_session" && c.Value == "new-session-id"
-	})).Return(s.mockResponse).Once()
-
-	_, err := s.sessionGuard.LoginUsingID(1)
-	s.Nil(err)
-}
-
-func (s *SessionGuardTestSuite) expectReissueCookie() {
-	s.mockSession.EXPECT().GetName().Return("goravel_session").Once()
-	s.mockSession.EXPECT().GetID().Return("session-id").Once()
-	s.mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
-	s.mockConfig.EXPECT().GetString("session.path").Return("/").Once()
-	s.mockConfig.EXPECT().GetString("session.domain").Return("").Once()
-	s.mockConfig.EXPECT().GetBool("session.secure").Return(false).Once()
-	s.mockConfig.EXPECT().GetBool("session.http_only").Return(true).Once()
-	s.mockConfig.EXPECT().GetString("session.same_site").Return("").Once()
-	s.mockResponse.EXPECT().Cookie(mock.Anything).Return(s.mockResponse).Once()
 }

--- a/auth/session_guard_test.go
+++ b/auth/session_guard_test.go
@@ -220,7 +220,7 @@ func (s *SessionGuardTestSuite) Test_InvalidKey() {
 	s.ErrorIs(err, errors.AuthInvalidKey)
 }
 
-func (s *SessionGuardTestSuite) TestLoginUsingID_RegenerateError() {
+func (s *SessionGuardTestSuite) Test_LoginUsingID_RegenerateError() {
 	s.mockSession.EXPECT().Regenerate(true).Return(assert.AnError).Once()
 
 	token, err := s.sessionGuard.LoginUsingID(1)
@@ -228,7 +228,7 @@ func (s *SessionGuardTestSuite) TestLoginUsingID_RegenerateError() {
 	s.ErrorIs(err, assert.AnError)
 }
 
-func (s *SessionGuardTestSuite) TestLogout_InvalidateError() {
+func (s *SessionGuardTestSuite) Test_Logout_InvalidateError() {
 	s.mockSession.EXPECT().Invalidate().Return(assert.AnError).Once()
 
 	s.ErrorIs(s.sessionGuard.Logout(), assert.AnError)

--- a/auth/session_guard_test.go
+++ b/auth/session_guard_test.go
@@ -107,6 +107,7 @@ func (s *SessionGuardTestSuite) TestCheck_LoginUsingID_Logout() {
 	s.False(s.sessionGuard.Check())
 	s.True(s.sessionGuard.Guest())
 
+	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
 	s.mockSession.EXPECT().Put("auth_user_id", "1").Return(nil).Once()
 	token, err := s.sessionGuard.LoginUsingID(1)
 	s.Nil(err)
@@ -116,7 +117,7 @@ func (s *SessionGuardTestSuite) TestCheck_LoginUsingID_Logout() {
 	s.True(s.sessionGuard.Check())
 	s.False(s.sessionGuard.Guest())
 
-	s.mockSession.EXPECT().Forget("auth_user_id").Return(nil).Once()
+	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -133,6 +134,7 @@ func (s *SessionGuardTestSuite) Test_Login() {
 	user.Name = "Goravel"
 
 	s.mockUserProvider.EXPECT().GetID(&user).Return("2", nil).Once()
+	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
 	s.mockSession.EXPECT().Put("auth_user_id", "2").Return(nil).Once()
 	token, err := s.sessionGuard.Login(&user)
 	s.Nil(err)
@@ -142,7 +144,7 @@ func (s *SessionGuardTestSuite) Test_Login() {
 	s.True(s.sessionGuard.Check())
 	s.False(s.sessionGuard.Guest())
 
-	s.mockSession.EXPECT().Forget("auth_user_id").Return(nil).Once()
+	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -167,7 +169,7 @@ func (s *SessionGuardTestSuite) Test_LoginFailed() {
 	s.False(s.sessionGuard.Check())
 	s.True(s.sessionGuard.Guest())
 
-	s.mockSession.EXPECT().Forget("auth_user_id").Return(nil).Once()
+	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -216,4 +218,18 @@ func (s *SessionGuardTestSuite) Test_InvalidKey() {
 
 	s.NotNil(err)
 	s.ErrorIs(err, errors.AuthInvalidKey)
+}
+
+func (s *SessionGuardTestSuite) TestLoginUsingID_RegenerateError() {
+	s.mockSession.EXPECT().Regenerate(true).Return(assert.AnError).Once()
+
+	token, err := s.sessionGuard.LoginUsingID(1)
+	s.Empty(token)
+	s.ErrorIs(err, assert.AnError)
+}
+
+func (s *SessionGuardTestSuite) TestLogout_InvalidateError() {
+	s.mockSession.EXPECT().Invalidate().Return(assert.AnError).Once()
+
+	s.ErrorIs(s.sessionGuard.Logout(), assert.AnError)
 }

--- a/auth/session_guard_test.go
+++ b/auth/session_guard_test.go
@@ -16,6 +16,7 @@ import (
 	mockshttp "github.com/goravel/framework/mocks/http"
 	mockslog "github.com/goravel/framework/mocks/log"
 	mockssession "github.com/goravel/framework/mocks/session"
+	"github.com/goravel/framework/session"
 	"github.com/goravel/framework/support/carbon"
 )
 
@@ -62,6 +63,7 @@ func (s *SessionGuardTestSuite) SetupTest() {
 
 	cacheFacade = s.mockCache
 	configFacade = s.mockConfig
+	session.ConfigFacade = s.mockConfig
 
 	sessionGuard, err := NewSessionGuard(s.mockContext, testUserGuard, s.mockUserProvider)
 	s.Require().Nil(err)

--- a/auth/session_guard_test.go
+++ b/auth/session_guard_test.go
@@ -59,7 +59,12 @@ func (s *SessionGuardTestSuite) SetupTest() {
 
 	cacheFacade = s.mockCache
 	configFacade = s.mockConfig
+
+	originConfigFacade := session.ConfigFacade
 	session.ConfigFacade = s.mockConfig
+	s.T().Cleanup(func() {
+		session.ConfigFacade = originConfigFacade
+	})
 
 	sessionGuard, err := NewSessionGuard(s.mockContext, testUserGuard, s.mockUserProvider)
 	s.Require().Nil(err)

--- a/auth/session_guard_test.go
+++ b/auth/session_guard_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/errors"
 	mocksauth "github.com/goravel/framework/mocks/auth"
@@ -21,15 +22,16 @@ import (
 
 type SessionGuardTestSuite struct {
 	suite.Suite
-	sessionGuard     *SessionGuard
-	mockCache        *mockscache.Cache
-	mockConfig       *mocksconfig.Config
-	mockContext      *mockshttp.Context
-	mockDB           *mocksorm.Query
-	mockLog          *mockslog.Log
-	mockUserProvider *mocksauth.UserProvider
-	mockSession      *mockssession.Session
-	now              *carbon.Carbon
+	sessionGuard       *SessionGuard
+	mockCache          *mockscache.Cache
+	mockConfig         *mocksconfig.Config
+	mockContext        *mockshttp.Context
+	mockDB             *mocksorm.Query
+	mockLog            *mockslog.Log
+	mockUserProvider   *mocksauth.UserProvider
+	mockSession        *mockssession.Session
+	now                *carbon.Carbon
+	originConfigFacade config.Config
 }
 
 func TestSessionGuardTestSuite(t *testing.T) {
@@ -38,6 +40,10 @@ func TestSessionGuardTestSuite(t *testing.T) {
 
 func (s *SessionGuardTestSuite) TearDownSuite() {
 	carbon.ClearTestNow()
+}
+
+func (s *SessionGuardTestSuite) TearDownTest() {
+	session.ConfigFacade = s.originConfigFacade
 }
 
 func (s *SessionGuardTestSuite) SetupTest() {
@@ -60,11 +66,8 @@ func (s *SessionGuardTestSuite) SetupTest() {
 	cacheFacade = s.mockCache
 	configFacade = s.mockConfig
 
-	originConfigFacade := session.ConfigFacade
+	s.originConfigFacade = session.ConfigFacade
 	session.ConfigFacade = s.mockConfig
-	s.T().Cleanup(func() {
-		session.ConfigFacade = originConfigFacade
-	})
 
 	sessionGuard, err := NewSessionGuard(s.mockContext, testUserGuard, s.mockUserProvider)
 	s.Require().Nil(err)

--- a/auth/session_guard_test.go
+++ b/auth/session_guard_test.go
@@ -15,6 +15,7 @@ import (
 	mockshttp "github.com/goravel/framework/mocks/http"
 	mockslog "github.com/goravel/framework/mocks/log"
 	mockssession "github.com/goravel/framework/mocks/session"
+	"github.com/goravel/framework/session"
 	"github.com/goravel/framework/support/carbon"
 )
 
@@ -23,7 +24,7 @@ type SessionGuardTestSuite struct {
 	sessionGuard     *SessionGuard
 	mockCache        *mockscache.Cache
 	mockConfig       *mocksconfig.Config
-	mockContext      http.Context
+	mockContext      *mockshttp.Context
 	mockDB           *mocksorm.Query
 	mockLog          *mockslog.Log
 	mockUserProvider *mocksauth.UserProvider
@@ -58,6 +59,7 @@ func (s *SessionGuardTestSuite) SetupTest() {
 
 	cacheFacade = s.mockCache
 	configFacade = s.mockConfig
+	session.ConfigFacade = s.mockConfig
 
 	sessionGuard, err := NewSessionGuard(s.mockContext, testUserGuard, s.mockUserProvider)
 	s.Require().Nil(err)
@@ -66,6 +68,27 @@ func (s *SessionGuardTestSuite) SetupTest() {
 	carbon.SetTestNow(now)
 	s.now = now
 	s.sessionGuard = sessionGuard.(*SessionGuard)
+}
+
+func (s *SessionGuardTestSuite) expectWriteCookie(id string) {
+	s.mockSession.EXPECT().GetName().Return("goravel_session").Once()
+	s.mockSession.EXPECT().GetID().Return(id).Once()
+	s.mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
+	s.mockConfig.EXPECT().GetString("session.path").Return("/").Once()
+	s.mockConfig.EXPECT().GetString("session.domain").Return("").Once()
+	s.mockConfig.EXPECT().GetBool("session.secure").Return(false).Once()
+	s.mockConfig.EXPECT().GetBool("session.http_only").Return(true).Once()
+	s.mockConfig.EXPECT().GetString("session.same_site").Return("").Once()
+
+	mockResponse := mockshttp.NewContextResponse(s.T())
+	mockResponse.EXPECT().Cookie(http.Cookie{
+		Name:     "goravel_session",
+		Value:    id,
+		Expires:  s.now.Copy().AddMinutes(120).StdTime(),
+		Path:     "/",
+		HttpOnly: true,
+	}).Return(mockResponse).Once()
+	s.mockContext.EXPECT().Response().Return(mockResponse).Once()
 }
 
 func (s *SessionGuardTestSuite) TestNewSessionGuard() {
@@ -109,6 +132,7 @@ func (s *SessionGuardTestSuite) TestCheck_LoginUsingID_Logout() {
 
 	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
 	s.mockSession.EXPECT().Put("auth_user_id", "1").Return(nil).Once()
+	s.expectWriteCookie("login-session-id")
 	token, err := s.sessionGuard.LoginUsingID(1)
 	s.Nil(err)
 	s.Empty(token)
@@ -117,7 +141,9 @@ func (s *SessionGuardTestSuite) TestCheck_LoginUsingID_Logout() {
 	s.True(s.sessionGuard.Check())
 	s.False(s.sessionGuard.Guest())
 
-	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
+	s.mockSession.EXPECT().Forget("auth_user_id").Return(nil).Once()
+	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
+	s.expectWriteCookie("logout-session-id")
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -136,6 +162,7 @@ func (s *SessionGuardTestSuite) Test_Login() {
 	s.mockUserProvider.EXPECT().GetID(&user).Return("2", nil).Once()
 	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
 	s.mockSession.EXPECT().Put("auth_user_id", "2").Return(nil).Once()
+	s.expectWriteCookie("login-session-id")
 	token, err := s.sessionGuard.Login(&user)
 	s.Nil(err)
 	s.Empty(token)
@@ -144,7 +171,9 @@ func (s *SessionGuardTestSuite) Test_Login() {
 	s.True(s.sessionGuard.Check())
 	s.False(s.sessionGuard.Guest())
 
-	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
+	s.mockSession.EXPECT().Forget("auth_user_id").Return(nil).Once()
+	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
+	s.expectWriteCookie("logout-session-id")
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -169,7 +198,9 @@ func (s *SessionGuardTestSuite) Test_LoginFailed() {
 	s.False(s.sessionGuard.Check())
 	s.True(s.sessionGuard.Guest())
 
-	s.mockSession.EXPECT().Invalidate().Return(nil).Once()
+	s.mockSession.EXPECT().Forget("auth_user_id").Return(nil).Once()
+	s.mockSession.EXPECT().Regenerate(true).Return(nil).Once()
+	s.expectWriteCookie("logout-session-id")
 	s.NoError(s.sessionGuard.Logout())
 
 	s.mockSession.EXPECT().Get("auth_user_id", nil).Return(nil).Once()
@@ -228,8 +259,9 @@ func (s *SessionGuardTestSuite) Test_LoginUsingID_RegenerateError() {
 	s.ErrorIs(err, assert.AnError)
 }
 
-func (s *SessionGuardTestSuite) Test_Logout_InvalidateError() {
-	s.mockSession.EXPECT().Invalidate().Return(assert.AnError).Once()
+func (s *SessionGuardTestSuite) Test_Logout_RegenerateError() {
+	s.mockSession.EXPECT().Forget("auth_user_id").Return(nil).Once()
+	s.mockSession.EXPECT().Regenerate(true).Return(assert.AnError).Once()
 
 	s.ErrorIs(s.sessionGuard.Logout(), assert.AnError)
 }

--- a/session/cookie.go
+++ b/session/cookie.go
@@ -6,11 +6,13 @@ import (
 )
 
 // WriteCookie emits the current session ID as a Set-Cookie header on the
-// response. Shared between StartSession middleware and guards that rotate
-// the session ID mid-request so the cookie attributes and config keys
-// live in one place. Safe to call with a partially initialised context —
-// returns without effect if the context, response, session, or config
-// facade is nil.
+// response, using the standard session.* config keys for cookie
+// attributes. The StartSession middleware uses it to issue the session
+// cookie, and application code can call it after rotating the session
+// ID (for example, after auth.Login or auth.Logout) so the rotated ID
+// reaches the client. Safe to call with a partially initialised
+// context — returns without effect if the context, response, session,
+// or config facade is nil.
 func WriteCookie(ctx http.Context) {
 	if ctx == nil || ConfigFacade == nil {
 		return

--- a/session/cookie.go
+++ b/session/cookie.go
@@ -1,0 +1,41 @@
+package session
+
+import (
+	"github.com/goravel/framework/contracts/http"
+	"github.com/goravel/framework/support/carbon"
+)
+
+// WriteCookie emits the current session ID as a Set-Cookie header on the
+// response. Shared between StartSession middleware and guards that rotate
+// the session ID mid-request so the cookie attributes and config keys
+// live in one place. Safe to call with a partially initialised context —
+// returns without effect if the context, response, session, or config
+// facade is nil.
+func WriteCookie(ctx http.Context) {
+	if ctx == nil || ConfigFacade == nil {
+		return
+	}
+	req := ctx.Request()
+	if req == nil {
+		return
+	}
+	s := req.Session()
+	if s == nil {
+		return
+	}
+	resp := ctx.Response()
+	if resp == nil {
+		return
+	}
+
+	resp.Cookie(http.Cookie{
+		Name:     s.GetName(),
+		Value:    s.GetID(),
+		Expires:  carbon.Now().AddMinutes(ConfigFacade.GetInt("session.lifetime", 120)).StdTime(),
+		Path:     ConfigFacade.GetString("session.path"),
+		Domain:   ConfigFacade.GetString("session.domain"),
+		Secure:   ConfigFacade.GetBool("session.secure"),
+		HttpOnly: ConfigFacade.GetBool("session.http_only"),
+		SameSite: ConfigFacade.GetString("session.same_site"),
+	})
+}

--- a/session/cookie.go
+++ b/session/cookie.go
@@ -2,37 +2,17 @@ package session
 
 import (
 	"github.com/goravel/framework/contracts/http"
+	sessioncontract "github.com/goravel/framework/contracts/session"
 	"github.com/goravel/framework/support/carbon"
 )
 
-// WriteCookie emits the current session ID as a Set-Cookie header on the
-// response, using the standard session.* config keys for cookie
-// attributes. The StartSession middleware uses it to issue the session
-// cookie, and application code can call it after rotating the session
-// ID (for example, after auth.Login or auth.Logout) so the rotated ID
-// reaches the client. Safe to call with a partially initialised
-// context — returns without effect if the context, response, session,
-// or config facade is nil.
-func WriteCookie(ctx http.Context) {
-	if ctx == nil || ConfigFacade == nil {
-		return
-	}
-	req := ctx.Request()
-	if req == nil {
-		return
-	}
-	s := req.Session()
-	if s == nil {
-		return
-	}
-	resp := ctx.Response()
-	if resp == nil {
-		return
-	}
-
-	resp.Cookie(http.Cookie{
-		Name:     s.GetName(),
-		Value:    s.GetID(),
+// WriteCookie sends the session ID to the client as a cookie. Call it again
+// after rotating the session ID (e.g. Regenerate or Invalidate) so the new ID
+// reaches the client; the response may already carry a cookie with the stale ID.
+func WriteCookie(ctx http.Context, session sessioncontract.Session) {
+	ctx.Response().Cookie(http.Cookie{
+		Name:     session.GetName(),
+		Value:    session.GetID(),
 		Expires:  carbon.Now().AddMinutes(ConfigFacade.GetInt("session.lifetime", 120)).StdTime(),
 		Path:     ConfigFacade.GetString("session.path"),
 		Domain:   ConfigFacade.GetString("session.domain"),

--- a/session/cookie_test.go
+++ b/session/cookie_test.go
@@ -1,0 +1,47 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/goravel/framework/contracts/http"
+	mocksconfig "github.com/goravel/framework/mocks/config"
+	mockshttp "github.com/goravel/framework/mocks/http"
+	mockssession "github.com/goravel/framework/mocks/session"
+	"github.com/goravel/framework/support/carbon"
+)
+
+func TestWriteCookie(t *testing.T) {
+	now := carbon.Now()
+	carbon.SetTestNow(now)
+	defer carbon.ClearTestNow()
+
+	mockConfig := mocksconfig.NewConfig(t)
+	mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
+	mockConfig.EXPECT().GetString("session.path").Return("/").Once()
+	mockConfig.EXPECT().GetString("session.domain").Return("example.com").Once()
+	mockConfig.EXPECT().GetBool("session.secure").Return(true).Once()
+	mockConfig.EXPECT().GetBool("session.http_only").Return(true).Once()
+	mockConfig.EXPECT().GetString("session.same_site").Return("lax").Once()
+	ConfigFacade = mockConfig
+
+	mockSession := mockssession.NewSession(t)
+	mockSession.EXPECT().GetName().Return("goravel_session").Once()
+	mockSession.EXPECT().GetID().Return("session-id").Once()
+
+	mockResponse := mockshttp.NewContextResponse(t)
+	mockResponse.EXPECT().Cookie(http.Cookie{
+		Name:     "goravel_session",
+		Value:    "session-id",
+		Expires:  now.Copy().AddMinutes(120).StdTime(),
+		Path:     "/",
+		Domain:   "example.com",
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: "lax",
+	}).Return(mockResponse).Once()
+
+	mockContext := mockshttp.NewContext(t)
+	mockContext.EXPECT().Response().Return(mockResponse).Once()
+
+	WriteCookie(mockContext, mockSession)
+}

--- a/session/cookie_test.go
+++ b/session/cookie_test.go
@@ -15,11 +15,12 @@ func TestWriteCookie(t *testing.T) {
 	carbon.SetTestNow(now)
 	defer carbon.ClearTestNow()
 
-	mockConfig := mocksconfig.NewConfig(t)
 	originConfigFacade := ConfigFacade
-	t.Cleanup(func() {
+	defer func() {
 		ConfigFacade = originConfigFacade
-	})
+	}()
+
+	mockConfig := mocksconfig.NewConfig(t)
 	mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
 	mockConfig.EXPECT().GetString("session.path").Return("/").Once()
 	mockConfig.EXPECT().GetString("session.domain").Return("example.com").Once()

--- a/session/cookie_test.go
+++ b/session/cookie_test.go
@@ -16,6 +16,10 @@ func TestWriteCookie(t *testing.T) {
 	defer carbon.ClearTestNow()
 
 	mockConfig := mocksconfig.NewConfig(t)
+	originConfigFacade := ConfigFacade
+	t.Cleanup(func() {
+		ConfigFacade = originConfigFacade
+	})
 	mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
 	mockConfig.EXPECT().GetString("session.path").Return("/").Once()
 	mockConfig.EXPECT().GetString("session.domain").Return("example.com").Once()

--- a/session/middleware/start_session.go
+++ b/session/middleware/start_session.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/session"
-	"github.com/goravel/framework/support/carbon"
 	"github.com/goravel/framework/support/color"
 )
 
@@ -45,17 +44,7 @@ func StartSession() http.Middleware {
 		// logout) reissue the cookie themselves, so this avoids emitting a
 		// duplicate Set-Cookie header in that flow.
 		if incomingCookie != s.GetID() {
-			config := session.ConfigFacade
-			ctx.Response().Cookie(http.Cookie{
-				Name:     s.GetName(),
-				Value:    s.GetID(),
-				Expires:  carbon.Now().AddMinutes(config.GetInt("session.lifetime", 120)).StdTime(),
-				Path:     config.GetString("session.path"),
-				Domain:   config.GetString("session.domain"),
-				Secure:   config.GetBool("session.secure"),
-				HttpOnly: config.GetBool("session.http_only"),
-				SameSite: config.GetString("session.same_site"),
-			})
+			session.WriteCookie(ctx)
 		}
 
 		// Continue processing request

--- a/session/middleware/start_session.go
+++ b/session/middleware/start_session.go
@@ -39,7 +39,11 @@ func StartSession() http.Middleware {
 		s.Start()
 		req.SetSession(s)
 
-		// Set session cookie in response
+		// Continue processing request
+		req.Next()
+
+		// Set session cookie in response using the current (post-handler)
+		// session ID so rotations via Regenerate/Invalidate reach the client.
 		config := session.ConfigFacade
 		ctx.Response().Cookie(http.Cookie{
 			Name:     s.GetName(),
@@ -51,9 +55,6 @@ func StartSession() http.Middleware {
 			HttpOnly: config.GetBool("session.http_only"),
 			SameSite: config.GetString("session.same_site"),
 		})
-
-		// Continue processing request
-		req.Next()
 
 		// Save session
 		if err = s.Save(); err != nil {

--- a/session/middleware/start_session.go
+++ b/session/middleware/start_session.go
@@ -32,20 +32,14 @@ func StartSession() http.Middleware {
 			return
 		}
 
-		incomingCookie := req.Cookie(s.GetName())
-		s.SetID(incomingCookie)
+		s.SetID(req.Cookie(s.GetName()))
 
 		// Start session
 		s.Start()
 		req.SetSession(s)
 
-		// Only write the session cookie when the client doesn't already have
-		// a matching one. Rotations triggered in the handler (e.g. login /
-		// logout) reissue the cookie themselves, so this avoids emitting a
-		// duplicate Set-Cookie header in that flow.
-		if incomingCookie != s.GetID() {
-			session.WriteCookie(ctx)
-		}
+		// Set session cookie in response
+		session.WriteCookie(ctx)
 
 		// Continue processing request
 		req.Next()

--- a/session/middleware/start_session.go
+++ b/session/middleware/start_session.go
@@ -39,11 +39,7 @@ func StartSession() http.Middleware {
 		s.Start()
 		req.SetSession(s)
 
-		// Continue processing request
-		req.Next()
-
-		// Set session cookie in response using the current (post-handler)
-		// session ID so rotations via Regenerate/Invalidate reach the client.
+		// Set session cookie in response
 		config := session.ConfigFacade
 		ctx.Response().Cookie(http.Cookie{
 			Name:     s.GetName(),
@@ -55,6 +51,9 @@ func StartSession() http.Middleware {
 			HttpOnly: config.GetBool("session.http_only"),
 			SameSite: config.GetString("session.same_site"),
 		})
+
+		// Continue processing request
+		req.Next()
 
 		// Save session
 		if err = s.Save(); err != nil {

--- a/session/middleware/start_session.go
+++ b/session/middleware/start_session.go
@@ -33,24 +33,30 @@ func StartSession() http.Middleware {
 			return
 		}
 
-		s.SetID(req.Cookie(s.GetName()))
+		incomingCookie := req.Cookie(s.GetName())
+		s.SetID(incomingCookie)
 
 		// Start session
 		s.Start()
 		req.SetSession(s)
 
-		// Set session cookie in response
-		config := session.ConfigFacade
-		ctx.Response().Cookie(http.Cookie{
-			Name:     s.GetName(),
-			Value:    s.GetID(),
-			Expires:  carbon.Now().AddMinutes(config.GetInt("session.lifetime", 120)).StdTime(),
-			Path:     config.GetString("session.path"),
-			Domain:   config.GetString("session.domain"),
-			Secure:   config.GetBool("session.secure"),
-			HttpOnly: config.GetBool("session.http_only"),
-			SameSite: config.GetString("session.same_site"),
-		})
+		// Only write the session cookie when the client doesn't already have
+		// a matching one. Rotations triggered in the handler (e.g. login /
+		// logout) reissue the cookie themselves, so this avoids emitting a
+		// duplicate Set-Cookie header in that flow.
+		if incomingCookie != s.GetID() {
+			config := session.ConfigFacade
+			ctx.Response().Cookie(http.Cookie{
+				Name:     s.GetName(),
+				Value:    s.GetID(),
+				Expires:  carbon.Now().AddMinutes(config.GetInt("session.lifetime", 120)).StdTime(),
+				Path:     config.GetString("session.path"),
+				Domain:   config.GetString("session.domain"),
+				Secure:   config.GetBool("session.secure"),
+				HttpOnly: config.GetBool("session.http_only"),
+				SameSite: config.GetString("session.same_site"),
+			})
+		}
 
 		// Continue processing request
 		req.Next()

--- a/session/middleware/start_session.go
+++ b/session/middleware/start_session.go
@@ -39,7 +39,7 @@ func StartSession() http.Middleware {
 		req.SetSession(s)
 
 		// Set session cookie in response
-		session.WriteCookie(ctx)
+		session.WriteCookie(ctx, s)
 
 		// Continue processing request
 		req.Next()

--- a/session/middleware/start_session_test.go
+++ b/session/middleware/start_session_test.go
@@ -82,6 +82,38 @@ func TestStartSession(t *testing.T) {
 	assert.NoError(t, file.Remove("storage"))
 }
 
+func TestStartSession_RegenerateReachesClient(t *testing.T) {
+	mockConfig := configmocks.NewConfig(t)
+	session.ConfigFacade = mockConfig
+	mockConfig.EXPECT().GetString("session.default", "file").Return("file").Once()
+	mockConfig.EXPECT().GetString("session.drivers.file.driver").Return("file").Once()
+	mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
+	mockConfig.EXPECT().GetInt("session.gc_interval", 30).Return(30).Once()
+	mockConfig.EXPECT().GetString("session.files").Return(path.Storage("framework/sessions")).Once()
+	mockConfig.EXPECT().GetString("session.cookie").Return("goravel_session").Once()
+
+	session.SessionFacade = session.NewManager(mockConfig, json.New())
+
+	var preID, postID string
+	server := httptest.NewServer(testHttpSessionMiddleware(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+		s := r.Context().Value("session").(contractsession.Session)
+		preID = s.GetID()
+		require.NoError(t, s.Regenerate(true))
+		postID = s.GetID()
+	}), mockConfig))
+	defer server.Close()
+
+	resp, err := (&nethttp.Client{}).Get(server.URL + "/login")
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Cookies())
+
+	cookie := resp.Cookies()[0]
+	assert.NotEqual(t, preID, postID)
+	assert.Equal(t, postID, cookie.Value)
+
+	assert.NoError(t, file.Remove("storage"))
+}
+
 type TestContext struct {
 	ctx     context.Context
 	next    nethttp.Handler

--- a/session/middleware/start_session_test.go
+++ b/session/middleware/start_session_test.go
@@ -28,13 +28,15 @@ func testHttpSessionMiddleware(next nethttp.Handler, mockConfig *configmocks.Con
 }
 
 func mockConfigFacade(mockConfig *configmocks.Config) {
-	mockConfig.On("GetString", "session.default").Return("file").Once()
-	mockConfig.On("GetInt", "session.lifetime", 120).Return(120).Once()
-	mockConfig.On("GetString", "session.path").Return("/").Once()
-	mockConfig.On("GetString", "session.domain").Return("").Once()
-	mockConfig.On("GetBool", "session.secure").Return(false).Once()
-	mockConfig.On("GetBool", "session.http_only").Return(true).Once()
-	mockConfig.On("GetString", "session.same_site").Return("").Once()
+	mockConfig.EXPECT().GetString("session.default").Return("file").Once()
+	// Cookie-related reads only happen when the middleware emits a new
+	// Set-Cookie (no matching incoming cookie), so mark them optional.
+	mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Maybe()
+	mockConfig.EXPECT().GetString("session.path").Return("/").Maybe()
+	mockConfig.EXPECT().GetString("session.domain").Return("").Maybe()
+	mockConfig.EXPECT().GetBool("session.secure").Return(false).Maybe()
+	mockConfig.EXPECT().GetBool("session.http_only").Return(true).Maybe()
+	mockConfig.EXPECT().GetString("session.same_site").Return("").Maybe()
 }
 
 func TestStartSession(t *testing.T) {
@@ -76,8 +78,10 @@ func TestStartSession(t *testing.T) {
 
 	resp, err = client.Do(req)
 	require.NoError(t, err)
-	assert.Equal(t, cookie.Name, resp.Cookies()[0].Name)
-	assert.Equal(t, cookie.Value, resp.Cookies()[0].Value)
+	// Incoming cookie already matches the loaded session ID — middleware
+	// skips emitting another Set-Cookie to avoid duplicating the header
+	// produced by any in-handler rotation.
+	assert.Empty(t, resp.Cookies())
 
 	assert.NoError(t, file.Remove("storage"))
 }

--- a/session/middleware/start_session_test.go
+++ b/session/middleware/start_session_test.go
@@ -82,38 +82,6 @@ func TestStartSession(t *testing.T) {
 	assert.NoError(t, file.Remove("storage"))
 }
 
-func TestStartSession_RegenerateReachesClient(t *testing.T) {
-	mockConfig := configmocks.NewConfig(t)
-	session.ConfigFacade = mockConfig
-	mockConfig.EXPECT().GetString("session.default", "file").Return("file").Once()
-	mockConfig.EXPECT().GetString("session.drivers.file.driver").Return("file").Once()
-	mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
-	mockConfig.EXPECT().GetInt("session.gc_interval", 30).Return(30).Once()
-	mockConfig.EXPECT().GetString("session.files").Return(path.Storage("framework/sessions")).Once()
-	mockConfig.EXPECT().GetString("session.cookie").Return("goravel_session").Once()
-
-	session.SessionFacade = session.NewManager(mockConfig, json.New())
-
-	var preID, postID string
-	server := httptest.NewServer(testHttpSessionMiddleware(nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
-		s := r.Context().Value("session").(contractsession.Session)
-		preID = s.GetID()
-		require.NoError(t, s.Regenerate(true))
-		postID = s.GetID()
-	}), mockConfig))
-	defer server.Close()
-
-	resp, err := (&nethttp.Client{}).Get(server.URL + "/login")
-	require.NoError(t, err)
-	require.NotEmpty(t, resp.Cookies())
-
-	cookie := resp.Cookies()[0]
-	assert.NotEqual(t, preID, postID)
-	assert.Equal(t, postID, cookie.Value)
-
-	assert.NoError(t, file.Remove("storage"))
-}
-
 type TestContext struct {
 	ctx     context.Context
 	next    nethttp.Handler

--- a/session/middleware/start_session_test.go
+++ b/session/middleware/start_session_test.go
@@ -29,14 +29,12 @@ func testHttpSessionMiddleware(next nethttp.Handler, mockConfig *configmocks.Con
 
 func mockConfigFacade(mockConfig *configmocks.Config) {
 	mockConfig.EXPECT().GetString("session.default").Return("file").Once()
-	// Cookie-related reads only happen when the middleware emits a new
-	// Set-Cookie (no matching incoming cookie), so mark them optional.
-	mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Maybe()
-	mockConfig.EXPECT().GetString("session.path").Return("/").Maybe()
-	mockConfig.EXPECT().GetString("session.domain").Return("").Maybe()
-	mockConfig.EXPECT().GetBool("session.secure").Return(false).Maybe()
-	mockConfig.EXPECT().GetBool("session.http_only").Return(true).Maybe()
-	mockConfig.EXPECT().GetString("session.same_site").Return("").Maybe()
+	mockConfig.EXPECT().GetInt("session.lifetime", 120).Return(120).Once()
+	mockConfig.EXPECT().GetString("session.path").Return("/").Once()
+	mockConfig.EXPECT().GetString("session.domain").Return("").Once()
+	mockConfig.EXPECT().GetBool("session.secure").Return(false).Once()
+	mockConfig.EXPECT().GetBool("session.http_only").Return(true).Once()
+	mockConfig.EXPECT().GetString("session.same_site").Return("").Once()
 }
 
 func TestStartSession(t *testing.T) {
@@ -78,10 +76,8 @@ func TestStartSession(t *testing.T) {
 
 	resp, err = client.Do(req)
 	require.NoError(t, err)
-	// Incoming cookie already matches the loaded session ID — middleware
-	// skips emitting another Set-Cookie to avoid duplicating the header
-	// produced by any in-handler rotation.
-	assert.Empty(t, resp.Cookies())
+	assert.Equal(t, cookie.Name, resp.Cookies()[0].Name)
+	assert.Equal(t, cookie.Value, resp.Cookies()[0].Value)
 
 	assert.NoError(t, file.Remove("storage"))
 }


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/925

Session-based auth kept the same session ID across login/logout boundaries, leaving apps open to session fixation.

### What changed

- `SessionGuard.LoginUsingID` now calls `Session.Regenerate(true)` before storing the auth key, destroying the pre-auth session record and issuing a fresh ID (same as Laravel's `SessionGuard::updateSession`).
- `SessionGuard.Logout` forgets the guard's auth key and then rotates with `Regenerate(true)`. It deliberately does **not** use `Invalidate()`: invalidating flushes the whole session, which would also log out other guards sharing the session and wipe unrelated state (flash messages, locale). Forget + destructive regenerate kills the old session ID just the same, without the collateral damage.
- The session cookie is re-issued at rotation time via a shared `session.WriteCookie(ctx, session)` helper (also used by the `StartSession` middleware). This is required for correctness: the middleware writes the cookie **before** `req.Next()`, and on the gin driver the response is rendered inside the innermost handler — by the time middleware code after `Next()` runs, headers are already flushed. Without re-issuing during the handler, the rotated ID would never reach the client and every login would effectively end the session. Browsers take the last `Set-Cookie` for the same name, so the rotated cookie wins over the one the middleware wrote earlier.

@coderabbitai summary

## ✅ Checks

- [x] Added test cases for my code
