### PR TITLE
feat(ai): add attachment helper subpackages

### DIFF
--- a/ai/document/file.go
+++ b/ai/document/file.go
@@ -1,0 +1,49 @@
+package document
+
+import (
+	"io"
+
+	frameworkai "github.com/goravel/framework/ai"
+	contractsai "github.com/goravel/framework/contracts/ai"
+	contractsfilesystem "github.com/goravel/framework/contracts/filesystem"
+)
+
+func WithMimeType(mimeType string) contractsai.AttachmentOption {
+	return frameworkai.WithMimeType(mimeType)
+}
+
+func WithDisk(disk string) contractsai.AttachmentOption {
+	return frameworkai.WithDisk(disk)
+}
+
+func FromByte(content []byte, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.DocumentFromByte(content, options...)
+}
+
+func FromString(content string, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.DocumentFromString(content, options...)
+}
+
+func FromBase64(content string, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.DocumentFromBase64(content, options...)
+}
+
+func FromReader(reader io.Reader, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.DocumentFromReader(reader, options...)
+}
+
+func FromPath(path string, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.DocumentFromPath(path, options...)
+}
+
+func FromStorage(path string, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.DocumentFromStorage(path, options...)
+}
+
+func FromURL(rawURL string, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.DocumentFromURL(rawURL, options...)
+}
+
+func FromUpload(file contractsfilesystem.File, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.DocumentFromUpload(file, options...)
+}

--- a/ai/image/file.go
+++ b/ai/image/file.go
@@ -1,0 +1,45 @@
+package image
+
+import (
+	"io"
+
+	frameworkai "github.com/goravel/framework/ai"
+	contractsai "github.com/goravel/framework/contracts/ai"
+	contractsfilesystem "github.com/goravel/framework/contracts/filesystem"
+)
+
+func WithMimeType(mimeType string) contractsai.AttachmentOption {
+	return frameworkai.WithMimeType(mimeType)
+}
+
+func WithDisk(disk string) contractsai.AttachmentOption {
+	return frameworkai.WithDisk(disk)
+}
+
+func FromByte(content []byte, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.ImageFromByte(content, options...)
+}
+
+func FromBase64(content string, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.ImageFromBase64(content, options...)
+}
+
+func FromReader(reader io.Reader, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.ImageFromReader(reader, options...)
+}
+
+func FromPath(path string, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.ImageFromPath(path, options...)
+}
+
+func FromStorage(path string, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.ImageFromStorage(path, options...)
+}
+
+func FromURL(rawURL string, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.ImageFromURL(rawURL, options...)
+}
+
+func FromUpload(file contractsfilesystem.File, options ...contractsai.AttachmentOption) contractsai.Attachment {
+	return frameworkai.ImageFromUpload(file, options...)
+}


### PR DESCRIPTION
## Summary
- Add `ai/document` helper functions that mirror the existing document attachment constructors.
- Add `ai/image` helper functions that mirror the existing image attachment constructors.
- Keep attachment options available from the new helper packages so AI attachment imports stay focused.

## Why
This adds the package-level helpers needed to write attachment code as `document.FromPath(...)` and `image.FromPath(...)` without changing the existing `ai.DocumentFrom*` and `ai.ImageFrom*` behavior.

That keeps the change minimal while making the attachment API read more naturally for application code that already organizes documents and images separately.

```go
import (
	"github.com/goravel/framework/ai/document"
	"github.com/goravel/framework/ai/image"
)

attachments := []ai.Attachment{
	document.FromPath("storage/app/reports/monthly.pdf"),
	image.FromPath("storage/app/charts/revenue.png", image.WithMimeType("image/png")),
}
```
