### PR TITLE
feat(ai): add make tool command

### DIFF
--- a/ai/console/stubs.go
+++ b/ai/console/stubs.go
@@ -32,11 +32,7 @@ func (r *DummyAgent) Tools() []ai.Tool {
 func (r Stubs) Tool() string {
 	return `package DummyPackage
 
-import (
-	"context"
-
-	"github.com/goravel/framework/contracts/ai"
-)
+import "context"
 
 type DummyTool struct {
 }
@@ -50,13 +46,11 @@ func (r *DummyTool) Description() string {
 }
 
 func (r *DummyTool) Parameters() map[string]any {
-	return map[string]any{}
+	return nil
 }
 
 func (r *DummyTool) Execute(ctx context.Context, args map[string]any) (string, error) {
 	return "", nil
 }
-
-var _ ai.Tool = (*DummyTool)(nil)
 `
 }

--- a/ai/console/stubs.go
+++ b/ai/console/stubs.go
@@ -28,3 +28,35 @@ func (r *DummyAgent) Tools() []ai.Tool {
 }
 `
 }
+
+func (r Stubs) Tool() string {
+	return `package DummyPackage
+
+import (
+	"context"
+
+	"github.com/goravel/framework/contracts/ai"
+)
+
+type DummyTool struct {
+}
+
+func (r *DummyTool) Name() string {
+	return "DummyName"
+}
+
+func (r *DummyTool) Description() string {
+	return "A description of the tool."
+}
+
+func (r *DummyTool) Parameters() map[string]any {
+	return map[string]any{}
+}
+
+func (r *DummyTool) Execute(ctx context.Context, args map[string]any) (string, error) {
+	return "", nil
+}
+
+var _ ai.Tool = (*DummyTool)(nil)
+`
+}

--- a/ai/console/tool_make_command.go
+++ b/ai/console/tool_make_command.go
@@ -1,0 +1,71 @@
+package console
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/goravel/framework/contracts/console"
+	"github.com/goravel/framework/contracts/console/command"
+	"github.com/goravel/framework/support"
+	supportconsole "github.com/goravel/framework/support/console"
+	"github.com/goravel/framework/support/file"
+	"github.com/goravel/framework/support/str"
+)
+
+type ToolMakeCommand struct {
+}
+
+// Signature The name and signature of the console command.
+func (r *ToolMakeCommand) Signature() string {
+	return "make:tool"
+}
+
+// Description The console command description.
+func (r *ToolMakeCommand) Description() string {
+	return "Create a new agent tool"
+}
+
+// Extend The console command extend.
+func (r *ToolMakeCommand) Extend() command.Extend {
+	return command.Extend{
+		Category: "make",
+		Flags: []command.Flag{
+			&command.BoolFlag{
+				Name:    "force",
+				Aliases: []string{"f"},
+				Usage:   "Create the tool even if it already exists",
+			},
+		},
+	}
+}
+
+// Handle Execute the console command.
+func (r *ToolMakeCommand) Handle(ctx console.Context) error {
+	make, err := supportconsole.NewMake(ctx, "tool", ctx.Argument(0), filepath.Join(support.Config.Paths.App, "tools"))
+	if err != nil {
+		ctx.Error(err.Error())
+		return nil
+	}
+
+	if err := file.PutContent(make.GetFilePath(), r.populateStub(r.getStub(), make.GetPackageName(), make.GetStructName())); err != nil {
+		ctx.Error(err.Error())
+		return nil
+	}
+
+	ctx.Success("Tool created successfully")
+
+	return nil
+}
+
+func (r *ToolMakeCommand) getStub() string {
+	return Stubs{}.Tool()
+}
+
+// populateStub Populate the place-holders in the command stub.
+func (r *ToolMakeCommand) populateStub(stub string, packageName, structName string) string {
+	stub = strings.ReplaceAll(stub, "DummyTool", structName)
+	stub = strings.ReplaceAll(stub, "DummyName", str.Of(structName).Snake().String())
+	stub = strings.ReplaceAll(stub, "DummyPackage", packageName)
+
+	return stub
+}

--- a/ai/console/tool_make_command_test.go
+++ b/ai/console/tool_make_command_test.go
@@ -1,0 +1,64 @@
+package console
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/goravel/framework/contracts/console/command"
+	mocksconsole "github.com/goravel/framework/mocks/console"
+	"github.com/goravel/framework/support/file"
+)
+
+func TestToolMakeCommand(t *testing.T) {
+	toolMakeCommand := &ToolMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+
+	assert.Equal(t, "make:tool", toolMakeCommand.Signature())
+	assert.Equal(t, "Create a new agent tool", toolMakeCommand.Description())
+
+	extend := toolMakeCommand.Extend()
+	assert.Equal(t, "make", extend.Category)
+	if assert.Len(t, extend.Flags, 1) {
+		flag, ok := extend.Flags[0].(*command.BoolFlag)
+		assert.True(t, ok)
+		if ok {
+			assert.Equal(t, "force", flag.Name)
+			assert.Equal(t, []string{"f"}, flag.Aliases)
+			assert.Equal(t, "Create the tool even if it already exists", flag.Usage)
+		}
+	}
+
+	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Ask("Enter the tool name", mock.Anything).Return("", errors.New("the tool name cannot be empty")).Once()
+	mockContext.EXPECT().Error("the tool name cannot be empty").Once()
+	assert.NoError(t, toolMakeCommand.Handle(mockContext))
+
+	mockContext.EXPECT().Argument(0).Return("WeatherTool").Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Once()
+	mockContext.EXPECT().Success("Tool created successfully").Once()
+	assert.NoError(t, toolMakeCommand.Handle(mockContext))
+	assert.True(t, file.Exists("app/tools/weather_tool.go"))
+
+	mockContext.EXPECT().Argument(0).Return("WeatherTool").Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Once()
+	mockContext.EXPECT().Error("the tool already exists. Use the --force or -f flag to overwrite").Once()
+	assert.NoError(t, toolMakeCommand.Handle(mockContext))
+
+	mockContext.EXPECT().Argument(0).Return("user/WeatherTool").Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Once()
+	mockContext.EXPECT().Success("Tool created successfully").Once()
+	assert.NoError(t, toolMakeCommand.Handle(mockContext))
+	assert.True(t, file.Exists("app/tools/user/weather_tool.go"))
+	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "package user"))
+	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "type WeatherTool struct"))
+	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "func (r *WeatherTool) Name() string"))
+	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "return \"weather_tool\""))
+	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "func (r *WeatherTool) Description() string"))
+	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "func (r *WeatherTool) Parameters() map[string]any"))
+	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "func (r *WeatherTool) Execute(ctx context.Context, args map[string]any) (string, error)"))
+	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "var _ ai.Tool = (*WeatherTool)(nil)"))
+	assert.NoError(t, file.Remove("app"))
+}

--- a/ai/console/tool_make_command_test.go
+++ b/ai/console/tool_make_command_test.go
@@ -58,7 +58,8 @@ func TestToolMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "return \"weather_tool\""))
 	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "func (r *WeatherTool) Description() string"))
 	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "func (r *WeatherTool) Parameters() map[string]any"))
+	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "return nil"))
 	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "func (r *WeatherTool) Execute(ctx context.Context, args map[string]any) (string, error)"))
-	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "var _ ai.Tool = (*WeatherTool)(nil)"))
+	assert.False(t, file.Contain("app/tools/user/weather_tool.go", "var _ ai.Tool = (*WeatherTool)(nil)"))
 	assert.NoError(t, file.Remove("app"))
 }

--- a/ai/service_provider.go
+++ b/ai/service_provider.go
@@ -48,5 +48,6 @@ func (r *ServiceProvider) Boot(app foundation.Application) {
 
 	app.Commands([]contractsconsole.Command{
 		&console.AgentMakeCommand{},
+		&console.ToolMakeCommand{},
 	})
 }

--- a/ai/service_provider_test.go
+++ b/ai/service_provider_test.go
@@ -128,9 +128,19 @@ func (s *ServiceProviderTestSuite) TestBoot() {
 	mockApp.EXPECT().MakeHttp().Return(httpFactory).Once()
 
 	mockApp.EXPECT().Commands(mock.MatchedBy(func(commands []contractsconsole.Command) bool {
-		return len(commands) == 1 &&
-			commands[0] != nil &&
-			commands[0].Signature() == "make:agent"
+		if len(commands) != 2 {
+			return false
+		}
+
+		signatures := make(map[string]bool, len(commands))
+		for _, command := range commands {
+			if command == nil {
+				return false
+			}
+			signatures[command.Signature()] = true
+		}
+
+		return signatures["make:agent"] && signatures["make:tool"]
 	})).Once()
 
 	provider.Boot(mockApp)


### PR DESCRIPTION
## Summary
- Add an AI `make:tool` command for generating agent tools.
- Generate tool stubs under `app/tools` with `ai.Tool` methods and force overwrite support.
- Register the tool generator through the AI service provider.

## Why
Goravel AI agents can expose tools to model conversations, but users currently need to create tool structs manually. This command gives AI tools the same generator workflow as existing make commands, including nested paths and duplicate protection.

After running `go run . artisan make:tool WeatherTool`, users can attach the generated tool to an agent like this:

```go
package agents

import (
	"github.com/goravel/example/app/tools"
	"github.com/goravel/framework/contracts/ai"
)

type SupportAgent struct {
}

func (r *SupportAgent) Instructions() string {
	return "Help users with weather questions."
}

func (r *SupportAgent) Messages() []ai.Message {
	return nil
}

func (r *SupportAgent) Middleware() []ai.Middleware {
	return nil
}

func (r *SupportAgent) Tools() []ai.Tool {
	return []ai.Tool{
		&tools.WeatherTool{},
	}
}
```
