### PR TITLE
fix: read maintenance config from app config

### DIFF
--- a/foundation/console/down_command_test.go
+++ b/foundation/console/down_command_test.go
@@ -72,7 +72,7 @@ func (s *DownCommandTestSuite) TestHandle() {
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false)
 	mockCtx.EXPECT().Option("reason").Return(flag.Value)
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"reason\":\"The application is under maintenance\",\"status\":503}").Return(nil)
 
 	err := cmd.Handle(mockCtx)
@@ -89,7 +89,7 @@ func (s *DownCommandTestSuite) TestHandleWithReason() {
 	mockCtx.EXPECT().Option("secret").Return("").Once()
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"reason\":\"Under maintenance\",\"status\":505}").Return(nil).Once()
 
 	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
@@ -106,7 +106,7 @@ func (s *DownCommandTestSuite) TestHandleWithRedirect() {
 	mockCtx.EXPECT().Option("secret").Return("").Once()
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"redirect\":\"/maintenance\",\"status\":503}").Return(nil).Once()
 
 	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
@@ -125,7 +125,7 @@ func (s *DownCommandTestSuite) TestHandleWithRender() {
 	mockCtx.EXPECT().Option("secret").Return("").Once()
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"render\":\"errors/503.tmpl\",\"status\":503}").Return(nil).Once()
 
 	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
@@ -144,7 +144,7 @@ func (s *DownCommandTestSuite) TestHandleSecret() {
 	mockCtx.EXPECT().Option("secret").Return("secretpassword").Once()
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"reason\":\"Under maintenance\",\"secret\":\"hashedsecretpassword\",\"status\":503}").Return(nil).Once()
 
 	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
@@ -183,7 +183,7 @@ func (s *DownCommandTestSuite) TestHandleWithSecret() {
 		return strings.HasPrefix(arg, "Using secret:")
 	})).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Put("framework/maintenance.json", "{\"reason\":\"Under maintenance\",\"secret\":\"randomhashedsecretpassword\",\"status\":503}").Return(nil).Once()
 
 	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
