### PR TITLE
feat(ai): customize make command paths

### DIFF
--- a/ai/console/agent_make_command.go
+++ b/ai/console/agent_make_command.go
@@ -1,7 +1,6 @@
 package console
 
 import (
-	"path/filepath"
 	"strings"
 
 	"github.com/goravel/framework/contracts/console"
@@ -40,7 +39,7 @@ func (r *AgentMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *AgentMakeCommand) Handle(ctx console.Context) error {
-	make, err := supportconsole.NewMake(ctx, "agent", ctx.Argument(0), filepath.Join(support.Config.Paths.App, "agents"))
+	make, err := supportconsole.NewMake(ctx, "agent", ctx.Argument(0), support.Config.Paths.Agents)
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil

--- a/ai/console/agent_make_command_test.go
+++ b/ai/console/agent_make_command_test.go
@@ -9,12 +9,19 @@ import (
 
 	"github.com/goravel/framework/contracts/console/command"
 	mocksconsole "github.com/goravel/framework/mocks/console"
+	"github.com/goravel/framework/support"
 	"github.com/goravel/framework/support/file"
 )
 
 func TestAgentMakeCommand(t *testing.T) {
 	agentMakeCommand := &AgentMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
+	originalPaths := support.Config.Paths
+	defer func() {
+		support.Config.Paths = originalPaths
+		_ = file.Remove("app")
+		_ = file.Remove("custom")
+	}()
 
 	assert.Equal(t, "make:agent", agentMakeCommand.Signature())
 	assert.Equal(t, "Create a new agent", agentMakeCommand.Description())
@@ -40,7 +47,7 @@ func TestAgentMakeCommand(t *testing.T) {
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Agent created successfully").Once()
 	assert.NoError(t, agentMakeCommand.Handle(mockContext))
-	assert.True(t, file.Exists("app/agents/user_agent.go"))
+	assert.True(t, file.Exists("app/ai/agents/user_agent.go"))
 
 	mockContext.EXPECT().Argument(0).Return("UserAgent").Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
@@ -51,11 +58,17 @@ func TestAgentMakeCommand(t *testing.T) {
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Agent created successfully").Once()
 	assert.NoError(t, agentMakeCommand.Handle(mockContext))
-	assert.True(t, file.Exists("app/agents/user/support_agent.go"))
-	assert.True(t, file.Contain("app/agents/user/support_agent.go", "package user"))
-	assert.True(t, file.Contain("app/agents/user/support_agent.go", "type SupportAgent struct"))
-	assert.True(t, file.Contain("app/agents/user/support_agent.go", "func (r *SupportAgent) Instructions() string"))
-	assert.True(t, file.Contain("app/agents/user/support_agent.go", "func (r *SupportAgent) Messages() []ai.Message"))
-	assert.True(t, file.Contain("app/agents/user/support_agent.go", "func (r *SupportAgent) Middleware() []ai.Middleware"))
-	assert.NoError(t, file.Remove("app"))
+	assert.True(t, file.Exists("app/ai/agents/user/support_agent.go"))
+	assert.True(t, file.Contain("app/ai/agents/user/support_agent.go", "package user"))
+	assert.True(t, file.Contain("app/ai/agents/user/support_agent.go", "type SupportAgent struct"))
+	assert.True(t, file.Contain("app/ai/agents/user/support_agent.go", "func (r *SupportAgent) Instructions() string"))
+	assert.True(t, file.Contain("app/ai/agents/user/support_agent.go", "func (r *SupportAgent) Messages() []ai.Message"))
+	assert.True(t, file.Contain("app/ai/agents/user/support_agent.go", "func (r *SupportAgent) Middleware() []ai.Middleware"))
+
+	support.Config.Paths.Agents = "custom/agents"
+	mockContext.EXPECT().Argument(0).Return("BillingAgent").Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Once()
+	mockContext.EXPECT().Success("Agent created successfully").Once()
+	assert.NoError(t, agentMakeCommand.Handle(mockContext))
+	assert.True(t, file.Exists("custom/agents/billing_agent.go"))
 }

--- a/ai/console/tool_make_command.go
+++ b/ai/console/tool_make_command.go
@@ -1,7 +1,6 @@
 package console
 
 import (
-	"path/filepath"
 	"strings"
 
 	"github.com/goravel/framework/contracts/console"
@@ -41,7 +40,7 @@ func (r *ToolMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *ToolMakeCommand) Handle(ctx console.Context) error {
-	make, err := supportconsole.NewMake(ctx, "tool", ctx.Argument(0), filepath.Join(support.Config.Paths.App, "tools"))
+	make, err := supportconsole.NewMake(ctx, "tool", ctx.Argument(0), support.Config.Paths.Tools)
 	if err != nil {
 		ctx.Error(err.Error())
 		return nil

--- a/ai/console/tool_make_command_test.go
+++ b/ai/console/tool_make_command_test.go
@@ -9,12 +9,19 @@ import (
 
 	"github.com/goravel/framework/contracts/console/command"
 	mocksconsole "github.com/goravel/framework/mocks/console"
+	"github.com/goravel/framework/support"
 	"github.com/goravel/framework/support/file"
 )
 
 func TestToolMakeCommand(t *testing.T) {
 	toolMakeCommand := &ToolMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
+	originalPaths := support.Config.Paths
+	defer func() {
+		support.Config.Paths = originalPaths
+		_ = file.Remove("app")
+		_ = file.Remove("custom")
+	}()
 
 	assert.Equal(t, "make:tool", toolMakeCommand.Signature())
 	assert.Equal(t, "Create a new agent tool", toolMakeCommand.Description())
@@ -40,7 +47,7 @@ func TestToolMakeCommand(t *testing.T) {
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Tool created successfully").Once()
 	assert.NoError(t, toolMakeCommand.Handle(mockContext))
-	assert.True(t, file.Exists("app/tools/weather_tool.go"))
+	assert.True(t, file.Exists("app/ai/tools/weather_tool.go"))
 
 	mockContext.EXPECT().Argument(0).Return("WeatherTool").Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
@@ -51,15 +58,21 @@ func TestToolMakeCommand(t *testing.T) {
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Tool created successfully").Once()
 	assert.NoError(t, toolMakeCommand.Handle(mockContext))
-	assert.True(t, file.Exists("app/tools/user/weather_tool.go"))
-	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "package user"))
-	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "type WeatherTool struct"))
-	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "func (r *WeatherTool) Name() string"))
-	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "return \"weather_tool\""))
-	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "func (r *WeatherTool) Description() string"))
-	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "func (r *WeatherTool) Parameters() map[string]any"))
-	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "return nil"))
-	assert.True(t, file.Contain("app/tools/user/weather_tool.go", "func (r *WeatherTool) Execute(ctx context.Context, args map[string]any) (string, error)"))
-	assert.False(t, file.Contain("app/tools/user/weather_tool.go", "var _ ai.Tool = (*WeatherTool)(nil)"))
-	assert.NoError(t, file.Remove("app"))
+	assert.True(t, file.Exists("app/ai/tools/user/weather_tool.go"))
+	assert.True(t, file.Contain("app/ai/tools/user/weather_tool.go", "package user"))
+	assert.True(t, file.Contain("app/ai/tools/user/weather_tool.go", "type WeatherTool struct"))
+	assert.True(t, file.Contain("app/ai/tools/user/weather_tool.go", "func (r *WeatherTool) Name() string"))
+	assert.True(t, file.Contain("app/ai/tools/user/weather_tool.go", "return \"weather_tool\""))
+	assert.True(t, file.Contain("app/ai/tools/user/weather_tool.go", "func (r *WeatherTool) Description() string"))
+	assert.True(t, file.Contain("app/ai/tools/user/weather_tool.go", "func (r *WeatherTool) Parameters() map[string]any"))
+	assert.True(t, file.Contain("app/ai/tools/user/weather_tool.go", "return nil"))
+	assert.True(t, file.Contain("app/ai/tools/user/weather_tool.go", "func (r *WeatherTool) Execute(ctx context.Context, args map[string]any) (string, error)"))
+	assert.False(t, file.Contain("app/ai/tools/user/weather_tool.go", "var _ ai.Tool = (*WeatherTool)(nil)"))
+
+	support.Config.Paths.Tools = "custom/tools"
+	mockContext.EXPECT().Argument(0).Return("CurrencyTool").Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Once()
+	mockContext.EXPECT().Success("Tool created successfully").Once()
+	assert.NoError(t, toolMakeCommand.Handle(mockContext))
+	assert.True(t, file.Exists("custom/tools/currency_tool.go"))
 }

