### PR TITLE
feat(ai): add default agent middleware

### DIFF
--- a/ai/application.go
+++ b/ai/application.go
@@ -40,7 +40,7 @@ func (r *Application) Agent(agent contractsai.Agent, options ...contractsai.Opti
 	}
 
 	model := opts.Model
-	middlewares := slices.Clone(opts.Middlewares)
+	middlewares := append(slices.Clone(agent.Middleware()), opts.Middlewares...)
 
 	return NewConversation(r.ctx, agent, provider, model, middlewares), nil
 }

--- a/ai/application_test.go
+++ b/ai/application_test.go
@@ -95,6 +95,7 @@ func TestApplication_Agent(t *testing.T) {
 			config, provider := tt.setupConfig(t)
 			agent := mocksai.NewAgent(t)
 			agent.EXPECT().Messages().Return(nil).Once()
+			agent.EXPECT().Middleware().Return(nil).Once()
 
 			app := NewApplication(ctx, config)
 			conv, err := app.Agent(agent, tt.options...)
@@ -187,6 +188,7 @@ func TestApplication_Agent_WithMiddleware(t *testing.T) {
 	}
 	mockAgent := mocksai.NewAgent(t)
 	mockAgent.EXPECT().Messages().Return(nil).Once()
+	mockAgent.EXPECT().Middleware().Return(nil).Once()
 	mockAgent.EXPECT().Tools().Return(nil).Once()
 
 	middleware := &applicationTestMiddleware{}
@@ -205,6 +207,66 @@ func TestApplication_Agent_WithMiddleware(t *testing.T) {
 	resp, err := conv.Prompt("hello")
 	assert.NoError(t, err)
 	assert.Equal(t, "before middleware after middleware", resp.Text())
+}
+
+func TestApplication_Agent_WithDefaultMiddleware(t *testing.T) {
+	ctx := context.Background()
+	mockProvider := mocksai.NewProvider(t)
+	config := contractsai.Config{
+		Default: "default",
+		Providers: map[string]contractsai.ProviderConfig{
+			"default": {Via: mockProvider},
+		},
+	}
+	mockAgent := mocksai.NewAgent(t)
+	mockAgent.EXPECT().Messages().Return(nil).Once()
+	mockAgent.EXPECT().Middleware().Return([]contractsai.Middleware{&applicationTestMiddleware{}}).Once()
+	mockAgent.EXPECT().Tools().Return(nil).Once()
+
+	app := NewApplication(ctx, config)
+	conv, err := app.Agent(mockAgent)
+	assert.NoError(t, err)
+	convImpl, ok := conv.(*conversation)
+	assert.True(t, ok)
+
+	mockProvider.EXPECT().
+		Prompt(ctx, contractsai.AgentPrompt{Agent: convImpl, Input: "hello", Tools: nil}).
+		Return(&stubResponse{text: "before middleware"}, nil).
+		Once()
+
+	resp, err := conv.Prompt("hello")
+	assert.NoError(t, err)
+	assert.Equal(t, "before middleware after middleware", resp.Text())
+}
+
+func TestApplication_Agent_MergesDefaultMiddlewareWithOptions(t *testing.T) {
+	ctx := context.Background()
+	mockProvider := mocksai.NewProvider(t)
+	config := contractsai.Config{
+		Default: "default",
+		Providers: map[string]contractsai.ProviderConfig{
+			"default": {Via: mockProvider},
+		},
+	}
+	mockAgent := mocksai.NewAgent(t)
+	mockAgent.EXPECT().Messages().Return(nil).Once()
+	mockAgent.EXPECT().Middleware().Return([]contractsai.Middleware{&applicationTestMiddleware{}}).Once()
+	mockAgent.EXPECT().Tools().Return(nil).Once()
+
+	app := NewApplication(ctx, config)
+	conv, err := app.Agent(mockAgent, WithMiddleware(&applicationTestMiddleware{}))
+	assert.NoError(t, err)
+	convImpl, ok := conv.(*conversation)
+	assert.True(t, ok)
+
+	mockProvider.EXPECT().
+		Prompt(ctx, contractsai.AgentPrompt{Agent: convImpl, Input: "hello", Tools: nil}).
+		Return(&stubResponse{text: "before middleware"}, nil).
+		Once()
+
+	resp, err := conv.Prompt("hello")
+	assert.NoError(t, err)
+	assert.Equal(t, "before middleware after middleware after middleware", resp.Text())
 }
 
 type applicationTestMiddleware struct{}

--- a/ai/console/agent_make_command_test.go
+++ b/ai/console/agent_make_command_test.go
@@ -56,5 +56,6 @@ func TestAgentMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("app/agents/user/support_agent.go", "type SupportAgent struct"))
 	assert.True(t, file.Contain("app/agents/user/support_agent.go", "func (r *SupportAgent) Instructions() string"))
 	assert.True(t, file.Contain("app/agents/user/support_agent.go", "func (r *SupportAgent) Messages() []ai.Message"))
