### PR TITLE
feat: support cache maintenance mode driver

### DIFF
--- a/cache/application.go
+++ b/cache/application.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"sync"
+
 	"github.com/goravel/framework/contracts/cache"
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/log"
@@ -8,10 +10,11 @@ import (
 
 type Application struct {
 	cache.Driver
-	config config.Config
-	log    log.Log
-	driver *Driver
-	stores map[string]cache.Driver
+	config   config.Config
+	log      log.Log
+	driver   *Driver
+	storesMu sync.RWMutex
+	stores   map[string]cache.Driver
 }
 
 func NewApplication(config config.Config, log log.Log, store string) (*Application, error) {
@@ -33,6 +36,16 @@ func NewApplication(config config.Config, log log.Log, store string) (*Applicati
 }
 
 func (app *Application) Store(name string) cache.Driver {
+	app.storesMu.RLock()
+	if driver, exist := app.stores[name]; exist {
+		app.storesMu.RUnlock()
+		return driver
+	}
+	app.storesMu.RUnlock()
+
+	app.storesMu.Lock()
+	defer app.storesMu.Unlock()
+
 	if driver, exist := app.stores[name]; exist {
 		return driver
 	}

--- a/cache/driver_test.go
+++ b/cache/driver_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -102,6 +103,46 @@ func (s *DriverTestSuite) TestStore() {
 	s.Equal("", custom.GetString("hello"))
 
 	s.Equal("goravel", memory.GetString("hello"))
+
+	s.mockConfig.AssertExpectations(s.T())
+}
+
+func (s *DriverTestSuite) TestStoreConcurrent() {
+	s.mockConfig.On("GetString", "cache.stores.memory.driver").Return("memory").Once()
+	s.mockConfig.On("GetString", "cache.prefix").Return("goravel_cache").Once()
+
+	memory, err := NewApplication(s.mockConfig, s.mockLog, "memory")
+	s.NotNil(memory)
+	s.Nil(err)
+
+	s.mockConfig.On("GetString", "cache.stores.custom.driver").Return("custom").Once()
+	s.mockConfig.On("Get", "cache.stores.custom.via").Return(&Store{}).Once()
+
+	const goroutines = 10
+	stores := make([]cache.Driver, goroutines)
+	start := make(chan struct{})
+	var waitGroup sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		waitGroup.Add(1)
+		index := i
+		go func() {
+			defer waitGroup.Done()
+			<-start
+			stores[index] = memory.Store("custom")
+		}()
+	}
+	close(start)
+	waitGroup.Wait()
+
+	var first cache.Driver
+	for _, store := range stores {
+		s.NotNil(store)
+		if first == nil {
+			first = store
+			continue
+		}
+		s.Same(first, store)
+	}
 
 	s.mockConfig.AssertExpectations(s.T())
 }

--- a/errors/list.go
+++ b/errors/list.go
@@ -6,6 +6,7 @@ var (
 	ConfigFacadeNotSet      = New("config facade is not initialized")
 	ConsoleFacadeNotSet     = New("console facade is not initialized, skipping artisan command execution")
 	DBFacadeNotSet          = New("db facade is not initialized")
+	HashFacadeNotSet        = New("hash facade is not initialized")
 	HttpFacadeNotSet        = New("http facade is not initialized")
 	JSONParserNotSet        = New("JSON parser is not initialized")
 	LogFacadeNotSet         = New("log facade is not initialized")
@@ -160,7 +161,11 @@ var (
 	MailTemplateEngineViaInvalid    = New("invalid via type for template engine '%s'").SetModule(ModuleMail)
 	MailTemplateEngineFactoryFailed = New("factory for template engine '%s' failed: %w").SetModule(ModuleMail)
 
-	MiddlewareRegisterFailed = New("failed to register middleware '%s': %v")
+	MiddlewareRegisterFailed      = New("failed to register middleware '%s': %v")
+	MaintenanceCacheDeleteFailed  = New("failed to delete maintenance mode from cache")
+	MaintenanceCachePutFailed     = New("failed to put application into maintenance mode using cache")
+	MaintenanceCacheStoreNotFound = New("maintenance cache store %s is not initialized")
+	MaintenanceDriverNotSupported = New("invalid maintenance driver: %s, only support file, cache")
 
 	MigrationCreateFailed    = New("create migration failed: %v")
 	MigrationFreshFailed     = New("migration fresh failed: %v")

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -728,9 +728,12 @@ func (r *Application) defaultCommands() []contractsconsole.Command {
 	storage := r.MakeStorage()
 	view := r.MakeView()
 	hash := r.MakeHash()
+	cache := r.MakeCache()
+	config := r.MakeConfig()
 
 	if storage != nil && view != nil && hash != nil {
-		commands = append(commands, console.NewUpCommand(storage), console.NewDownCommand(view, hash, storage))
+		maintenance := console.NewMaintenanceMode(config, cache, storage)
+		commands = append(commands, console.NewUpCommand(maintenance), console.NewDownCommand(view, hash, maintenance))
 	}
 
 	return commands

--- a/foundation/console/down_command.go
+++ b/foundation/console/down_command.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/console/command"
-	"github.com/goravel/framework/contracts/filesystem"
 	"github.com/goravel/framework/contracts/hash"
 	"github.com/goravel/framework/contracts/view"
 	"github.com/goravel/framework/errors"
@@ -15,9 +14,9 @@ import (
 )
 
 type DownCommand struct {
-	view    view.View
-	hash    hash.Hash
-	storage filesystem.Storage
+	view        view.View
+	hash        hash.Hash
+	maintenance *MaintenanceMode
 }
 
 type MaintenanceOptions struct {
@@ -28,8 +27,8 @@ type MaintenanceOptions struct {
 	Status   int    `json:"status"`
 }
 
-func NewDownCommand(view view.View, hash hash.Hash, storage filesystem.Storage) *DownCommand {
-	return &DownCommand{view, hash, storage}
+func NewDownCommand(view view.View, hash hash.Hash, maintenance *MaintenanceMode) *DownCommand {
+	return &DownCommand{view, hash, maintenance}
 }
 
 // Signature The name and signature of the console command.
@@ -78,8 +77,6 @@ func (r *DownCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *DownCommand) Handle(ctx console.Context) error {
-	path := "framework/maintenance.json"
-
 	options := MaintenanceOptions{}
 
 	options.Status = ctx.OptionInt("status")
@@ -129,7 +126,7 @@ func (r *DownCommand) Handle(ctx console.Context) error {
 		return nil
 	}
 
-	if err := r.storage.Put(path, string(jsonBytes)); err != nil {
+	if err := r.maintenance.Put(string(jsonBytes)); err != nil {
 		ctx.Error(err.Error())
 		return nil
 	}

--- a/foundation/console/down_command_test.go
+++ b/foundation/console/down_command_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/goravel/framework/contracts/console/command"
+	mockscache "github.com/goravel/framework/mocks/cache"
+	mocksconfig "github.com/goravel/framework/mocks/config"
 	mocksconsole "github.com/goravel/framework/mocks/console"
 	mocksfilesystem "github.com/goravel/framework/mocks/filesystem"
 	mockshash "github.com/goravel/framework/mocks/hash"
@@ -19,6 +21,8 @@ type DownCommandTestSuite struct {
 	suite.Suite
 	mockHash    *mockshash.Hash
 	mockView    *mocksview.View
+	mockCache   *mockscache.Cache
+	mockConfig  *mocksconfig.Config
 	mockStorage *mocksfilesystem.Storage
 }
 
@@ -26,31 +30,37 @@ func TestDownCommandTestSuite(t *testing.T) {
 	suite.Run(t, new(DownCommandTestSuite))
 }
 
-func (s *DownCommandTestSuite) SetupSuite() {
+func (s *DownCommandTestSuite) SetupTest() {
 	s.mockHash = mockshash.NewHash(s.T())
 	s.mockView = mocksview.NewView(s.T())
+	s.mockCache = mockscache.NewCache(s.T())
+	s.mockConfig = mocksconfig.NewConfig(s.T())
 	s.mockStorage = mocksfilesystem.NewStorage(s.T())
+}
+
+func (s *DownCommandTestSuite) maintenance() *MaintenanceMode {
+	return NewMaintenanceMode(s.mockConfig, s.mockCache, s.mockStorage)
 }
 
 func (s *DownCommandTestSuite) TestSignature() {
 	expected := "down"
-	s.Require().Equal(expected, NewDownCommand(s.mockView, s.mockHash, s.mockStorage).Signature())
+	s.Require().Equal(expected, NewDownCommand(s.mockView, s.mockHash, s.maintenance()).Signature())
 }
 
 func (s *DownCommandTestSuite) TestDescription() {
 	expected := "Put the application into maintenance mode"
-	s.Require().Equal(expected, NewDownCommand(s.mockView, s.mockHash, s.mockStorage).Description())
+	s.Require().Equal(expected, NewDownCommand(s.mockView, s.mockHash, s.maintenance()).Description())
 }
 
 func (s *DownCommandTestSuite) TestExtend() {
-	cmd := NewDownCommand(s.mockView, s.mockHash, s.mockStorage)
+	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
 	got := cmd.Extend()
 
 	s.Equal(6, len(got.Flags))
 }
 
 func (s *DownCommandTestSuite) TestHandle() {
-	cmd := NewDownCommand(s.mockView, s.mockHash, s.mockStorage)
+	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
 
 	flag := cmd.Extend().Flags[0].(*command.StringFlag)
 	mockCtx := mocksconsole.NewContext(s.T())
@@ -61,6 +71,7 @@ func (s *DownCommandTestSuite) TestHandle() {
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false)
 	mockCtx.EXPECT().Option("reason").Return(flag.Value)
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"reason\":\"The application is under maintenance\",\"status\":503}").Return(nil)
 
 	err := cmd.Handle(mockCtx)
@@ -77,9 +88,10 @@ func (s *DownCommandTestSuite) TestHandleWithReason() {
 	mockCtx.EXPECT().Option("secret").Return("").Once()
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"reason\":\"Under maintenance\",\"status\":505}").Return(nil).Once()
 
-	cmd := NewDownCommand(s.mockView, s.mockHash, s.mockStorage)
+	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
 	err := cmd.Handle(mockCtx)
 
 	assert.Nil(s.T(), err)
@@ -93,9 +105,10 @@ func (s *DownCommandTestSuite) TestHandleWithRedirect() {
 	mockCtx.EXPECT().Option("secret").Return("").Once()
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"redirect\":\"/maintenance\",\"status\":503}").Return(nil).Once()
 
-	cmd := NewDownCommand(s.mockView, s.mockHash, s.mockStorage)
+	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
 	err := cmd.Handle(mockCtx)
 
 	assert.Nil(s.T(), err)
@@ -111,9 +124,10 @@ func (s *DownCommandTestSuite) TestHandleWithRender() {
 	mockCtx.EXPECT().Option("secret").Return("").Once()
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"render\":\"errors/503.tmpl\",\"status\":503}").Return(nil).Once()
 
-	cmd := NewDownCommand(s.mockView, s.mockHash, s.mockStorage)
+	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
 	err := cmd.Handle(mockCtx)
 
 	assert.Nil(s.T(), err)
@@ -129,9 +143,10 @@ func (s *DownCommandTestSuite) TestHandleSecret() {
 	mockCtx.EXPECT().Option("secret").Return("secretpassword").Once()
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"reason\":\"Under maintenance\",\"secret\":\"hashedsecretpassword\",\"status\":503}").Return(nil).Once()
 
-	cmd := NewDownCommand(s.mockView, s.mockHash, s.mockStorage)
+	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
 	err := cmd.Handle(mockCtx)
 
 	assert.Nil(s.T(), err)
@@ -150,9 +165,50 @@ func (s *DownCommandTestSuite) TestHandleWithSecret() {
 		return strings.HasPrefix(arg, "Using secret:")
 	})).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"reason\":\"Under maintenance\",\"secret\":\"randomhashedsecretpassword\",\"status\":503}").Return(nil).Once()
 
-	cmd := NewDownCommand(s.mockView, s.mockHash, s.mockStorage)
+	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
+	err := cmd.Handle(mockCtx)
+
+	assert.Nil(s.T(), err)
+}
+
+func (s *DownCommandTestSuite) TestHandleWithCacheDriver() {
+	mockCtx := mocksconsole.NewContext(s.T())
+	mockCtx.EXPECT().OptionInt("status").Return(503).Once()
+	mockCtx.EXPECT().Option("reason").Return("Under maintenance").Once()
+	mockCtx.EXPECT().Option("render").Return("").Once()
+	mockCtx.EXPECT().Option("redirect").Return("").Once()
+	mockCtx.EXPECT().Option("secret").Return("").Once()
+	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
+	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("").Once()
+	s.mockCache.EXPECT().Forever("framework:maintenance", "{\"reason\":\"Under maintenance\",\"status\":503}").Return(true).Once()
+
+	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
+	err := cmd.Handle(mockCtx)
+
+	assert.Nil(s.T(), err)
+}
+
+func (s *DownCommandTestSuite) TestHandleWithNamedCacheStore() {
+	mockCacheDriver := mockscache.NewDriver(s.T())
+	mockCtx := mocksconsole.NewContext(s.T())
+	mockCtx.EXPECT().OptionInt("status").Return(503).Once()
+	mockCtx.EXPECT().Option("reason").Return("Under maintenance").Once()
+	mockCtx.EXPECT().Option("render").Return("").Once()
+	mockCtx.EXPECT().Option("redirect").Return("").Once()
+	mockCtx.EXPECT().Option("secret").Return("").Once()
+	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
+	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("redis").Once()
+	s.mockCache.EXPECT().Store("redis").Return(mockCacheDriver).Once()
+	mockCacheDriver.EXPECT().Forever("framework:maintenance", "{\"reason\":\"Under maintenance\",\"status\":503}").Return(true).Once()
+
+	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
 	err := cmd.Handle(mockCtx)
 
 	assert.Nil(s.T(), err)

--- a/foundation/console/maintenance.go
+++ b/foundation/console/maintenance.go
@@ -1,0 +1,152 @@
+package console
+
+import (
+	"strings"
+
+	"github.com/goravel/framework/contracts/cache"
+	"github.com/goravel/framework/contracts/config"
+	"github.com/goravel/framework/contracts/filesystem"
+	"github.com/goravel/framework/errors"
+)
+
+const (
+	maintenanceCacheKey    = "framework:maintenance"
+	maintenanceDriverCache = "cache"
+	maintenanceDriverFile  = "file"
+	maintenanceFilePath    = "framework/maintenance.json"
+)
+
+type MaintenanceMode struct {
+	cache   cache.Cache
+	config  config.Config
+	storage filesystem.Storage
+}
+
+func NewMaintenanceMode(config config.Config, cache cache.Cache, storage filesystem.Storage) *MaintenanceMode {
+	return &MaintenanceMode{
+		cache:   cache,
+		config:  config,
+		storage: storage,
+	}
+}
+
+func (r *MaintenanceMode) Get() ([]byte, bool, error) {
+	driver := r.driver()
+	switch driver {
+	case maintenanceDriverFile:
+		if r.storage == nil {
+			return nil, false, errors.StorageFacadeNotSet
+		}
+		if !r.storage.Exists(maintenanceFilePath) {
+			return nil, false, nil
+		}
+
+		content, err := r.storage.GetBytes(maintenanceFilePath)
+		return content, true, err
+	case maintenanceDriverCache:
+		cacheStore, err := r.cacheDriver()
+		if err != nil {
+			return nil, false, err
+		}
+		if !cacheStore.Has(maintenanceCacheKey) {
+			return nil, false, nil
+		}
+
+		return []byte(cacheStore.GetString(maintenanceCacheKey)), true, nil
+	default:
+		return nil, false, errors.MaintenanceDriverNotSupported.Args(driver)
+	}
+}
+
+func (r *MaintenanceMode) Put(content string) error {
+	driver := r.driver()
+	switch driver {
+	case maintenanceDriverFile:
+		if r.storage == nil {
+			return errors.StorageFacadeNotSet
+		}
+
+		return r.storage.Put(maintenanceFilePath, content)
+	case maintenanceDriverCache:
+		cacheStore, err := r.cacheDriver()
+		if err != nil {
+			return err
+		}
+		if !cacheStore.Forever(maintenanceCacheKey, content) {
+			return errors.MaintenanceCachePutFailed
+		}
+
+		return nil
+	default:
+		return errors.MaintenanceDriverNotSupported.Args(driver)
+	}
+}
+
+func (r *MaintenanceMode) Delete() (bool, error) {
+	driver := r.driver()
+	switch driver {
+	case maintenanceDriverFile:
+		if r.storage == nil {
+			return false, errors.StorageFacadeNotSet
+		}
+		if !r.storage.Exists(maintenanceFilePath) {
+			return false, nil
+		}
+
+		return true, r.storage.Delete(maintenanceFilePath)
+	case maintenanceDriverCache:
+		cacheStore, err := r.cacheDriver()
+		if err != nil {
+			return false, err
+		}
+		if !cacheStore.Has(maintenanceCacheKey) {
+			return false, nil
+		}
+		if !cacheStore.Forget(maintenanceCacheKey) {
+			return true, errors.MaintenanceCacheDeleteFailed
+		}
+
+		return true, nil
+	default:
+		return false, errors.MaintenanceDriverNotSupported.Args(driver)
+	}
+}
+
+func (r *MaintenanceMode) cacheDriver() (cache.Driver, error) {
+	if r.cache == nil {
+		return nil, errors.CacheFacadeNotSet
+	}
+
+	store := r.store()
+	if store == "" {
+		return r.cache, nil
+	}
+
+	driver := r.cache.Store(store)
+	if driver == nil {
+		return nil, errors.MaintenanceCacheStoreNotFound.Args(store)
+	}
+
+	return driver, nil
+}
+
+func (r *MaintenanceMode) driver() string {
+	if r.config == nil {
+		return maintenanceDriverFile
+	}
+
+	driver := strings.ToLower(r.config.GetString("APP_MAINTENANCE_DRIVER", maintenanceDriverFile))
+	if driver == "" {
+		return maintenanceDriverFile
+	}
+
+	return driver
+}
+
+func (r *MaintenanceMode) store() string {
+	if r.config == nil {
+		return ""
+	}
+
+	return r.config.GetString("APP_MAINTENANCE_STORE")
+}

--- a/foundation/console/maintenance_test.go
+++ b/foundation/console/maintenance_test.go
@@ -1,0 +1,79 @@
+package console
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	frameworkerrors "github.com/goravel/framework/errors"
+	mockscache "github.com/goravel/framework/mocks/cache"
+	mocksconfig "github.com/goravel/framework/mocks/config"
+	mocksfilesystem "github.com/goravel/framework/mocks/filesystem"
+)
+
+type MaintenanceModeTestSuite struct {
+	suite.Suite
+	mockCache   *mockscache.Cache
+	mockConfig  *mocksconfig.Config
+	mockStorage *mocksfilesystem.Storage
+}
+
+func TestMaintenanceModeTestSuite(t *testing.T) {
+	suite.Run(t, new(MaintenanceModeTestSuite))
+}
+
+func (s *MaintenanceModeTestSuite) SetupTest() {
+	s.mockCache = mockscache.NewCache(s.T())
+	s.mockConfig = mocksconfig.NewConfig(s.T())
+	s.mockStorage = mocksfilesystem.NewStorage(s.T())
+}
+
+func (s *MaintenanceModeTestSuite) maintenance() *MaintenanceMode {
+	return NewMaintenanceMode(s.mockConfig, s.mockCache, s.mockStorage)
+}
+
+func (s *MaintenanceModeTestSuite) TestGetWithFileDriver() {
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+	s.mockStorage.EXPECT().Exists("framework/maintenance.json").Return(true).Once()
+	s.mockStorage.EXPECT().GetBytes("framework/maintenance.json").Return([]byte(`{"status":503}`), nil).Once()
+
+	content, exists, err := s.maintenance().Get()
+
+	s.Nil(err)
+	s.True(exists)
+	s.Equal([]byte(`{"status":503}`), content)
+}
+
+func (s *MaintenanceModeTestSuite) TestPutWithCacheDriver() {
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("").Once()
+	s.mockCache.EXPECT().Forever("framework:maintenance", `{"status":503}`).Return(true).Once()
+
+	err := s.maintenance().Put(`{"status":503}`)
+
+	s.Nil(err)
+}
+
+func (s *MaintenanceModeTestSuite) TestDeleteWithNamedCacheStore() {
+	mockCacheDriver := mockscache.NewDriver(s.T())
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("redis").Once()
+	s.mockCache.EXPECT().Store("redis").Return(mockCacheDriver).Once()
+	mockCacheDriver.EXPECT().Has("framework:maintenance").Return(true).Once()
+	mockCacheDriver.EXPECT().Forget("framework:maintenance").Return(true).Once()
+
+	deleted, err := s.maintenance().Delete()
+
+	s.Nil(err)
+	s.True(deleted)
+}
+
+func (s *MaintenanceModeTestSuite) TestGetWithUnsupportedDriver() {
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("redis").Once()
+
+	content, exists, err := s.maintenance().Get()
+
+	s.Nil(content)
+	s.False(exists)
+	s.ErrorIs(err, frameworkerrors.MaintenanceDriverNotSupported)
+}

--- a/foundation/console/up_command.go
+++ b/foundation/console/up_command.go
@@ -3,15 +3,14 @@ package console
 import (
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/console/command"
-	"github.com/goravel/framework/contracts/filesystem"
 )
 
 type UpCommand struct {
-	storage filesystem.Storage
+	maintenance *MaintenanceMode
 }
 
-func NewUpCommand(storage filesystem.Storage) *UpCommand {
-	return &UpCommand{storage}
+func NewUpCommand(maintenance *MaintenanceMode) *UpCommand {
+	return &UpCommand{maintenance}
 }
 
 // Signature The name and signature of the console command.
@@ -31,18 +30,16 @@ func (r *UpCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *UpCommand) Handle(ctx console.Context) error {
-	path := "framework/maintenance.json"
-	if ok := r.storage.Exists(path); ok {
-		if err := r.storage.Delete(path); err != nil {
-			return err
-		}
-
-		ctx.Success("The application is up and live now")
-
+	deleted, err := r.maintenance.Delete()
+	if err != nil {
+		return err
+	}
+	if !deleted {
+		ctx.Error("The application is not in maintenance mode")
 		return nil
 	}
 
-	ctx.Error("The application is not in maintenance mode")
+	ctx.Success("The application is up and live now")
 
 	return nil
 }

--- a/foundation/console/up_command_test.go
+++ b/foundation/console/up_command_test.go
@@ -6,12 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	mockscache "github.com/goravel/framework/mocks/cache"
+	mocksconfig "github.com/goravel/framework/mocks/config"
 	mocksconsole "github.com/goravel/framework/mocks/console"
 	mocksfilesystem "github.com/goravel/framework/mocks/filesystem"
 )
 
 type UpCommandTestSuite struct {
 	suite.Suite
+	mockCache   *mockscache.Cache
+	mockConfig  *mocksconfig.Config
 	mockStorage *mocksfilesystem.Storage
 }
 
@@ -19,48 +23,83 @@ func TestUpCommandTestSuite(t *testing.T) {
 	suite.Run(t, new(UpCommandTestSuite))
 }
 
-func (s *UpCommandTestSuite) SetupSuite() {
+func (s *UpCommandTestSuite) SetupTest() {
+	s.mockCache = mockscache.NewCache(s.T())
+	s.mockConfig = mocksconfig.NewConfig(s.T())
 	s.mockStorage = mocksfilesystem.NewStorage(s.T())
 }
 
-func (s *UpCommandTestSuite) TearDownSuite() {
+func (s *UpCommandTestSuite) maintenance() *MaintenanceMode {
+	return NewMaintenanceMode(s.mockConfig, s.mockCache, s.mockStorage)
 }
 
 func (s *UpCommandTestSuite) TestSignature() {
 	expected := "up"
-	s.Require().Equal(expected, NewUpCommand(s.mockStorage).Signature())
+	s.Require().Equal(expected, NewUpCommand(s.maintenance()).Signature())
 }
 
 func (s *UpCommandTestSuite) TestDescription() {
 	expected := "Bring the application out of maintenance mode"
-	s.Require().Equal(expected, NewUpCommand(s.mockStorage).Description())
+	s.Require().Equal(expected, NewUpCommand(s.maintenance()).Description())
 }
 
 func (s *UpCommandTestSuite) TestExtend() {
-	cmd := NewUpCommand(s.mockStorage)
+	cmd := NewUpCommand(s.maintenance())
 	got := cmd.Extend()
 
 	s.Empty(got)
 }
 
 func (s *UpCommandTestSuite) TestHandle() {
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Exists("framework/maintenance.json").Return(true).Once()
 	s.mockStorage.EXPECT().Delete("framework/maintenance.json").Return(nil).Once()
 
 	mockContext := mocksconsole.NewContext(s.T())
 	mockContext.EXPECT().Success("The application is up and live now").Once()
 
-	cmd := NewUpCommand(s.mockStorage)
+	cmd := NewUpCommand(s.maintenance())
 	err := cmd.Handle(mockContext)
 	assert.Nil(s.T(), err)
 }
 
 func (s *UpCommandTestSuite) TestHandleWhenNotDown() {
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Exists("framework/maintenance.json").Return(false).Once()
 	mockContext := mocksconsole.NewContext(s.T())
 	mockContext.EXPECT().Error("The application is not in maintenance mode").Once()
 
-	cmd := NewUpCommand(s.mockStorage)
+	cmd := NewUpCommand(s.maintenance())
+	err := cmd.Handle(mockContext)
+	assert.Nil(s.T(), err)
+}
+
+func (s *UpCommandTestSuite) TestHandleWithCacheDriver() {
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("").Once()
+	s.mockCache.EXPECT().Has("framework:maintenance").Return(true).Once()
+	s.mockCache.EXPECT().Forget("framework:maintenance").Return(true).Once()
+
+	mockContext := mocksconsole.NewContext(s.T())
+	mockContext.EXPECT().Success("The application is up and live now").Once()
+
+	cmd := NewUpCommand(s.maintenance())
+	err := cmd.Handle(mockContext)
+	assert.Nil(s.T(), err)
+}
+
+func (s *UpCommandTestSuite) TestHandleWithNamedCacheStore() {
+	mockCacheDriver := mockscache.NewDriver(s.T())
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("redis").Once()
+	s.mockCache.EXPECT().Store("redis").Return(mockCacheDriver).Once()
+	mockCacheDriver.EXPECT().Has("framework:maintenance").Return(true).Once()
+	mockCacheDriver.EXPECT().Forget("framework:maintenance").Return(true).Once()
+
+	mockContext := mocksconsole.NewContext(s.T())
+	mockContext.EXPECT().Success("The application is up and live now").Once()
+
+	cmd := NewUpCommand(s.maintenance())
 	err := cmd.Handle(mockContext)
 	assert.Nil(s.T(), err)
 }

--- a/http/middleware/check_for_maintenance_mode.go
+++ b/http/middleware/check_for_maintenance_mode.go
@@ -3,42 +3,41 @@ package middleware
 import (
 	"encoding/json"
 
-	"github.com/goravel/framework/contracts/http"
-	"github.com/goravel/framework/facades"
+	httpcontract "github.com/goravel/framework/contracts/http"
+	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/foundation/console"
+	"github.com/goravel/framework/http"
 )
 
-func CheckForMaintenanceMode() http.Middleware {
-	return func(ctx http.Context) {
-		storage := facades.Storage()
-		filepath := "framework/maintenance.json"
-		if !storage.Exists(filepath) {
+func CheckForMaintenanceMode() httpcontract.Middleware {
+	return func(ctx httpcontract.Context) {
+		maintenance := console.NewMaintenanceMode(http.App.MakeConfig(), http.App.MakeCache(), http.App.MakeStorage())
+		content, exists, err := maintenance.Get()
+		if err != nil {
+			abortMaintenanceMode(ctx, err)
+			return
+		}
+		if !exists {
 			ctx.Request().Next()
 			return
 		}
 
-		content, err := storage.GetBytes(filepath)
-
-		if err != nil {
-			if err = ctx.Response().String(http.StatusServiceUnavailable, err.Error()).Abort(); err != nil {
-				panic(err)
-			}
-			return
-		}
-
-		var maintenanceOptions *console.MaintenanceOptions
+		var maintenanceOptions console.MaintenanceOptions
 		err = json.Unmarshal(content, &maintenanceOptions)
 
 		if err != nil {
-			if err = ctx.Response().String(http.StatusServiceUnavailable, err.Error()).Abort(); err != nil {
-				panic(err)
-			}
+			abortMaintenanceMode(ctx, err)
 			return
 		}
 
 		secret := ctx.Request().Query("secret", "")
 		if secret != "" && maintenanceOptions.Secret != "" {
-			if facades.Hash().Check(secret, maintenanceOptions.Secret) {
+			hash := http.App.MakeHash()
+			if hash == nil {
+				panic(errors.HashFacadeNotSet)
+			}
+
+			if hash.Check(secret, maintenanceOptions.Secret) {
 				ctx.Request().Next()
 				return
 			}
@@ -50,7 +49,7 @@ func CheckForMaintenanceMode() http.Middleware {
 				return
 			}
 
-			if err = ctx.Response().Redirect(http.StatusTemporaryRedirect, maintenanceOptions.Redirect).Abort(); err != nil {
+			if err = ctx.Response().Redirect(httpcontract.StatusTemporaryRedirect, maintenanceOptions.Redirect).Abort(); err != nil {
 				return
 			}
 			return
@@ -67,5 +66,11 @@ func CheckForMaintenanceMode() http.Middleware {
 		if err = ctx.Response().String(maintenanceOptions.Status, maintenanceOptions.Reason).Abort(); err != nil {
 			panic(err)
 		}
+	}
+}
+
+func abortMaintenanceMode(ctx httpcontract.Context, err error) {
+	if err = ctx.Response().String(httpcontract.StatusServiceUnavailable, err.Error()).Abort(); err != nil {
+		panic(err)
 	}
 }

--- a/http/middleware/check_for_maintenance_mode.go
+++ b/http/middleware/check_for_maintenance_mode.go
@@ -3,14 +3,14 @@ package middleware
 import (
 	"encoding/json"
 
-	httpcontract "github.com/goravel/framework/contracts/http"
+	contractshttp "github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/foundation/console"
 	"github.com/goravel/framework/http"
 )
 
-func CheckForMaintenanceMode() httpcontract.Middleware {
-	return func(ctx httpcontract.Context) {
+func CheckForMaintenanceMode() contractshttp.Middleware {
+	return func(ctx contractshttp.Context) {
 		maintenance := console.NewMaintenanceMode(http.App.MakeConfig(), http.App.MakeCache(), http.App.MakeStorage())
 		content, exists, err := maintenance.Get()
 		if err != nil {
@@ -49,7 +49,7 @@ func CheckForMaintenanceMode() httpcontract.Middleware {
 				return
 			}
 
-			if err = ctx.Response().Redirect(httpcontract.StatusTemporaryRedirect, maintenanceOptions.Redirect).Abort(); err != nil {
+			if err = ctx.Response().Redirect(contractshttp.StatusTemporaryRedirect, maintenanceOptions.Redirect).Abort(); err != nil {
 				return
 			}
 			return
@@ -69,8 +69,8 @@ func CheckForMaintenanceMode() httpcontract.Middleware {
 	}
 }
 
-func abortMaintenanceMode(ctx httpcontract.Context, err error) {
-	if err = ctx.Response().String(httpcontract.StatusServiceUnavailable, err.Error()).Abort(); err != nil {
+func abortMaintenanceMode(ctx contractshttp.Context, err error) {
+	if err = ctx.Response().String(contractshttp.StatusServiceUnavailable, err.Error()).Abort(); err != nil {
 		panic(err)
 	}
 }

--- a/http/middleware/check_for_maintenance_mode_test.go
+++ b/http/middleware/check_for_maintenance_mode_test.go
@@ -9,8 +9,9 @@ import (
 
 	contractshttp "github.com/goravel/framework/contracts/http"
 	"github.com/goravel/framework/http"
-	"github.com/goravel/framework/testing/mock"
 
+	mockscache "github.com/goravel/framework/mocks/cache"
+	mocksconfig "github.com/goravel/framework/mocks/config"
 	mocksfilesystem "github.com/goravel/framework/mocks/filesystem"
 	mocksfoundation "github.com/goravel/framework/mocks/foundation"
 	mockshash "github.com/goravel/framework/mocks/hash"
@@ -20,6 +21,8 @@ import (
 type MaintenanceTestSuite struct {
 	suite.Suite
 	mockApp               *mocksfoundation.Application
+	mockCache             *mockscache.Cache
+	mockConfig            *mocksconfig.Config
 	mockCtx               *mockshttp.Context
 	mockFile              *mocksfilesystem.File
 	mockHash              *mockshash.Hash
@@ -34,19 +37,36 @@ func TestMaintenanceModeSuite(t *testing.T) {
 }
 
 func (s *MaintenanceTestSuite) SetupTest() {
-	mockFactory := mock.Factory()
 	s.mockApp = mocksfoundation.NewApplication(s.T())
+	s.mockCache = mockscache.NewCache(s.T())
+	s.mockConfig = mocksconfig.NewConfig(s.T())
 	s.mockCtx = mockshttp.NewContext(s.T())
 	s.mockFile = mocksfilesystem.NewFile(s.T())
-	s.mockHash = mockFactory.Hash()
+	s.mockHash = mockshash.NewHash(s.T())
 	s.mockRequest = mockshttp.NewContextRequest(s.T())
 	s.mockResponse = mockshttp.NewContextResponse(s.T())
 	s.mockAbortableResponse = mockshttp.NewAbortableResponse(s.T())
-	s.mockStorage = mockFactory.Storage()
+	s.mockStorage = mocksfilesystem.NewStorage(s.T())
 	http.App = s.mockApp
 }
 
+func (s *MaintenanceTestSuite) expectFileMaintenanceDriver() {
+	s.mockApp.EXPECT().MakeConfig().Return(s.mockConfig).Once()
+	s.mockApp.EXPECT().MakeCache().Return(s.mockCache).Once()
+	s.mockApp.EXPECT().MakeStorage().Return(s.mockStorage).Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+}
+
+func (s *MaintenanceTestSuite) expectCacheMaintenanceDriver() {
+	s.mockApp.EXPECT().MakeConfig().Return(s.mockConfig).Once()
+	s.mockApp.EXPECT().MakeCache().Return(s.mockCache).Once()
+	s.mockApp.EXPECT().MakeStorage().Return(s.mockStorage).Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("").Once()
+}
+
 func (s *MaintenanceTestSuite) TestMaintenaneMode_NotUnderMaintenance() {
+	s.expectFileMaintenanceDriver()
 	s.mockCtx.EXPECT().Request().Return(s.mockRequest).Once()
 	s.mockRequest.EXPECT().Next().Once()
 	s.mockStorage.EXPECT().Exists("framework/maintenance.json").Return(false).Once()
@@ -60,6 +80,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_StorageFilePermissionIssue() {
 	abortableResponse := mockshttp.NewAbortableResponse(s.T())
 	abortableResponse.EXPECT().Abort().Return(err).Once()
 
+	s.expectFileMaintenanceDriver()
 	s.mockCtx.EXPECT().Response().Return(s.mockResponse).Once()
 	s.mockStorage.EXPECT().Exists("framework/maintenance.json").Return(true).Once()
 	s.mockStorage.EXPECT().GetBytes("framework/maintenance.json").Return(nil, err).Once()
@@ -75,6 +96,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_StorageFileInvalidJSON() {
 	err := errors.New("invalid character 'i' looking for beginning of value")
 	s.mockAbortableResponse.EXPECT().Abort().Return(err).Once()
 
+	s.expectFileMaintenanceDriver()
 	s.mockCtx.EXPECT().Response().Return(s.mockResponse).Once()
 	s.mockStorage.EXPECT().Exists("framework/maintenance.json").Return(true).Once()
 	s.mockStorage.EXPECT().GetBytes("framework/maintenance.json").Return([]byte("invalid json"), nil).Once()
@@ -87,6 +109,8 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_StorageFileInvalidJSON() {
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_SecretDoesNotMatch() {
+	s.expectFileMaintenanceDriver()
+	s.mockApp.EXPECT().MakeHash().Return(s.mockHash).Once()
 	s.mockHash.EXPECT().Check("invalid-secret", "hashed-secret").Return(false).Once()
 	s.mockCtx.EXPECT().Request().Return(s.mockRequest).Once()
 	s.mockCtx.EXPECT().Response().Return(s.mockResponse).Once()
@@ -101,6 +125,8 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_SecretDoesNotMatch() {
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_SecretMatches() {
+	s.expectFileMaintenanceDriver()
+	s.mockApp.EXPECT().MakeHash().Return(s.mockHash).Once()
 	s.mockHash.EXPECT().Check("valid-secret", "hashed-secret").Return(true).Once()
 	s.mockCtx.EXPECT().Request().Return(s.mockRequest).Twice()
 	s.mockRequest.EXPECT().Next().Once()
@@ -113,6 +139,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_SecretMatches() {
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_Redirect() {
+	s.expectFileMaintenanceDriver()
 	s.mockCtx.EXPECT().Request().Return(s.mockRequest).Twice()
 	s.mockCtx.EXPECT().Response().Return(s.mockResponse).Once()
 	s.mockRequest.EXPECT().Query("secret", "").Return("").Once()
@@ -127,6 +154,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_Redirect() {
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_Render() {
+	s.expectFileMaintenanceDriver()
 	s.mockCtx.EXPECT().Request().Return(s.mockRequest).Twice()
 	s.mockRequest.EXPECT().Query("secret", "").Return("").Once()
 	s.mockStorage.EXPECT().Exists("framework/maintenance.json").Return(true).Once()
@@ -139,6 +167,40 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_Render() {
 	mocksView.EXPECT().Make("maintenance").Return(mocksHttpResponse).Once()
 	s.mockResponse.EXPECT().View().Return(mocksView).Once()
 	s.mockCtx.EXPECT().Response().Return(s.mockResponse).Once()
+
+	middleware := CheckForMaintenanceMode()
+	middleware(s.mockCtx)
+}
+
+func (s *MaintenanceTestSuite) TestMaintenaneMode_CacheDriver() {
+	s.expectCacheMaintenanceDriver()
+	s.mockCache.EXPECT().Has("framework:maintenance").Return(true).Once()
+	s.mockCache.EXPECT().GetString("framework:maintenance").Return(`{"reason":"Under Maintenance", "status": 503}`).Once()
+	s.mockCtx.EXPECT().Request().Return(s.mockRequest).Once()
+	s.mockCtx.EXPECT().Response().Return(s.mockResponse).Once()
+	s.mockRequest.EXPECT().Query("secret", "").Return("").Once()
+	s.mockAbortableResponse.EXPECT().Abort().Return(nil).Once()
+	s.mockResponse.EXPECT().String(contractshttp.StatusServiceUnavailable, "Under Maintenance").Return(s.mockAbortableResponse).Once()
+
+	middleware := CheckForMaintenanceMode()
+	middleware(s.mockCtx)
+}
+
+func (s *MaintenanceTestSuite) TestMaintenaneMode_NamedCacheStore() {
+	mockCacheDriver := mockscache.NewDriver(s.T())
+	s.mockApp.EXPECT().MakeConfig().Return(s.mockConfig).Once()
+	s.mockApp.EXPECT().MakeCache().Return(s.mockCache).Once()
+	s.mockApp.EXPECT().MakeStorage().Return(s.mockStorage).Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("redis").Once()
+	s.mockCache.EXPECT().Store("redis").Return(mockCacheDriver).Once()
+	mockCacheDriver.EXPECT().Has("framework:maintenance").Return(true).Once()
+	mockCacheDriver.EXPECT().GetString("framework:maintenance").Return(`{"reason":"Under Maintenance", "status": 503}`).Once()
+	s.mockCtx.EXPECT().Request().Return(s.mockRequest).Once()
+	s.mockCtx.EXPECT().Response().Return(s.mockResponse).Once()
+	s.mockRequest.EXPECT().Query("secret", "").Return("").Once()
+	s.mockAbortableResponse.EXPECT().Abort().Return(nil).Once()
+	s.mockResponse.EXPECT().String(contractshttp.StatusServiceUnavailable, "Under Maintenance").Return(s.mockAbortableResponse).Once()
 
 	middleware := CheckForMaintenanceMode()
 	middleware(s.mockCtx)


### PR DESCRIPTION
## Summary
- Allows maintenance mode state to be stored in a shared cache store for multi-server deployments.
- Keeps file-backed maintenance mode as the default behavior.
- Resolves maintenance middleware dependencies from the HTTP application container instead of global storage/hash facades.

## Why
PR #1198 introduced file-backed up/down maintenance mode, which requires running the command on each server. A cache-backed driver lets applications share the same maintenance payload through an existing cache store while preserving the current file behavior by default.

```dotenv
APP_MAINTENANCE_DRIVER=cache
APP_MAINTENANCE_STORE=redis
```

With this configuration, running `go run . artisan down` or `go run . artisan up` on one server updates the maintenance state for every server using that cache store. The middleware now resolves storage, cache, config, and hash through `http.App.Make*()` like the other HTTP middleware, which makes it consistent with container-backed dependencies and easier to test.
