### PR TITLE
feat(ai): expose text max_tokens in provider config

### DIFF
--- a/ai/setup/stubs.go
+++ b/ai/setup/stubs.go
@@ -26,27 +26,7 @@ func init() {
 		// Here you may configure each AI provider used by your application.
 		// A variety of drivers are available, and each provider may also
 		// configure the models available to your application.
-		"providers": map[string]any{
-			"openai": map[string]any{
-				"key": "",
-				"models": map[string]any{
-					"text": map[string]any{
-						"default": "",
-					},
-					"audio": map[string]any{
-						"default": "",
-					},
-					"transcription": map[string]any{
-						"default": "",
-					},
-					"image": map[string]any{
-						"default": "",
-					},
-				},
-				"url": "",
-				"via": "",
-			},
-		},
+		"providers": map[string]any{},
 	})
 }
 `

--- a/contracts/ai/config.go
+++ b/contracts/ai/config.go
@@ -14,7 +14,8 @@ type ProviderConfig struct {
 
 type ModelsConfig struct {
 	Text struct {
-		Default string `json:"default"`
+		Default   string `json:"default"`
+		MaxTokens int    `json:"max_tokens"`
 	} `json:"text"`
 	Audio struct {
 		Default string `json:"default"`


### PR DESCRIPTION
## Summary
- adds a shared `models.text.max_tokens` field so external AI drivers can read text token limits from framework config.
- stops generating a built-in `openai` provider block in `config/ai.go`, leaving provider scaffolding to external packages.

## Why
External AI providers now live outside `goravel/framework`, but they still need a common config contract to read provider-specific text limits such as Anthropic's required `max_tokens`. Adding the field to the shared AI config keeps external drivers aligned with the framework's generated config structure.

The AI setup stub also no longer advertises `openai` as a built-in provider. New applications should start with an empty `providers` map and add the external AI package they actually install.

```go
config.Add("ai", map[string]any{
	"default": "anthropic",
	"providers": map[string]any{
		"anthropic": map[string]any{
			"key": config.Env("ANTHROPIC_API_KEY"),
			"models": map[string]any{
				"text": map[string]any{
					"default":    "claude-sonnet-4-0",
					"max_tokens": 4096,
				},
			},
		},
	},
})
```