### PR TITLE
fix: [#726] scope log handler cache to the application

### DIFF
--- a/log/application.go
+++ b/log/application.go
@@ -17,8 +17,6 @@ import (
 	telemetrylog "github.com/goravel/framework/telemetry/instrumentation/log"
 )
 
-var channelToHandlers sync.Map
-
 type Application struct {
 	log.Writer
 	ctx               context.Context
@@ -26,9 +24,18 @@ type Application struct {
 	config            config.Config
 	json              foundation.Json
 	telemetryResolver contractstelemetry.Resolver
+	handlerCache      *sync.Map
 }
 
 func NewApplication(ctx context.Context, channels []string, config config.Config, json foundation.Json, resolver contractstelemetry.Resolver) (*Application, error) {
+	return newApplication(ctx, channels, config, json, resolver, &sync.Map{})
+}
+
+// newApplication shares handlerCache between an Application and the instances
+// derived from it via WithContext, Channel, and Stack. Cached handlers hold
+// loggers from the telemetry providers that existed when they were built, so
+// the cache must not outlive the container that created the root Application.
+func newApplication(ctx context.Context, channels []string, config config.Config, json foundation.Json, resolver contractstelemetry.Resolver, handlerCache *sync.Map) (*Application, error) {
 	var handlers []slog.Handler
 
 	if len(channels) == 0 && config != nil {
@@ -38,7 +45,7 @@ func NewApplication(ctx context.Context, channels []string, config config.Config
 	}
 
 	for _, channel := range channels {
-		channelHandlers, err := getHandlers(config, json, resolver, channel)
+		channelHandlers, err := getHandlers(handlerCache, config, json, resolver, channel)
 		if err != nil {
 			return nil, err
 		}
@@ -54,6 +61,7 @@ func NewApplication(ctx context.Context, channels []string, config config.Config
 		config:            config,
 		json:              json,
 		telemetryResolver: resolver,
+		handlerCache:      handlerCache,
 		Writer:            NewWriter(ctx, slogLogger),
 	}, nil
 }
@@ -63,7 +71,7 @@ func (r *Application) WithContext(ctx context.Context) log.Log {
 		ctx = httpCtx.Context()
 	}
 
-	app, err := NewApplication(ctx, r.channels, r.config, r.json, r.telemetryResolver)
+	app, err := newApplication(ctx, r.channels, r.config, r.json, r.telemetryResolver, r.handlerCache)
 	if err != nil {
 		r.Error(err)
 
@@ -78,7 +86,7 @@ func (r *Application) Channel(channel string) log.Log {
 		return r
 	}
 
-	app, err := NewApplication(r.ctx, []string{channel}, r.config, r.json, r.telemetryResolver)
+	app, err := newApplication(r.ctx, []string{channel}, r.config, r.json, r.telemetryResolver, r.handlerCache)
 	if err != nil {
 		r.Error(err)
 
@@ -93,7 +101,7 @@ func (r *Application) Stack(channels []string) log.Log {
 		return r
 	}
 
-	app, err := NewApplication(r.ctx, channels, r.config, r.json, r.telemetryResolver)
+	app, err := newApplication(r.ctx, channels, r.config, r.json, r.telemetryResolver, r.handlerCache)
 	if err != nil {
 		r.Error(err)
 
@@ -104,9 +112,9 @@ func (r *Application) Stack(channels []string) log.Log {
 }
 
 // getHandlers returns slog log handlers for the specified channel.
-func getHandlers(config config.Config, json foundation.Json, telemetryResolver contractstelemetry.Resolver, channel string) ([]slog.Handler, error) {
+func getHandlers(handlerCache *sync.Map, config config.Config, json foundation.Json, telemetryResolver contractstelemetry.Resolver, channel string) ([]slog.Handler, error) {
 	var handlers []slog.Handler
-	handlersAny, ok := channelToHandlers.Load(channel)
+	handlersAny, ok := handlerCache.Load(channel)
 	if ok {
 		return handlersAny.([]slog.Handler), nil
 	}
@@ -126,7 +134,7 @@ func getHandlers(config config.Config, json foundation.Json, telemetryResolver c
 				return nil, errors.LogDriverCircularReference.Args("stack")
 			}
 
-			channelHandlers, err := getHandlers(config, json, telemetryResolver, stackChannel)
+			channelHandlers, err := getHandlers(handlerCache, config, json, telemetryResolver, stackChannel)
 			if err != nil {
 				return nil, err
 			}
@@ -186,7 +194,7 @@ func getHandlers(config config.Config, json foundation.Json, telemetryResolver c
 		return nil, errors.LogDriverNotSupported.Args(channel)
 	}
 
-	channelToHandlers.Store(channel, handlers)
+	handlerCache.Store(channel, handlers)
 
 	return handlers, nil
 }

--- a/log/application.go
+++ b/log/application.go
@@ -24,18 +24,18 @@ type Application struct {
 	config            config.Config
 	json              foundation.Json
 	telemetryResolver contractstelemetry.Resolver
-	handlerCache      *sync.Map
+	channelToHandlers *sync.Map
 }
 
 func NewApplication(ctx context.Context, channels []string, config config.Config, json foundation.Json, resolver contractstelemetry.Resolver) (*Application, error) {
 	return newApplication(ctx, channels, config, json, resolver, &sync.Map{})
 }
 
-// newApplication shares handlerCache between an Application and the instances
+// newApplication shares channelToHandlers between an Application and the instances
 // derived from it via WithContext, Channel, and Stack. Cached handlers hold
 // loggers from the telemetry providers that existed when they were built, so
 // the cache must not outlive the container that created the root Application.
-func newApplication(ctx context.Context, channels []string, config config.Config, json foundation.Json, resolver contractstelemetry.Resolver, handlerCache *sync.Map) (*Application, error) {
+func newApplication(ctx context.Context, channels []string, config config.Config, json foundation.Json, resolver contractstelemetry.Resolver, channelToHandlers *sync.Map) (*Application, error) {
 	var handlers []slog.Handler
 
 	if len(channels) == 0 && config != nil {
@@ -45,7 +45,7 @@ func newApplication(ctx context.Context, channels []string, config config.Config
 	}
 
 	for _, channel := range channels {
-		channelHandlers, err := getHandlers(handlerCache, config, json, resolver, channel)
+		channelHandlers, err := getHandlers(channelToHandlers, config, json, resolver, channel)
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func newApplication(ctx context.Context, channels []string, config config.Config
 		config:            config,
 		json:              json,
 		telemetryResolver: resolver,
-		handlerCache:      handlerCache,
+		channelToHandlers: channelToHandlers,
 		Writer:            NewWriter(ctx, slogLogger),
 	}, nil
 }
@@ -71,7 +71,7 @@ func (r *Application) WithContext(ctx context.Context) log.Log {
 		ctx = httpCtx.Context()
 	}
 
-	app, err := newApplication(ctx, r.channels, r.config, r.json, r.telemetryResolver, r.handlerCache)
+	app, err := newApplication(ctx, r.channels, r.config, r.json, r.telemetryResolver, r.channelToHandlers)
 	if err != nil {
 		r.Error(err)
 
@@ -86,7 +86,7 @@ func (r *Application) Channel(channel string) log.Log {
 		return r
 	}
 
-	app, err := newApplication(r.ctx, []string{channel}, r.config, r.json, r.telemetryResolver, r.handlerCache)
+	app, err := newApplication(r.ctx, []string{channel}, r.config, r.json, r.telemetryResolver, r.channelToHandlers)
 	if err != nil {
 		r.Error(err)
 
@@ -101,7 +101,7 @@ func (r *Application) Stack(channels []string) log.Log {
 		return r
 	}
 
-	app, err := newApplication(r.ctx, channels, r.config, r.json, r.telemetryResolver, r.handlerCache)
+	app, err := newApplication(r.ctx, channels, r.config, r.json, r.telemetryResolver, r.channelToHandlers)
 	if err != nil {
 		r.Error(err)
 
@@ -112,9 +112,9 @@ func (r *Application) Stack(channels []string) log.Log {
 }
 
 // getHandlers returns slog log handlers for the specified channel.
-func getHandlers(handlerCache *sync.Map, config config.Config, json foundation.Json, telemetryResolver contractstelemetry.Resolver, channel string) ([]slog.Handler, error) {
+func getHandlers(channelToHandlers *sync.Map, config config.Config, json foundation.Json, telemetryResolver contractstelemetry.Resolver, channel string) ([]slog.Handler, error) {
 	var handlers []slog.Handler
-	handlersAny, ok := handlerCache.Load(channel)
+	handlersAny, ok := channelToHandlers.Load(channel)
 	if ok {
 		return handlersAny.([]slog.Handler), nil
 	}
@@ -134,7 +134,7 @@ func getHandlers(handlerCache *sync.Map, config config.Config, json foundation.J
 				return nil, errors.LogDriverCircularReference.Args("stack")
 			}
 
-			channelHandlers, err := getHandlers(handlerCache, config, json, telemetryResolver, stackChannel)
+			channelHandlers, err := getHandlers(channelToHandlers, config, json, telemetryResolver, stackChannel)
 			if err != nil {
 				return nil, err
 			}
@@ -194,7 +194,7 @@ func getHandlers(handlerCache *sync.Map, config config.Config, json foundation.J
 		return nil, errors.LogDriverNotSupported.Args(channel)
 	}
 
-	handlerCache.Store(channel, handlers)
+	channelToHandlers.Store(channel, handlers)
 
 	return handlers, nil
 }

--- a/log/application_test.go
+++ b/log/application_test.go
@@ -91,15 +91,15 @@ func TestApplication_HandlerCacheScope(t *testing.T) {
 
 	app, err := NewApplication(context.Background(), nil, mockConfig, json.New(), nil)
 	assert.Nil(t, err)
-	app.handlerCache.Store("otel", []slog.Handler{})
+	app.channelToHandlers.Store("otel", []slog.Handler{})
 
 	derived := app.WithContext(context.Background()).(*Application)
-	_, shared := derived.handlerCache.Load("otel")
+	_, shared := derived.channelToHandlers.Load("otel")
 	assert.True(t, shared)
 
 	fresh, err := NewApplication(context.Background(), nil, mockConfig, json.New(), nil)
 	assert.Nil(t, err)
-	_, leaked := fresh.handlerCache.Load("otel")
+	_, leaked := fresh.channelToHandlers.Load("otel")
 	assert.False(t, leaked)
 }
 

--- a/log/application_test.go
+++ b/log/application_test.go
@@ -2,6 +2,8 @@ package log
 
 import (
 	"context"
+	"log/slog"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,14 +16,6 @@ import (
 	"github.com/goravel/framework/support/file"
 	telemetrylog "github.com/goravel/framework/telemetry/instrumentation/log"
 )
-
-// clearChannelCache clears all entries from the channel cache
-func clearChannelCache() {
-	channelToHandlers.Range(func(key, value any) bool {
-		channelToHandlers.Delete(key)
-		return true
-	})
-}
 
 func TestNewApplication(t *testing.T) {
 	j := json.New()
@@ -44,9 +38,6 @@ func TestNewApplication(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, app)
 
-	// Clear cache before testing unsupported driver
-	clearChannelCache()
-
 	mockConfig = mocksconfig.NewConfig(t)
 	mockConfig.EXPECT().GetString("logging.default").Return("test").Once()
 	mockConfig.EXPECT().GetString("logging.channels.test.driver").Return("test").Once()
@@ -61,9 +52,6 @@ func TestNewApplication(t *testing.T) {
 }
 
 func TestApplication_Channel(t *testing.T) {
-	// Clear cache before test
-	clearChannelCache()
-
 	mockConfig := mocksconfig.NewConfig(t)
 	mockConfig.EXPECT().GetString("logging.default").Return("test").Once()
 	mockConfig.EXPECT().GetString("logging.channels.test.driver").Return("single").Once()
@@ -97,10 +85,25 @@ func TestApplication_Channel(t *testing.T) {
 	_ = file.Remove("dummy")
 }
 
-func TestApplication_Stack(t *testing.T) {
-	// Clear cache before test
-	clearChannelCache()
+func TestApplication_HandlerCacheScope(t *testing.T) {
+	mockConfig := mocksconfig.NewConfig(t)
+	mockConfig.EXPECT().GetString("logging.default").Return("").Times(3)
 
+	app, err := NewApplication(context.Background(), nil, mockConfig, json.New(), nil)
+	assert.Nil(t, err)
+	app.handlerCache.Store("otel", []slog.Handler{})
+
+	derived := app.WithContext(context.Background()).(*Application)
+	_, shared := derived.handlerCache.Load("otel")
+	assert.True(t, shared)
+
+	fresh, err := NewApplication(context.Background(), nil, mockConfig, json.New(), nil)
+	assert.Nil(t, err)
+	_, leaked := fresh.handlerCache.Load("otel")
+	assert.False(t, leaked)
+}
+
+func TestApplication_Stack(t *testing.T) {
 	mockConfig := mocksconfig.NewConfig(t)
 	mockConfig.EXPECT().GetString("logging.default").Return("test").Once()
 	mockConfig.EXPECT().GetString("logging.channels.test.driver").Return("single").Once()
@@ -144,13 +147,12 @@ func TestGetHandlers(t *testing.T) {
 		mockConfig.EXPECT().GetString("logging.channels.test-single.formatter", "text").Return("text").Once()
 		mockConfig.EXPECT().GetBool("logging.channels.test-single.print").Return(false).Once()
 
-		handlers, err := getHandlers(mockConfig, j, nil, "test-single")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, nil, "test-single")
 		assert.NoError(t, err)
 		assert.Len(t, handlers, 1)
 
 		// Cleanup
 		_ = file.Remove("test-single.log")
-		clearChannelCache()
 	})
 
 	t.Run("single driver with print enabled", func(t *testing.T) {
@@ -161,13 +163,12 @@ func TestGetHandlers(t *testing.T) {
 		mockConfig.EXPECT().GetString("logging.channels.test-single-print.formatter", "text").Return("text").Times(2)
 		mockConfig.EXPECT().GetBool("logging.channels.test-single-print.print").Return(true).Once()
 
-		handlers, err := getHandlers(mockConfig, j, nil, "test-single-print")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, nil, "test-single-print")
 		assert.NoError(t, err)
 		assert.Len(t, handlers, 2) // file handler + console handler
 
 		// Cleanup
 		_ = file.Remove("test-single-print.log")
-		clearChannelCache()
 	})
 
 	t.Run("daily driver", func(t *testing.T) {
@@ -179,12 +180,10 @@ func TestGetHandlers(t *testing.T) {
 		mockConfig.EXPECT().GetBool("logging.channels.test-daily.print").Return(false).Once()
 		mockConfig.EXPECT().GetInt("logging.channels.test-daily.days").Return(7).Once()
 
-		handlers, err := getHandlers(mockConfig, j, nil, "test-daily")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, nil, "test-daily")
 		assert.NoError(t, err)
 		assert.Len(t, handlers, 1)
 
-		// Cleanup
-		clearChannelCache()
 	})
 
 	t.Run("daily driver with print enabled", func(t *testing.T) {
@@ -196,12 +195,10 @@ func TestGetHandlers(t *testing.T) {
 		mockConfig.EXPECT().GetBool("logging.channels.test-daily-print.print").Return(true).Once()
 		mockConfig.EXPECT().GetInt("logging.channels.test-daily-print.days").Return(3).Once()
 
-		handlers, err := getHandlers(mockConfig, j, nil, "test-daily-print")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, nil, "test-daily-print")
 		assert.NoError(t, err)
 		assert.Len(t, handlers, 2)
 
-		// Cleanup
-		clearChannelCache()
 	})
 
 	t.Run("OTeL driver", func(t *testing.T) {
@@ -217,11 +214,10 @@ func TestGetHandlers(t *testing.T) {
 			return mockTelemetry
 		}
 
-		handlers, err := getHandlers(mockConfig, j, resolver, "test-otel")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, resolver, "test-otel")
 		assert.NoError(t, err)
 		assert.Len(t, handlers, 1)
 
-		clearChannelCache()
 	})
 
 	t.Run("OTeL driver with print enabled", func(t *testing.T) {
@@ -240,11 +236,10 @@ func TestGetHandlers(t *testing.T) {
 			return mockTelemetry
 		}
 
-		handlers, err := getHandlers(mockConfig, j, resolver, "test-otel-print")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, resolver, "test-otel-print")
 		assert.NoError(t, err)
 		assert.Len(t, handlers, 2)
 
-		clearChannelCache()
 	})
 
 	t.Run("stack driver", func(t *testing.T) {
@@ -266,14 +261,13 @@ func TestGetHandlers(t *testing.T) {
 		mockConfig.EXPECT().GetString("logging.channels.stack-single2.formatter", "text").Return("text").Once()
 		mockConfig.EXPECT().GetBool("logging.channels.stack-single2.print").Return(false).Once()
 
-		handlers, err := getHandlers(mockConfig, j, nil, "test-stack")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, nil, "test-stack")
 		assert.NoError(t, err)
 		assert.Len(t, handlers, 2) // One from each channel
 
 		// Cleanup
 		_ = file.Remove("test-stack-single1.log")
 		_ = file.Remove("test-stack-single2.log")
-		clearChannelCache()
 	})
 
 	t.Run("stack driver with circular reference", func(t *testing.T) {
@@ -281,13 +275,11 @@ func TestGetHandlers(t *testing.T) {
 		mockConfig.EXPECT().GetString("logging.channels.test-circular.driver").Return("stack").Once()
 		mockConfig.EXPECT().Get("logging.channels.test-circular.channels").Return([]string{"test-circular"}).Once()
 
-		handlers, err := getHandlers(mockConfig, j, nil, "test-circular")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, nil, "test-circular")
 		assert.Error(t, err)
 		assert.EqualError(t, err, errors.LogDriverCircularReference.Args("stack").Error())
 		assert.Nil(t, handlers)
 
-		// Cleanup
-		clearChannelCache()
 	})
 
 	t.Run("stack driver with invalid channels config", func(t *testing.T) {
@@ -295,13 +287,11 @@ func TestGetHandlers(t *testing.T) {
 		mockConfig.EXPECT().GetString("logging.channels.test-badstack.driver").Return("stack").Once()
 		mockConfig.EXPECT().Get("logging.channels.test-badstack.channels").Return("not-a-slice").Once()
 
-		handlers, err := getHandlers(mockConfig, j, nil, "test-badstack")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, nil, "test-badstack")
 		assert.Error(t, err)
 		assert.EqualError(t, err, errors.LogChannelNotFound.Args("test-badstack").Error())
 		assert.Nil(t, handlers)
 
-		// Cleanup
-		clearChannelCache()
 	})
 
 	t.Run("custom driver", func(t *testing.T) {
@@ -311,12 +301,10 @@ func TestGetHandlers(t *testing.T) {
 		customLogger := &CustomLogger{}
 		mockConfig.EXPECT().Get("logging.channels.test-custom.via").Return(customLogger).Once()
 
-		handlers, err := getHandlers(mockConfig, j, nil, "test-custom")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, nil, "test-custom")
 		assert.NoError(t, err)
 		assert.Len(t, handlers, 1)
 
-		// Cleanup
-		clearChannelCache()
 	})
 
 	t.Run("custom driver without logger", func(t *testing.T) {
@@ -324,26 +312,22 @@ func TestGetHandlers(t *testing.T) {
 		mockConfig.EXPECT().GetString("logging.channels.test-badcustom.driver").Return("custom").Once()
 		mockConfig.EXPECT().Get("logging.channels.test-badcustom.via").Return(nil).Once()
 
-		handlers, err := getHandlers(mockConfig, j, nil, "test-badcustom")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, nil, "test-badcustom")
 		assert.Error(t, err)
 		assert.EqualError(t, err, errors.LogChannelUnimplemented.Args("test-badcustom").Error())
 		assert.Nil(t, handlers)
 
-		// Cleanup
-		clearChannelCache()
 	})
 
 	t.Run("unsupported driver", func(t *testing.T) {
 		mockConfig := mocksconfig.NewConfig(t)
 		mockConfig.EXPECT().GetString("logging.channels.test-unknown.driver").Return("unknown").Once()
 
-		handlers, err := getHandlers(mockConfig, j, nil, "test-unknown")
+		handlers, err := getHandlers(&sync.Map{}, mockConfig, j, nil, "test-unknown")
 		assert.Error(t, err)
 		assert.EqualError(t, err, errors.LogDriverNotSupported.Args("test-unknown").Error())
 		assert.Nil(t, handlers)
 
-		// Cleanup
-		clearChannelCache()
 	})
 
 	t.Run("cached handlers", func(t *testing.T) {
@@ -354,19 +338,20 @@ func TestGetHandlers(t *testing.T) {
 		mockConfig.EXPECT().GetString("logging.channels.test-cached.formatter", "text").Return("text").Once()
 		mockConfig.EXPECT().GetBool("logging.channels.test-cached.print").Return(false).Once()
 
+		cache := &sync.Map{}
+
 		// First call should use mock config
-		handlers1, err := getHandlers(mockConfig, j, nil, "test-cached")
+		handlers1, err := getHandlers(cache, mockConfig, j, nil, "test-cached")
 		assert.NoError(t, err)
 		assert.Len(t, handlers1, 1)
 
 		// Second call should use cached handlers (no mock expectations needed)
-		handlers2, err := getHandlers(mockConfig, j, nil, "test-cached")
+		handlers2, err := getHandlers(cache, mockConfig, j, nil, "test-cached")
 		assert.NoError(t, err)
 		assert.Len(t, handlers2, 1)
 		assert.Equal(t, handlers1, handlers2)
 
 		// Cleanup
 		_ = file.Remove("test-cached.log")
-		clearChannelCache()
 	})
 }

--- a/log/writer_test.go
+++ b/log/writer_test.go
@@ -38,8 +38,6 @@ func TestWriter(t *testing.T) {
 	)
 
 	beforeEach := func() {
-		// Clear handler cache to ensure each test starts fresh
-		clearChannelCache()
 		mockConfig = initMockConfig(t)
 	}
 
@@ -368,8 +366,6 @@ func TestWriter(t *testing.T) {
 }
 
 func TestWriter_WithContext(t *testing.T) {
-	// Clear handler cache
-	clearChannelCache()
 
 	// First NewApplication call reads config and creates handlers which are then cached.
 	// WithContext creates a new Application, but reuses the cached handlers,
@@ -415,8 +411,6 @@ func TestWriter_WithContext(t *testing.T) {
 }
 
 func TestWriter_LevelNotMatch(t *testing.T) {
-	// Clear handler cache
-	clearChannelCache()
 
 	mockConfig := mocksconfig.NewConfig(t)
 	mockConfig.EXPECT().GetString("logging.default").Return("stack").Once()
@@ -445,8 +439,6 @@ func TestWriter_LevelNotMatch(t *testing.T) {
 }
 
 func TestWriter_DailyLogWithDifferentDays(t *testing.T) {
-	// Clear handler cache
-	clearChannelCache()
 
 	mockConfig := initMockConfig(t)
 	// app.env is called twice per log write (once for each handler: single + daily)
@@ -481,8 +473,6 @@ func TestWriter_DailyLogWithDifferentDays(t *testing.T) {
 }
 
 func TestWriterWithCustomLogger(t *testing.T) {
-	// Clear handler cache
-	clearChannelCache()
 
 	mockConfig := mocksconfig.NewConfig(t)
 	mockConfig.EXPECT().GetString("logging.default").Return("customLogger").Once()
@@ -512,8 +502,6 @@ func TestWriterWithCustomLogger(t *testing.T) {
 }
 
 func TestWriter_Fatal(t *testing.T) {
-	// Clear handler cache
-	clearChannelCache()
 
 	mockConfig := initMockConfig(t)
 	log, err := NewApplication(context.Background(), nil, mockConfig, json.New(), nil)
@@ -537,8 +525,6 @@ func TestWriter_Fatal(t *testing.T) {
 }
 
 func TestWriter_Fatalf(t *testing.T) {
-	// Clear handler cache
-	clearChannelCache()
 
 	mockConfig := initMockConfig(t)
 	log, err := NewApplication(context.Background(), nil, mockConfig, json.New(), nil)
@@ -562,8 +548,6 @@ func TestWriter_Fatalf(t *testing.T) {
 }
 
 func TestWriter_ConcurrentAccess(t *testing.T) {
-	// Clear handler cache
-	clearChannelCache()
 
 	// This test verifies that concurrent access to the same log.Writer
 	// does not cause data races or entry contamination.
@@ -667,8 +651,6 @@ func TestWriter_ConcurrentAccess(t *testing.T) {
 }
 
 func TestWriter_NoEntryContamination(t *testing.T) {
-	// Clear handler cache
-	clearChannelCache()
 
 	// This test verifies that calling fluent methods on the base writer
 	// returns a new writer and does not affect the original.
@@ -691,8 +673,6 @@ func TestWriter_NoEntryContamination(t *testing.T) {
 }
 
 func TestWriter_FluentChainIsolation(t *testing.T) {
-	// Clear handler cache
-	clearChannelCache()
 
 	// This test verifies that multiple fluent chains are isolated from each other.
 	mockConfig := initMockConfig(t)


### PR DESCRIPTION
## 📑 Description

RelatedTo https://github.com/goravel/goravel/issues/726

The log module caches channel handlers in a package level `sync.Map`, so they survive `facades.App().Restart()`. Handlers that hold per container resources keep using the old ones after the restart; for the otel channel this means emitting into a shut down logger provider, which silently drops every record.

Scope the cache to the `Application` instead: instances derived via `WithContext`/`Channel`/`Stack` share it, and it dies with the container. Also removes the `clearChannelCache()` test helper that existed to work around the global.

@coderabbitai summary

## ✅ Checks

- [x] Added test cases for my code