--- a/contracts/foundation/configuration/paths.go
+++ b/contracts/foundation/configuration/paths.go
@@ -3,6 +3,8 @@ package configuration
 type Paths interface {
 	// App sets the path for the application directory, default is "app".
 	App(path string) Paths
+	// Agents sets the path for the agents directory, default is "app/ai/agents".
+	Agents(path string) Paths
 	// Bootstrap sets the path for the bootstrap directory, default is "bootstrap".
 	Bootstrap(path string) Paths
 	// Commands sets the path for the commands directory, default is "app/console/commands".
@@ -59,6 +61,8 @@ type Paths interface {
 	Storage(path string) Paths
 	// Tests sets the path for the tests directory, default is "tests".
 	Tests(path string) Paths
+	// Tools sets the path for the tools directory, default is "app/ai/tools".
+	Tools(path string) Paths
 	// Views sets the path for the views directory, default is "resources/views".
 	Views(path string) Paths
 }

--- a/foundation/configuration/paths.go
+++ b/foundation/configuration/paths.go
@@ -18,6 +18,12 @@ func (r *Paths) App(path string) configuration.Paths {
 	return r
 }
 
+func (r *Paths) Agents(path string) configuration.Paths {
+	support.Config.Paths.Agents = path
+
+	return r
+}
+
 func (r *Paths) Bootstrap(path string) configuration.Paths {
 	support.Config.Paths.Bootstrap = path
 
@@ -182,6 +188,12 @@ func (r *Paths) Storage(path string) configuration.Paths {
 
 func (r *Paths) Tests(path string) configuration.Paths {
 	support.Config.Paths.Tests = path
+
+	return r
+}
+
+func (r *Paths) Tools(path string) configuration.Paths {
+	support.Config.Paths.Tools = path
 
 	return r
 }

--- a/foundation/configuration/paths_test.go
+++ b/foundation/configuration/paths_test.go
@@ -39,6 +39,12 @@ func (s *PathsTestSuite) TestApp() {
 	s.Equal(s.paths, result)
 }
 
+func (s *PathsTestSuite) TestAgents() {
+	result := s.paths.Agents("custom/agents")
+	s.Equal("custom/agents", support.Config.Paths.Agents)
+	s.Equal(s.paths, result)
+}
+
 func (s *PathsTestSuite) TestBootstrap() {
 	result := s.paths.Bootstrap("custom/bootstrap")
 	s.Equal("custom/bootstrap", support.Config.Paths.Bootstrap)
@@ -204,6 +210,12 @@ func (s *PathsTestSuite) TestStorage() {
 func (s *PathsTestSuite) TestTests() {
 	result := s.paths.Tests("custom/tests")
 	s.Equal("custom/tests", support.Config.Paths.Tests)
+	s.Equal(s.paths, result)
+}
+
+func (s *PathsTestSuite) TestTools() {
+	result := s.paths.Tools("custom/tools")
+	s.Equal("custom/tools", support.Config.Paths.Tools)
 	s.Equal(s.paths, result)
 }
 

--- a/mocks/foundation/configuration/Paths.go
+++ b/mocks/foundation/configuration/Paths.go
@@ -20,6 +20,54 @@ func (_m *Paths) EXPECT() *Paths_Expecter {
 	return &Paths_Expecter{mock: &_m.Mock}
 }
 
+// Agents provides a mock function with given fields: path
+func (_m *Paths) Agents(path string) configuration.Paths {
+	ret := _m.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Agents")
+	}
+
+	var r0 configuration.Paths
+	if rf, ok := ret.Get(0).(func(string) configuration.Paths); ok {
+		r0 = rf(path)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(configuration.Paths)
+		}
+	}
+
+	return r0
+}
+
+// Paths_Agents_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Agents'
+type Paths_Agents_Call struct {
+	*mock.Call
+}
+
+// Agents is a helper method to define mock.On call
+//   - path string
+func (_e *Paths_Expecter) Agents(path interface{}) *Paths_Agents_Call {
+	return &Paths_Agents_Call{Call: _e.mock.On("Agents", path)}
+}
+
+func (_c *Paths_Agents_Call) Run(run func(path string)) *Paths_Agents_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Paths_Agents_Call) Return(_a0 configuration.Paths) *Paths_Agents_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Paths_Agents_Call) RunAndReturn(run func(string) configuration.Paths) *Paths_Agents_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // App provides a mock function with given fields: path
 func (_m *Paths) App(path string) configuration.Paths {
 	ret := _m.Called(path)
@@ -1408,6 +1456,54 @@ func (_c *Paths_Tests_Call) Return(_a0 configuration.Paths) *Paths_Tests_Call {
 }
 
 func (_c *Paths_Tests_Call) RunAndReturn(run func(string) configuration.Paths) *Paths_Tests_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Tools provides a mock function with given fields: path
+func (_m *Paths) Tools(path string) configuration.Paths {
+	ret := _m.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Tools")
+	}
+
+	var r0 configuration.Paths
+	if rf, ok := ret.Get(0).(func(string) configuration.Paths); ok {
+		r0 = rf(path)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(configuration.Paths)
+		}
+	}
+
+	return r0
+}
+
+// Paths_Tools_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Tools'
+type Paths_Tools_Call struct {
+	*mock.Call
+}
+
+// Tools is a helper method to define mock.On call
+//   - path string
+func (_e *Paths_Expecter) Tools(path interface{}) *Paths_Tools_Call {
+	return &Paths_Tools_Call{Call: _e.mock.On("Tools", path)}
+}
+
+func (_c *Paths_Tools_Call) Run(run func(path string)) *Paths_Tools_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Paths_Tools_Call) Return(_a0 configuration.Paths) *Paths_Tools_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Paths_Tools_Call) RunAndReturn(run func(string) configuration.Paths) *Paths_Tools_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/support/variable.go
+++ b/support/variable.go
@@ -3,6 +3,8 @@ package support
 type Paths struct {
 	// The base directory path, default is "app".
 	App string
+	// The agents directory path, default is "app/ai/agents".
+	Agents string
 	// The bootstrap directory path, default is "bootstrap".
 	Bootstrap string
 	// The commands directory path, default is "app/console/commands".
@@ -59,6 +61,8 @@ type Paths struct {
 	Storage string
 	// The tests directory path, default is "tests".
 	Tests string
+	// The tools directory path, default is "app/ai/tools".
+	Tools string
 	// The view directory path, default is "resources/views".
 	Views string
 }
@@ -83,6 +87,7 @@ var (
 	Config = Configuration{
 		Paths: Paths{
 			App:         "app",
+			Agents:      "app/ai/agents",
 			Bootstrap:   "bootstrap",
 			Commands:    "app/console/commands",
 			Config:      "config",
@@ -111,6 +116,7 @@ var (
 			Seeders:     "database/seeders",
 			Storage:     "storage",
 			Tests:       "tests",
+			Tools:       "app/ai/tools",
 			Views:       "resources/views",
 		},
 	}


### PR DESCRIPTION
## Summary
- `make:agent` creates agents under `app/ai/agents` by default and honors custom agent paths.
- `make:tool` creates tools under `app/ai/tools` by default and honors custom tool paths.

## Why
Generated AI code should live under a shared `app/ai` namespace so agents and tools stay grouped together. Applications that use a different source layout can now customize each generator path through `WithPaths` without changing command usage.

```go
package bootstrap

import (
	"github.com/goravel/framework/contracts/foundation/configuration"
	"github.com/goravel/framework/foundation"
)

var App = foundation.Setup().
	WithPaths(func(paths configuration.Paths) {
		paths.Agents("internal/ai/agents")
		paths.Tools("internal/ai/tools")
	}).
	Create()
```
