### PR TITLE
feat: [#726] Add processor tuning and span limits [8]

### DIFF
--- a/errors/list.go
+++ b/errors/list.go
@@ -287,6 +287,7 @@ var (
 	TelemetryLogViaTypeMismatch             = New("custom logger driver requires func(context.Context) (sdklog.Exporter, error), received %s").SetModule(ModuleTelemetry)
 	TelemetryGrpcServerStatsHandlerDisabled = New("Facade not initialized. gRPC server stats instrumentation is disabled.").SetModule(ModuleTelemetry)
 	TelemetryGrpcClientStatsHandlerDisabled = New("Facade not initialized. gRPC client stats instrumentation is disabled.").SetModule(ModuleTelemetry)
+	TelemetryUnsupportedProcessor           = New("unsupported telemetry processor type: %s").SetModule(ModuleTelemetry)
 
 	TestingImageBuildFailed   = New("init %s docker error: %v")
 	TestingImageNoContainerId = New("no container id return when creating %s docker")

--- a/telemetry/config.go
+++ b/telemetry/config.go
@@ -19,8 +19,32 @@ type ServiceConfig struct {
 }
 
 type TracesConfig struct {
-	Exporter string
-	Sampler  SamplerConfig
+	Exporter  string
+	Sampler   SamplerConfig
+	Processor ProcessorConfig
+	Limits    SpanLimitsConfig
+}
+
+const (
+	ProcessorBatch  = "batch"
+	ProcessorSimple = "simple"
+)
+
+type ProcessorConfig struct {
+	Type         string
+	Interval     time.Duration
+	Timeout      time.Duration
+	MaxQueueSize int `json:"max_queue_size"`
+	MaxBatchSize int `json:"max_batch_size"`
+}
+
+type SpanLimitsConfig struct {
+	AttributeValueLength   int `json:"attribute_value_length"`
+	AttributeCount         int `json:"attribute_count"`
+	EventCount             int `json:"event_count"`
+	LinkCount              int `json:"link_count"`
+	AttributePerEventCount int `json:"attribute_per_event_count"`
+	AttributePerLinkCount  int `json:"attribute_per_link_count"`
 }
 
 type MetricsConfig struct {
@@ -30,12 +54,7 @@ type MetricsConfig struct {
 
 type LogsConfig struct {
 	Exporter  string
-	Processor LogsProcessorConfig
-}
-
-type LogsProcessorConfig struct {
-	Interval time.Duration
-	Timeout  time.Duration
+	Processor ProcessorConfig
 }
 
 type MetricsReaderConfig struct {

--- a/telemetry/log.go
+++ b/telemetry/log.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
@@ -21,11 +20,6 @@ const (
 	LogExporterDriverCustom  ExporterDriver = "custom"
 	LogExporterDriverOTLP    ExporterDriver = "otlp"
 	LogExporterDriverConsole ExporterDriver = "console"
-)
-
-const (
-	defaultLogExportInterval = 1 * time.Second
-	defaultLogExportTimeout  = 30 * time.Second
 )
 
 func NewLoggerProvider(ctx context.Context, cfg Config, opts ...sdklog.LoggerProviderOption) (log.LoggerProvider, ShutdownFunc, error) {
@@ -46,24 +40,13 @@ func NewLoggerProvider(ctx context.Context, cfg Config, opts ...sdklog.LoggerPro
 		return nil, NoopShutdown(), err
 	}
 
-	interval := cfg.Logs.Processor.Interval
-	timeout := cfg.Logs.Processor.Timeout
-
-	if interval == 0 {
-		interval = defaultLogExportInterval
-	}
-	if timeout == 0 {
-		timeout = defaultLogExportTimeout
-	}
-
-	processorOptions := []sdklog.BatchProcessorOption{
-		sdklog.WithExportInterval(interval),
-		sdklog.WithExportTimeout(timeout),
+	processor, err := newLogProcessor(exporter, cfg.Logs.Processor)
+	if err != nil {
+		return nil, NoopShutdown(), err
 	}
 
 	providerOptions := []sdklog.LoggerProviderOption{
-		// TODO: add support for SimpleProcessor
-		sdklog.WithProcessor(sdklog.NewBatchProcessor(exporter, processorOptions...)),
+		sdklog.WithProcessor(processor),
 	}
 	providerOptions = append(providerOptions, opts...)
 
@@ -71,6 +54,30 @@ func NewLoggerProvider(ctx context.Context, cfg Config, opts ...sdklog.LoggerPro
 	global.SetLoggerProvider(lp)
 
 	return lp, lp.Shutdown, nil
+}
+
+func newLogProcessor(exporter sdklog.Exporter, cfg ProcessorConfig) (sdklog.Processor, error) {
+	switch cfg.Type {
+	case ProcessorSimple:
+		return sdklog.NewSimpleProcessor(exporter), nil
+	case ProcessorBatch, "":
+		var opts []sdklog.BatchProcessorOption
+		if cfg.Interval > 0 {
+			opts = append(opts, sdklog.WithExportInterval(cfg.Interval))
+		}
+		if cfg.Timeout > 0 {
+			opts = append(opts, sdklog.WithExportTimeout(cfg.Timeout))
+		}
+		if cfg.MaxQueueSize > 0 {
+			opts = append(opts, sdklog.WithMaxQueueSize(cfg.MaxQueueSize))
+		}
+		if cfg.MaxBatchSize > 0 {
+			opts = append(opts, sdklog.WithExportMaxBatchSize(cfg.MaxBatchSize))
+		}
+		return sdklog.NewBatchProcessor(exporter, opts...), nil
+	default:
+		return nil, errors.TelemetryUnsupportedProcessor.Args(cfg.Type)
+	}
 }
 
 func newLogExporter(ctx context.Context, cfg ExporterEntry) (sdklog.Exporter, error) {

--- a/telemetry/log_test.go
+++ b/telemetry/log_test.go
@@ -2,10 +2,12 @@ package telemetry
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 
 	"github.com/goravel/framework/errors"
@@ -141,6 +143,16 @@ func TestNewLoggerProvider(t *testing.T) {
 			},
 			expectError: errors.TelemetryLogViaTypeMismatch.Args("string"),
 		},
+		{
+			name: "Error: Unsupported Processor",
+			config: Config{
+				Logs: LogsConfig{Exporter: "console", Processor: ProcessorConfig{Type: "alien"}},
+				Exporters: map[string]ExporterEntry{
+					"console": {Driver: LogExporterDriverConsole},
+				},
+			},
+			expectError: errors.TelemetryUnsupportedProcessor.Args("alien"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -251,4 +263,67 @@ func (m *MockLogExporter) Shutdown(ctx context.Context) error {
 
 func (m *MockLogExporter) ForceFlush(ctx context.Context) error {
 	return nil
+}
+
+type recordingLogExporter struct {
+	mu      sync.Mutex
+	records []sdklog.Record
+}
+
+func (r *recordingLogExporter) Export(ctx context.Context, records []sdklog.Record) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = append(r.records, records...)
+	return nil
+}
+
+func (r *recordingLogExporter) Shutdown(ctx context.Context) error   { return nil }
+func (r *recordingLogExporter) ForceFlush(ctx context.Context) error { return nil }
+
+func (r *recordingLogExporter) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.records)
+}
+
+func TestNewLoggerProvider_ProcessorTypes(t *testing.T) {
+	ctx := context.Background()
+
+	newConfig := func(exporter sdklog.Exporter, processor ProcessorConfig) Config {
+		return Config{
+			Logs: LogsConfig{Exporter: "custom", Processor: processor},
+			Exporters: map[string]ExporterEntry{
+				"custom": {Driver: LogExporterDriverCustom, Via: exporter},
+			},
+		}
+	}
+
+	emit := func(provider otellog.LoggerProvider) {
+		var record otellog.Record
+		record.SetBody(otellog.StringValue("message"))
+		provider.Logger("test").Emit(ctx, record)
+	}
+
+	t.Run("simple exports on emit", func(t *testing.T) {
+		exporter := &recordingLogExporter{}
+		provider, shutdown, err := NewLoggerProvider(ctx, newConfig(exporter, ProcessorConfig{Type: ProcessorSimple}))
+		assert.NoError(t, err)
+
+		emit(provider)
+
+		assert.Equal(t, 1, exporter.count())
+		assert.NoError(t, shutdown(ctx))
+	})
+
+	t.Run("batch defers export until shutdown", func(t *testing.T) {
+		exporter := &recordingLogExporter{}
+		provider, shutdown, err := NewLoggerProvider(ctx, newConfig(exporter, ProcessorConfig{Type: ProcessorBatch, Interval: time.Hour}))
+		assert.NoError(t, err)
+
+		emit(provider)
+
+		assert.Equal(t, 0, exporter.count())
+		assert.NoError(t, shutdown(ctx))
+		assert.Equal(t, 1, exporter.count())
+	})
 }

--- a/telemetry/log_test.go
+++ b/telemetry/log_test.go
@@ -33,7 +33,7 @@ func TestNewLoggerProvider(t *testing.T) {
 			config: Config{
 				Logs: LogsConfig{
 					Exporter: "console",
-					Processor: LogsProcessorConfig{
+					Processor: ProcessorConfig{
 						Interval: 5000 * time.Millisecond,
 						Timeout:  2000 * time.Millisecond,
 					},

--- a/telemetry/setup/stubs.go
+++ b/telemetry/setup/stubs.go
@@ -78,6 +78,33 @@ func init() {
 				// e.g., 0.1 records ~10% of traces.
 				"ratio": config.Env("OTEL_TRACES_SAMPLER_RATIO", 0.05),
 			},
+
+			// Processor Configuration
+			//
+			// Controls how finished spans are handed to the exporter.
+			"processor": map[string]any{
+				// Type: "batch" buffers spans for performance (recommended);
+				// "simple" exports each span synchronously (debugging, short-lived CLIs).
+				"type": config.Env("OTEL_TRACE_PROCESSOR_TYPE", "batch"),
+
+				// Zero/empty values use the SDK defaults shown.
+				"interval":       config.Env("OTEL_BSP_SCHEDULE_DELAY", ""),       // 5s
+				"timeout":        config.Env("OTEL_BSP_EXPORT_TIMEOUT", ""),       // 30s
+				"max_queue_size": config.Env("OTEL_BSP_MAX_QUEUE_SIZE", 0),        // 2048
+				"max_batch_size": config.Env("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", 0), // 512
+			},
+
+			// Span Limits
+			//
+			// Guards against unbounded span cardinality. 0 = SDK default, -1 = unlimited.
+			"limits": map[string]any{
+				"attribute_value_length":    config.Env("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", 0),
+				"attribute_count":           config.Env("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", 0),
+				"event_count":               config.Env("OTEL_SPAN_EVENT_COUNT_LIMIT", 0),
+				"link_count":                config.Env("OTEL_SPAN_LINK_COUNT_LIMIT", 0),
+				"attribute_per_event_count": config.Env("OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT", 0),
+				"attribute_per_link_count":  config.Env("OTEL_LINK_ATTRIBUTE_COUNT_LIMIT", 0),
+			},
 		},
 
 		// Metrics Configuration
@@ -121,13 +148,17 @@ func init() {
 			//
 			// Configures the BatchLogProcessor, which batches logs before export.
 			"processor": map[string]any{
-				// Interval: How often logs are flushed.
-				// Format: Duration string (e.g., "1s", "500ms").
-				"interval": config.Env("OTEL_LOG_EXPORT_INTERVAL", "1s"),
+				// Type: "batch" buffers logs for performance (recommended);
+				// "simple" exports each record synchronously (debugging).
+				"type": config.Env("OTEL_LOG_PROCESSOR_TYPE", "batch"),
 
-				// Timeout: Max time allowed for export before cancelling.
-				// Format: Duration string (e.g., "30s").
-				"timeout": config.Env("OTEL_LOG_EXPORT_TIMEOUT", "30s"),
+				// Zero/empty values use the SDK defaults shown.
+				// Format: Duration string (e.g., "1s", "500ms").
+				"interval": config.Env("OTEL_BLRP_SCHEDULE_DELAY", ""), // 1s
+				"timeout":  config.Env("OTEL_BLRP_EXPORT_TIMEOUT", ""), // 30s
+
+				"max_queue_size": config.Env("OTEL_BLRP_MAX_QUEUE_SIZE", 0),        // 2048
+				"max_batch_size": config.Env("OTEL_BLRP_MAX_EXPORT_BATCH_SIZE", 0), // 512
 			},
 		},
 

--- a/telemetry/trace.go
+++ b/telemetry/trace.go
@@ -44,8 +44,13 @@ func NewTracerProvider(ctx context.Context, cfg Config, opts ...sdktrace.TracerP
 		return nil, NoopShutdown(), err
 	}
 
+	processorOption, err := newTraceProcessorOption(exporter, cfg.Traces.Processor)
+	if err != nil {
+		return nil, NoopShutdown(), err
+	}
+
 	providerOptions := []sdktrace.TracerProviderOption{
-		sdktrace.WithBatcher(exporter),
+		processorOption,
 		sdktrace.WithSampler(newTraceSampler(cfg.Traces.Sampler)),
 	}
 	providerOptions = append(providerOptions, opts...)
@@ -54,6 +59,30 @@ func NewTracerProvider(ctx context.Context, cfg Config, opts ...sdktrace.TracerP
 	otel.SetTracerProvider(tp)
 
 	return tp, tp.Shutdown, nil
+}
+
+func newTraceProcessorOption(exporter sdktrace.SpanExporter, cfg ProcessorConfig) (sdktrace.TracerProviderOption, error) {
+	switch cfg.Type {
+	case ProcessorSimple:
+		return sdktrace.WithSyncer(exporter), nil
+	case ProcessorBatch, "":
+		var opts []sdktrace.BatchSpanProcessorOption
+		if cfg.Interval > 0 {
+			opts = append(opts, sdktrace.WithBatchTimeout(cfg.Interval))
+		}
+		if cfg.Timeout > 0 {
+			opts = append(opts, sdktrace.WithExportTimeout(cfg.Timeout))
+		}
+		if cfg.MaxQueueSize > 0 {
+			opts = append(opts, sdktrace.WithMaxQueueSize(cfg.MaxQueueSize))
+		}
+		if cfg.MaxBatchSize > 0 {
+			opts = append(opts, sdktrace.WithMaxExportBatchSize(cfg.MaxBatchSize))
+		}
+		return sdktrace.WithBatcher(exporter, opts...), nil
+	default:
+		return nil, errors.TelemetryUnsupportedProcessor.Args(cfg.Type)
+	}
 }
 
 func newTraceExporter(ctx context.Context, cfg ExporterEntry) (sdktrace.SpanExporter, error) {

--- a/telemetry/trace.go
+++ b/telemetry/trace.go
@@ -53,6 +53,11 @@ func NewTracerProvider(ctx context.Context, cfg Config, opts ...sdktrace.TracerP
 		processorOption,
 		sdktrace.WithSampler(newTraceSampler(cfg.Traces.Sampler)),
 	}
+
+	if limitsOption, ok := newSpanLimitsOption(cfg.Traces.Limits); ok {
+		providerOptions = append(providerOptions, limitsOption)
+	}
+
 	providerOptions = append(providerOptions, opts...)
 
 	tp := sdktrace.NewTracerProvider(providerOptions...)
@@ -83,6 +88,34 @@ func newTraceProcessorOption(exporter sdktrace.SpanExporter, cfg ProcessorConfig
 	default:
 		return nil, errors.TelemetryUnsupportedProcessor.Args(cfg.Type)
 	}
+}
+
+func newSpanLimitsOption(cfg SpanLimitsConfig) (sdktrace.TracerProviderOption, bool) {
+	if cfg == (SpanLimitsConfig{}) {
+		return nil, false
+	}
+
+	limits := sdktrace.NewSpanLimits()
+	if cfg.AttributeValueLength != 0 {
+		limits.AttributeValueLengthLimit = cfg.AttributeValueLength
+	}
+	if cfg.AttributeCount != 0 {
+		limits.AttributeCountLimit = cfg.AttributeCount
+	}
+	if cfg.EventCount != 0 {
+		limits.EventCountLimit = cfg.EventCount
+	}
+	if cfg.LinkCount != 0 {
+		limits.LinkCountLimit = cfg.LinkCount
+	}
+	if cfg.AttributePerEventCount != 0 {
+		limits.AttributePerEventCountLimit = cfg.AttributePerEventCount
+	}
+	if cfg.AttributePerLinkCount != 0 {
+		limits.AttributePerLinkCountLimit = cfg.AttributePerLinkCount
+	}
+
+	return sdktrace.WithRawSpanLimits(limits), true
 }
 
 func newTraceExporter(ctx context.Context, cfg ExporterEntry) (sdktrace.SpanExporter, error) {

--- a/telemetry/trace_test.go
+++ b/telemetry/trace_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/goravel/framework/errors"
@@ -299,4 +300,30 @@ func TestNewTracerProvider_ProcessorTypes(t *testing.T) {
 		assert.NoError(t, shutdown(ctx))
 		assert.Equal(t, 1, exporter.count())
 	})
+}
+
+func TestNewTracerProvider_SpanLimits(t *testing.T) {
+	ctx := context.Background()
+	exporter := &recordingSpanExporter{}
+
+	provider, shutdown, err := NewTracerProvider(ctx, Config{
+		Traces: TracesConfig{
+			Exporter:  "custom",
+			Processor: ProcessorConfig{Type: ProcessorSimple},
+			Limits:    SpanLimitsConfig{AttributeCount: 1},
+		},
+		Exporters: map[string]ExporterEntry{
+			"custom": {Driver: TraceExporterDriverCustom, Via: exporter},
+		},
+	})
+	assert.NoError(t, err)
+
+	_, span := provider.Tracer("test").Start(ctx, "operation")
+	span.SetAttributes(attribute.String("first", "1"), attribute.String("second", "2"))
+	span.End()
+
+	assert.Equal(t, 1, exporter.count())
+	assert.Len(t, exporter.spans[0].Attributes(), 1)
+	assert.Equal(t, 1, exporter.spans[0].DroppedAttributes())
+	assert.NoError(t, shutdown(ctx))
 }

--- a/telemetry/trace_test.go
+++ b/telemetry/trace_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -133,6 +134,16 @@ func TestNewTracerProvider(t *testing.T) {
 			},
 			expectError: errors.TelemetryTraceViaTypeMismatch.Args("string"),
 		},
+		{
+			name: "Error: Unsupported Processor",
+			config: Config{
+				Traces: TracesConfig{Exporter: "console", Processor: ProcessorConfig{Type: "alien"}},
+				Exporters: map[string]ExporterEntry{
+					"console": {Driver: TraceExporterDriverConsole},
+				},
+			},
+			expectError: errors.TelemetryUnsupportedProcessor.Args("alien"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -230,4 +241,62 @@ func (m *MockSpanExporter) ExportSpans(ctx context.Context, ss []sdktrace.ReadOn
 
 func (m *MockSpanExporter) Shutdown(ctx context.Context) error {
 	return nil
+}
+
+type recordingSpanExporter struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (r *recordingSpanExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.spans = append(r.spans, spans...)
+	return nil
+}
+
+func (r *recordingSpanExporter) Shutdown(ctx context.Context) error { return nil }
+
+func (r *recordingSpanExporter) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.spans)
+}
+
+func TestNewTracerProvider_ProcessorTypes(t *testing.T) {
+	ctx := context.Background()
+
+	newConfig := func(exporter sdktrace.SpanExporter, processor ProcessorConfig) Config {
+		return Config{
+			Traces: TracesConfig{Exporter: "custom", Processor: processor},
+			Exporters: map[string]ExporterEntry{
+				"custom": {Driver: TraceExporterDriverCustom, Via: exporter},
+			},
+		}
+	}
+
+	t.Run("simple exports on span end", func(t *testing.T) {
+		exporter := &recordingSpanExporter{}
+		provider, shutdown, err := NewTracerProvider(ctx, newConfig(exporter, ProcessorConfig{Type: ProcessorSimple}))
+		assert.NoError(t, err)
+
+		_, span := provider.Tracer("test").Start(ctx, "operation")
+		span.End()
+
+		assert.Equal(t, 1, exporter.count())
+		assert.NoError(t, shutdown(ctx))
+	})
+
+	t.Run("batch defers export until shutdown", func(t *testing.T) {
+		exporter := &recordingSpanExporter{}
+		provider, shutdown, err := NewTracerProvider(ctx, newConfig(exporter, ProcessorConfig{Type: ProcessorBatch, Interval: time.Hour}))
+		assert.NoError(t, err)
+
+		_, span := provider.Tracer("test").Start(ctx, "operation")
+		span.End()
+
+		assert.Equal(t, 0, exporter.count())
+		assert.NoError(t, shutdown(ctx))
+		assert.Equal(t, 1, exporter.count())
+	})
 }


### PR DESCRIPTION
## 📑 Description

RelatedTo https://github.com/goravel/goravel/issues/726

Span and log processors are hardcoded to batching with SDK defaults, so short-lived CLIs lose telemetry on fast exits and there is no guard against unbounded span cardinality.

**What is changing (with examples):**

* `processor.type` ("batch"/"simple") for both traces and logs; unknown types fail at boot. "simple" exports synchronously for debugging and short-lived commands.

```go
"processor": map[string]any{
    "type": "simple",
}
// before: always batched; a CLI exiting within the 5s schedule delay drops its spans
// after: each span/record exports synchronously
```

* Batch tuning knobs (`interval`, `timeout`, `max_queue_size`, `max_batch_size`); zero values keep SDK defaults. The logs `processor` block reuses the same shared `ProcessorConfig` instead of its own two-field type.

```go
"processor": map[string]any{
    "type":           "batch",
    "interval":       "1s",  // high-throughput: flush more often than the 5s default
    "max_queue_size": 4096,  // before dropping spans under burst load
}
```

* `limits` block on traces wires `sdktrace.SpanLimits`; 0 keeps the SDK default, -1 means unlimited.

```go
"limits": map[string]any{
    "attribute_value_length": 256, // truncate oversized values (SQL, payloads)
    "event_count":            64,
}
```

## ✅ Checks

- [x] Added test cases for my code