@@ -217,8 +217,8 @@ func (s *DownCommandTestSuite) TestHandleWithCacheDriver() {
 	mockCtx.EXPECT().Option("secret").Return("").Once()
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.store").Return("").Once()
 	s.mockCache.EXPECT().Forever("framework:maintenance", "{\"reason\":\"Under maintenance\",\"status\":503}").Return(true).Once()
 
 	cmd := NewDownCommand(s.mockView, s.mockHash, s.maintenance())
@@ -237,8 +237,8 @@ func (s *DownCommandTestSuite) TestHandleWithNamedCacheStore() {
 	mockCtx.EXPECT().Option("secret").Return("").Once()
 	mockCtx.EXPECT().OptionBool("with-secret").Return(false).Once()
 	mockCtx.EXPECT().Success("The application is in maintenance mode now").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("redis").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.store").Return("redis").Once()
 	s.mockCache.EXPECT().Store("redis").Return(mockCacheDriver).Once()
 	mockCacheDriver.EXPECT().Forever("framework:maintenance", "{\"reason\":\"Under maintenance\",\"status\":503}").Return(true).Once()
 

--- a/foundation/console/maintenance.go
+++ b/foundation/console/maintenance.go
@@ -135,7 +135,7 @@ func (r *MaintenanceMode) driver() string {
 		return maintenanceDriverFile
 	}
 
-	driver := strings.ToLower(r.config.GetString("APP_MAINTENANCE_DRIVER", maintenanceDriverFile))
+	driver := strings.ToLower(r.config.GetString("app.maintenance.driver", maintenanceDriverFile))
 	if driver == "" {
 		return maintenanceDriverFile
 	}
@@ -148,5 +148,5 @@ func (r *MaintenanceMode) store() string {
 		return ""
 	}
 
-	return r.config.GetString("APP_MAINTENANCE_STORE")
+	return r.config.GetString("app.maintenance.store")
 }

--- a/foundation/console/maintenance_test.go
+++ b/foundation/console/maintenance_test.go
@@ -33,7 +33,7 @@ func (s *MaintenanceModeTestSuite) maintenance() *MaintenanceMode {
 }
 
 func (s *MaintenanceModeTestSuite) TestGetWithFileDriver() {
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Exists("framework/maintenance.json").Return(true).Once()
 	s.mockStorage.EXPECT().GetBytes("framework/maintenance.json").Return([]byte(`{"status":503}`), nil).Once()
 
@@ -45,8 +45,8 @@ func (s *MaintenanceModeTestSuite) TestGetWithFileDriver() {
 }
 
 func (s *MaintenanceModeTestSuite) TestPutWithCacheDriver() {
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.store").Return("").Once()
 	s.mockCache.EXPECT().Forever("framework:maintenance", `{"status":503}`).Return(true).Once()
 
 	err := s.maintenance().Put(`{"status":503}`)
@@ -56,8 +56,8 @@ func (s *MaintenanceModeTestSuite) TestPutWithCacheDriver() {
 
 func (s *MaintenanceModeTestSuite) TestDeleteWithNamedCacheStore() {
 	mockCacheDriver := mockscache.NewDriver(s.T())
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("redis").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.store").Return("redis").Once()
 	s.mockCache.EXPECT().Store("redis").Return(mockCacheDriver).Once()
 	mockCacheDriver.EXPECT().Has("framework:maintenance").Return(true).Once()
 	mockCacheDriver.EXPECT().Forget("framework:maintenance").Return(true).Once()
@@ -69,7 +69,7 @@ func (s *MaintenanceModeTestSuite) TestDeleteWithNamedCacheStore() {
 }
 
 func (s *MaintenanceModeTestSuite) TestGetWithUnsupportedDriver() {
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("redis").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("redis").Once()
 
 	content, exists, err := s.maintenance().Get()
 

--- a/foundation/console/up_command_test.go
+++ b/foundation/console/up_command_test.go
@@ -51,7 +51,7 @@ func (s *UpCommandTestSuite) TestExtend() {
 }
 
 func (s *UpCommandTestSuite) TestHandle() {
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Exists("framework/maintenance.json").Return(true).Once()
 	s.mockStorage.EXPECT().Delete("framework/maintenance.json").Return(nil).Once()
 
@@ -64,7 +64,7 @@ func (s *UpCommandTestSuite) TestHandle() {
 }
 
 func (s *UpCommandTestSuite) TestHandleWhenNotDown() {
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("file").Once()
 	s.mockStorage.EXPECT().Exists("framework/maintenance.json").Return(false).Once()
 	mockContext := mocksconsole.NewContext(s.T())
 	mockContext.EXPECT().Error("The application is not in maintenance mode").Once()
@@ -75,8 +75,8 @@ func (s *UpCommandTestSuite) TestHandleWhenNotDown() {
 }
 
 func (s *UpCommandTestSuite) TestHandleWithCacheDriver() {
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.store").Return("").Once()
 	s.mockCache.EXPECT().Has("framework:maintenance").Return(true).Once()
 	s.mockCache.EXPECT().Forget("framework:maintenance").Return(true).Once()
 
@@ -90,8 +90,8 @@ func (s *UpCommandTestSuite) TestHandleWithCacheDriver() {
 
 func (s *UpCommandTestSuite) TestHandleWithNamedCacheStore() {
 	mockCacheDriver := mockscache.NewDriver(s.T())
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("redis").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.store").Return("redis").Once()
 	s.mockCache.EXPECT().Store("redis").Return(mockCacheDriver).Once()
 	mockCacheDriver.EXPECT().Has("framework:maintenance").Return(true).Once()
 	mockCacheDriver.EXPECT().Forget("framework:maintenance").Return(true).Once()

--- a/http/middleware/check_for_maintenance_mode_test.go
+++ b/http/middleware/check_for_maintenance_mode_test.go
@@ -55,7 +55,7 @@ func (s *MaintenanceTestSuite) expectFileMaintenanceDriver() {
 	s.mockApp.EXPECT().MakeCache().Return(s.mockCache).Once()
 	s.mockApp.EXPECT().MakeStorage().Return(s.mockStorage).Once()
 	s.mockApp.EXPECT().MakeHash().Return(s.mockHash).Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("file").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("file").Once()
 }
 
 func (s *MaintenanceTestSuite) expectCacheMaintenanceDriver() {
@@ -63,8 +63,8 @@ func (s *MaintenanceTestSuite) expectCacheMaintenanceDriver() {
 	s.mockApp.EXPECT().MakeCache().Return(s.mockCache).Once()
 	s.mockApp.EXPECT().MakeStorage().Return(s.mockStorage).Once()
 	s.mockApp.EXPECT().MakeHash().Return(s.mockHash).Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.store").Return("").Once()
 }
 
 func (s *MaintenanceTestSuite) expectMissingMaintenanceDependency(configMissing, cacheMissing, storageMissing, hashMissing bool) {
@@ -254,8 +254,8 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_NamedCacheStore() {
 	s.mockApp.EXPECT().MakeCache().Return(s.mockCache).Once()
 	s.mockApp.EXPECT().MakeStorage().Return(s.mockStorage).Once()
 	s.mockApp.EXPECT().MakeHash().Return(s.mockHash).Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_DRIVER", "file").Return("cache").Once()
-	s.mockConfig.EXPECT().GetString("APP_MAINTENANCE_STORE").Return("redis").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.driver", "file").Return("cache").Once()
+	s.mockConfig.EXPECT().GetString("app.maintenance.store").Return("redis").Once()
 	s.mockCache.EXPECT().Store("redis").Return(mockCacheDriver).Once()
 	mockCacheDriver.EXPECT().Has("framework:maintenance").Return(true).Once()
 	mockCacheDriver.EXPECT().GetString("framework:maintenance").Return(`{"reason":"Under Maintenance", "status": 503}`).Once()

--- a/route/setup/setup.go
+++ b/route/setup/setup.go
@@ -5,6 +5,7 @@ import (
 
 	contractsmodify "github.com/goravel/framework/contracts/packages/modify"
 	"github.com/goravel/framework/packages"
+	"github.com/goravel/framework/packages/match"
 	"github.com/goravel/framework/packages/modify"
 	"github.com/goravel/framework/support/file"
 	"github.com/goravel/framework/support/path"
@@ -17,6 +18,7 @@ func main() {
 	routesImport := setup.Paths().Routes().Import()
 	webFunc := setup.Paths().Routes().Package() + ".Web()"
 	webRoutePath := path.Route("web.go")
+	appConfigPath := path.Config("app.go")
 	jwtConfigPath := path.Config("jwt.go")
 	corsConfigPath := path.Config("cors.go")
 	welcomeTmplPath := path.Resource("views", "welcome.tmpl")
@@ -41,11 +43,15 @@ JWT_SECRET=
 		// Add the route service provider to the providers array in bootstrap/providers.go
 		modify.RegisterProvider(moduleImport, routeServiceProvider),
 
-		// Create resources/views/welcome.tmpl, app/http/controllers/user_controller.go, public/.gitignore, routes/web.go, config/jwt.go, config/cors.go
+		// Create resources/views/welcome.tmpl, app/http/controllers/user_controller.go, public/.gitignore, routes/web.go, config/jwt.go, config/cors.go, and update config/app.go
 		modify.File(welcomeTmplPath).Overwrite(stubs.WelcomeTmpl()),
 		modify.File(controllerPath).Overwrite(stubs.Controller()),
 		modify.File(publicGitignorePath).Overwrite(""),
 		modify.File(webRoutePath).Overwrite(stubs.Routes(setup.Paths().Routes().Package(), setup.Paths().App().Import(), setup.Paths().Facades().Import(), facadesPackage)),
+		modify.GoFile(appConfigPath).
+			Find(match.Config("app")).
+			Modify(modify.AddConfig("maintenance", stubs.MaintenanceConfig())).
+			Format(),
 		modify.File(jwtConfigPath).Overwrite(stubs.JwtConfig(configPackage, facadesImport, facadesPackage)),
 		modify.File(corsConfigPath).Overwrite(stubs.CorsConfig(configPackage, facadesImport, facadesPackage)),
 
@@ -81,6 +87,10 @@ JWT_SECRET=
 		}),
 		modify.File(jwtConfigPath).Remove(),
 		modify.File(corsConfigPath).Remove(),
+		modify.GoFile(appConfigPath).
+			Find(match.Config("app")).
+			Modify(modify.RemoveConfig("maintenance")).
+			Format(),
 
 		// Remove the route service provider from the providers array in bootstrap/providers.go
 		modify.UnregisterProvider(moduleImport, routeServiceProvider),

--- a/route/setup/stubs.go
+++ b/route/setup/stubs.go
@@ -14,7 +14,12 @@ func (s Stubs) MaintenanceConfig() string {
     //
     // Supported drivers: "file", "cache"
     "driver": config.Env("APP_MAINTENANCE_DRIVER", "file"),
-    "store": config.Env("APP_MAINTENANCE_STORE", "database"),
+
+    // Maintenance Mode Store
+    //
+    // This option controls the cache store used by the "cache" maintenance
+    // driver. Leave it empty to use the default cache store.
+    "store": config.Env("APP_MAINTENANCE_STORE", ""),
 }`
 }
 

--- a/route/setup/stubs.go
+++ b/route/setup/stubs.go
@@ -4,6 +4,20 @@ import "strings"
 
 type Stubs struct{}
 
+func (s Stubs) MaintenanceConfig() string {
+	return `map[string]any{
+    // Maintenance Mode Driver
+    //
+    // These configuration options determine the driver used to determine and
+    // manage Goravel's "maintenance mode" status. The "cache" driver will
+    // allow maintenance mode to be controlled across multiple machines.
+    //
+    // Supported drivers: "file", "cache"
+    "driver": config.Env("APP_MAINTENANCE_DRIVER", "file"),
+    "store": config.Env("APP_MAINTENANCE_STORE", "database"),
+}`
+}
+
 func (s Stubs) Controller() string {
 	return `package controllers
 


### PR DESCRIPTION
## Summary
- Reads maintenance mode driver and cache store from `app.maintenance` config instead of raw env keys.
- Adds maintenance configuration when installing Route, with cache store left unset by default.
- Removes the installed maintenance configuration when uninstalling Route.

## Why
Maintenance mode settings should flow through the application config layer so applications can centralize defaults and environment bindings in `config/app.go`. Goravel keeps `APP_MAINTENANCE_DRIVER` defaulted to `file`, while `APP_MAINTENANCE_STORE` only applies when the `cache` driver is selected.

```go
config.Add("app", map[string]any{
    "maintenance": map[string]any{
        "driver": config.Env("APP_MAINTENANCE_DRIVER", "file"),
        "store":  config.Env("APP_MAINTENANCE_STORE", ""),
    },
})
```

Leaving the store empty preserves Goravel’s existing behavior: the cache maintenance driver uses the default cache store unless an application explicitly sets `APP_MAINTENANCE_STORE`.