+	assert.True(t, file.Contain("app/agents/user/support_agent.go", "func (r *SupportAgent) Middleware() []ai.Middleware"))
 	assert.NoError(t, file.Remove("app"))
 }

--- a/ai/console/stubs.go
+++ b/ai/console/stubs.go
@@ -19,6 +19,10 @@ func (r *DummyAgent) Messages() []ai.Message {
 	return nil
 }
 
+func (r *DummyAgent) Middleware() []ai.Middleware {
+	return nil
+}
+
 func (r *DummyAgent) Tools() []ai.Tool {
 	return nil
 }

--- a/ai/conversation.go
+++ b/ai/conversation.go
@@ -44,6 +44,10 @@ func NewConversation(ctx context.Context, agent contractsai.Agent, provider cont
 
 func (r *conversation) Instructions() string { return r.agent.Instructions() }
 
+func (r *conversation) Middleware() []contractsai.Middleware {
+	return slices.Clone(r.middlewares)
+}
+
 func (r *conversation) Messages() []contractsai.Message {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/ai/conversation_test.go
+++ b/ai/conversation_test.go
@@ -203,13 +203,15 @@ func (r *conversationProviderStub) Stream(ctx context.Context, prompt contractsa
 
 // agentStub is a minimal Agent implementation for stream tests that avoids mock expectation tracking.
 type agentStub struct {
-	messages []contractsai.Message
-	tools    []contractsai.Tool
+	messages   []contractsai.Message
+	middleware []contractsai.Middleware
+	tools      []contractsai.Tool
 }
 
-func (a *agentStub) Instructions() string            { return "" }
-func (a *agentStub) Messages() []contractsai.Message { return a.messages }
-func (a *agentStub) Tools() []contractsai.Tool       { return a.tools }
+func (a *agentStub) Instructions() string                 { return "" }
+func (a *agentStub) Middleware() []contractsai.Middleware { return a.middleware }
+func (a *agentStub) Messages() []contractsai.Message      { return a.messages }
+func (a *agentStub) Tools() []contractsai.Tool            { return a.tools }
 
 func (s *ConversationTestSuite) TestStream() {
 	ctx := context.Background()

--- a/contracts/ai/agent.go
+++ b/contracts/ai/agent.go
@@ -6,6 +6,9 @@ type Agent interface {
 	Instructions() string
 	// Messages returns prior conversation messages to include as context.
 	Messages() []Message
+	// Middleware returns the default middleware applied to the agent conversation.
+	// Return nil or an empty slice if no middleware is configured.
+	Middleware() []Middleware
 	// Tools returns the tools the model may invoke during the conversation.
 	// Return nil or an empty slice if no tools are available.
 	Tools() []Tool

--- a/mocks/ai/Agent.go
+++ b/mocks/ai/Agent.go
@@ -112,6 +112,53 @@ func (_c *Agent_Messages_Call) RunAndReturn(run func() []ai.Message) *Agent_Mess
 	return _c
 }
 
+// Middleware provides a mock function with no fields
+func (_m *Agent) Middleware() []ai.Middleware {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Middleware")
+	}
+
+	var r0 []ai.Middleware
+	if rf, ok := ret.Get(0).(func() []ai.Middleware); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]ai.Middleware)
+		}
+	}
+
+	return r0
+}
+
+// Agent_Middleware_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Middleware'
+type Agent_Middleware_Call struct {
+	*mock.Call
+}
+
+// Middleware is a helper method to define mock.On call
+func (_e *Agent_Expecter) Middleware() *Agent_Middleware_Call {
+	return &Agent_Middleware_Call{Call: _e.mock.On("Middleware")}
+}
+
+func (_c *Agent_Middleware_Call) Run(run func()) *Agent_Middleware_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Agent_Middleware_Call) Return(_a0 []ai.Middleware) *Agent_Middleware_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Agent_Middleware_Call) RunAndReturn(run func() []ai.Middleware) *Agent_Middleware_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Tools provides a mock function with no fields
 func (_m *Agent) Tools() []ai.Tool {
 	ret := _m.Called()


### PR DESCRIPTION
## Summary
- Adds `Agent.Middleware()` so agents can define default middleware directly on the agent contract.
- Merges agent-defined middleware before per-call `WithMiddleware(...)` options when creating conversations.
- Updates generated agent scaffolding and mocks to reflect the expanded AI agent interface.

## Why
Agent middleware is part of an agent's default behavior, so it should live with the agent definition instead of being repeated at every call site. This change lets framework users attach shared prompt middleware once and keep it active for every conversation created from that agent.

```go
type SupportAgent struct {
}

func (r *SupportAgent) Instructions() string {
	return ""
}

func (r *SupportAgent) Messages() []ai.Message {
	return nil
}

func (r *SupportAgent) Middleware() []ai.Middleware {
	return nil
}

func (r *SupportAgent) Tools() []ai.Tool {
	return nil
}
```

The application layer now preserves those defaults while still allowing callers to append request-specific middleware with `WithMiddleware(...)`. Tests cover both the default-only path and the merged ordering so the contract stays stable for framework consumers.
