### PR TITLE
fix(ai): remove context from image response content

### DIFF
--- a/ai/application_test.go
+++ b/ai/application_test.go
@@ -554,7 +554,7 @@ func (p *applicationImageProviderStub) Image(ctx context.Context, prompt contrac
 
 type applicationImageResponseStub struct{}
 
-func (r *applicationImageResponseStub) Content(context.Context) ([]byte, error) {
+func (r *applicationImageResponseStub) Content() ([]byte, error) {
 	return []byte("image"), nil
 }
 

--- a/ai/openai/provider_test.go
+++ b/ai/openai/provider_test.go
@@ -279,7 +279,7 @@ func TestProviderImage(t *testing.T) {
 			}
 
 			require.NotNil(t, response)
-			content, contentErr := response.Content(context.Background())
+			content, contentErr := response.Content()
 			require.NoError(t, contentErr)
 			assert.Equal(t, tt.expectContent, content)
 			assert.Equal(t, tt.expectMime, response.MimeType())

--- a/ai/openai/response.go
+++ b/ai/openai/response.go
@@ -44,7 +44,7 @@ func (r *response) Then(callback func(contractsai.Response)) contractsai.Respons
 
 func (r *storedFileResponse) ID() string { return r.id }
 
-func (r *imageResponse) Content(context.Context) ([]byte, error) { return bytes.Clone(r.content), nil }
+func (r *imageResponse) Content() ([]byte, error) { return bytes.Clone(r.content), nil }
 
 func (r *imageResponse) MimeType() string { return r.mimeType }
 

--- a/contracts/ai/response.go
+++ b/contracts/ai/response.go
@@ -1,7 +1,5 @@
 package ai
 
-import "context"
-
 // Response exposes generated text and provider metadata.
 type Response interface {
 	Text() string
@@ -22,7 +20,7 @@ type Usage interface {
 
 // ImageResponse exposes generated image bytes and provider metadata.
 type ImageResponse interface {
-	Content(ctx context.Context) ([]byte, error)
+	Content() ([]byte, error)
 	MimeType() string
 	Usage() Usage
 	Then(callback func(ImageResponse)) ImageResponse

--- a/mocks/ai/ImageResponse.go
+++ b/mocks/ai/ImageResponse.go
@@ -3,10 +3,7 @@
 package ai
 
 import (
-	context "context"
-
 	ai "github.com/goravel/framework/contracts/ai"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -23,9 +20,9 @@ func (_m *ImageResponse) EXPECT() *ImageResponse_Expecter {
 	return &ImageResponse_Expecter{mock: &_m.Mock}
 }
 
-// Content provides a mock function with given fields: ctx
-func (_m *ImageResponse) Content(ctx context.Context) ([]byte, error) {
-	ret := _m.Called(ctx)
+// Content provides a mock function with no fields
+func (_m *ImageResponse) Content() ([]byte, error) {
+	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for Content")
@@ -33,19 +30,19 @@ func (_m *ImageResponse) Content(ctx context.Context) ([]byte, error) {
 
 	var r0 []byte
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) ([]byte, error)); ok {
-		return rf(ctx)
+	if rf, ok := ret.Get(0).(func() ([]byte, error)); ok {
+		return rf()
 	}
-	if rf, ok := ret.Get(0).(func(context.Context) []byte); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func() []byte); ok {
+		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -59,14 +56,13 @@ type ImageResponse_Content_Call struct {
 }
 
 // Content is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *ImageResponse_Expecter) Content(ctx interface{}) *ImageResponse_Content_Call {
-	return &ImageResponse_Content_Call{Call: _e.mock.On("Content", ctx)}
+func (_e *ImageResponse_Expecter) Content() *ImageResponse_Content_Call {
+	return &ImageResponse_Content_Call{Call: _e.mock.On("Content")}
 }
 
-func (_c *ImageResponse_Content_Call) Run(run func(ctx context.Context)) *ImageResponse_Content_Call {
+func (_c *ImageResponse_Content_Call) Run(run func()) *ImageResponse_Content_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		run()
 	})
 	return _c
 }
@@ -76,7 +72,7 @@ func (_c *ImageResponse_Content_Call) Return(_a0 []byte, _a1 error) *ImageRespon
 	return _c
 }
 
-func (_c *ImageResponse_Content_Call) RunAndReturn(run func(context.Context) ([]byte, error)) *ImageResponse_Content_Call {
+func (_c *ImageResponse_Content_Call) RunAndReturn(run func() ([]byte, error)) *ImageResponse_Content_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary
- Removes the `context.Context` argument from `ai.ImageResponse.Content()` so generated image bytes can be read directly after `Generate()`.
- Keeps the OpenAI image response implementation and generated mocks aligned with the simplified image response contract.
- Preserves existing image generation behavior while updating tests to use the new no-argument API.

## Why
Image response bytes are already resolved before callers read them, so requiring a context at read time adds API surface without changing behavior. This makes image generation usage simpler and keeps the image response contract focused on returning the already-available content.

```go
response, err := facades.Ai().Image("draw a cat").Generate()
if err != nil {
	return ctx.Response().Json(500, http.Json{"message": err.Error()})
}

content, err := response.Content()
if err != nil {
	return ctx.Response().Json(500, http.Json{"message": err.Error()})
}

return ctx.Response().Header("Content-Type", response.MimeType()).Data(200, content)
```

This also keeps tests and mocks aligned with the public contract so downstream code can adopt the simpler call pattern consistently.
