### PR TITLE
fix: [#942] use connection driver for schema

### DIFF
--- a/database/console/wipe_command.go
+++ b/database/console/wipe_command.go
@@ -68,9 +68,10 @@ func (r *WipeCommand) Handle(ctx console.Context) error {
 	}
 
 	database := ctx.Option("database")
+	schema := r.schema.Connection(database)
 
 	if ctx.OptionBool("drop-views") {
-		if err := r.dropAllViews(database); err != nil {
+		if err := schema.DropAllViews(); err != nil {
 			ctx.Error(errors.ConsoleDropAllViewsFailed.Args(err).Error())
 			return nil
 		}
@@ -78,7 +79,7 @@ func (r *WipeCommand) Handle(ctx console.Context) error {
 		ctx.Success("Dropped all views successfully")
 	}
 
-	if err := r.dropAllTables(database); err != nil {
+	if err := schema.DropAllTables(); err != nil {
 		ctx.Error(errors.ConsoleDropAllTablesFailed.Args(err).Error())
 		return nil
 	}
@@ -86,7 +87,7 @@ func (r *WipeCommand) Handle(ctx console.Context) error {
 	ctx.Success("Dropped all tables successfully")
 
 	if ctx.OptionBool("drop-types") {
-		if err := r.dropAllTypes(database); err != nil {
+		if err := schema.DropAllTypes(); err != nil {
 			ctx.Error(errors.ConsoleDropAllTypesFailed.Args(err).Error())
 			return nil
 		}
@@ -94,22 +95,10 @@ func (r *WipeCommand) Handle(ctx console.Context) error {
 		ctx.Success("Dropped all types successfully")
 	}
 
-	if err := r.schema.Connection(database).Prune(); err != nil {
+	if err := schema.Prune(); err != nil {
 		ctx.Error(errors.ConsolePruneFailed.Args(err).Error())
 		return nil
 	}
 
 	return nil
-}
-
-func (r *WipeCommand) dropAllTables(database string) error {
-	return r.schema.Connection(database).DropAllTables()
-}
-
-func (r *WipeCommand) dropAllViews(database string) error {
-	return r.schema.Connection(database).DropAllViews()
-}
-
-func (r *WipeCommand) dropAllTypes(database string) error {
-	return r.schema.Connection(database).DropAllTypes()
 }

--- a/database/console/wipe_command_test.go
+++ b/database/console/wipe_command_test.go
@@ -37,14 +37,11 @@ func TestWipeCommand(t *testing.T) {
 				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllViews().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all views successfully").Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllTables().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all tables successfully").Once()
 				mockContext.EXPECT().OptionBool("drop-types").Return(true).Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllTypes().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all types successfully").Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().Prune().Return(nil).Once()
 			},
 		},
@@ -58,7 +55,6 @@ func TestWipeCommand(t *testing.T) {
 				mockSchema.EXPECT().DropAllTables().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all tables successfully").Once()
 				mockContext.EXPECT().OptionBool("drop-types").Return(false).Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().Prune().Return(nil).Once()
 			},
 		},
@@ -72,14 +68,11 @@ func TestWipeCommand(t *testing.T) {
 				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllViews().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all views successfully").Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllTables().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all tables successfully").Once()
 				mockContext.EXPECT().OptionBool("drop-types").Return(true).Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllTypes().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all types successfully").Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().Prune().Return(nil).Once()
 			},
 		},
@@ -94,14 +87,11 @@ func TestWipeCommand(t *testing.T) {
 				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllViews().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all views successfully").Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllTables().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all tables successfully").Once()
 				mockContext.EXPECT().OptionBool("drop-types").Return(true).Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllTypes().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all types successfully").Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().Prune().Return(nil).Once()
 			},
 		},
@@ -155,7 +145,6 @@ func TestWipeCommand(t *testing.T) {
 				mockSchema.EXPECT().DropAllTables().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all tables successfully").Once()
 				mockContext.EXPECT().OptionBool("drop-types").Return(true).Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllTypes().Return(assert.AnError).Once()
 				mockContext.EXPECT().Error(errors.ConsoleDropAllTypesFailed.Args(assert.AnError).Error()).Once()
 			},
@@ -169,14 +158,11 @@ func TestWipeCommand(t *testing.T) {
 				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllViews().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all views successfully").Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllTables().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all tables successfully").Once()
 				mockContext.EXPECT().OptionBool("drop-types").Return(true).Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().DropAllTypes().Return(nil).Once()
 				mockContext.EXPECT().Success("Dropped all types successfully").Once()
-				mockSchema.EXPECT().Connection("postgres").Return(mockSchema).Once()
 				mockSchema.EXPECT().Prune().Return(assert.AnError).Once()
 				mockContext.EXPECT().Error(errors.ConsolePruneFailed.Args(assert.AnError).Error()).Once()
 			},

--- a/database/schema/schema.go
+++ b/database/schema/schema.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"fmt"
 	"reflect"
 	"slices"
 	"strings"
@@ -72,7 +73,7 @@ func NewSchema(config config.Config, log log.Log, orm contractsorm.Orm, driver d
 }
 
 func (r *Schema) Connection(name string) contractsschema.Schema {
-	schema, err := NewSchema(r.config, r.log, r.orm.Connection(name), r.driver, r.migrations)
+	schema, err := r.newConnection(name)
 	if err != nil {
 		r.log.Panic(errors.SchemaConnectionNotFound.Args(name).SetModule(errors.ModuleSchedule).Error())
 		return nil
@@ -449,7 +450,57 @@ func (r *Schema) Rename(from, to string) error {
 }
 
 func (r *Schema) SetConnection(name string) {
-	r.orm = r.orm.Connection(name)
+	schema, err := r.newConnection(name)
+	if err != nil {
+		r.log.Panic(errors.SchemaConnectionNotFound.Args(name).SetModule(errors.ModuleSchedule).Error())
+		return
+	}
+
+	r.driver = schema.driver
+	r.grammar = schema.grammar
+	r.orm = schema.orm
+	r.prefix = schema.prefix
+	r.processor = schema.processor
+	r.schema = schema.schema
+}
+
+func (r *Schema) newConnection(name string) (*Schema, error) {
+	connection := r.connectionName(name)
+	connectionDriver, err := r.driverForConnection(connection)
+	if err != nil {
+		return nil, err
+	}
+
+	schema, err := NewSchema(r.config, r.log, r.orm.Connection(connection), connectionDriver, r.migrations)
+	if err != nil {
+		return nil, err
+	}
+
+	schema.goTypes = slices.Clone(r.goTypes)
+	schema.models = slices.Clone(r.models)
+	schema.modelsByFullName = make(map[string]any, len(r.modelsByFullName))
+	for name, model := range r.modelsByFullName {
+		schema.modelsByFullName[name] = model
+	}
+
+	return schema, nil
+}
+
+func (r *Schema) connectionName(name string) string {
+	if name != "" {
+		return name
+	}
+
+	return r.config.GetString("database.default")
+}
+
+func (r *Schema) driverForConnection(name string) (driver.Driver, error) {
+	driverCallback, exist := r.config.Get(fmt.Sprintf("database.connections.%s.via", name)).(func() (driver.Driver, error))
+	if !exist {
+		return nil, errors.DatabaseConfigNotFound
+	}
+
+	return driverCallback()
 }
 
 func (r *Schema) Sql(sql string) error {

--- a/database/schema/schema_test.go
+++ b/database/schema/schema_test.go
@@ -6,7 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	contractsdatabase "github.com/goravel/framework/contracts/database"
+	contractsdriver "github.com/goravel/framework/contracts/database/driver"
 	contractsschema "github.com/goravel/framework/contracts/database/schema"
+	mocksconfig "github.com/goravel/framework/mocks/config"
+	mocksdriver "github.com/goravel/framework/mocks/database/driver"
+	mocksorm "github.com/goravel/framework/mocks/database/orm"
 )
 
 type User struct {
@@ -214,6 +219,67 @@ func (r *SchemaTestSuite) TestExtendModels() {
 			test.assert(schema)
 		})
 	}
+}
+
+func (r *SchemaTestSuite) TestConnectionUsesConnectionDriver() {
+	mockConfig := mocksconfig.NewConfig(r.T())
+	mockOrm := mocksorm.NewOrm(r.T())
+	mockConnectionOrm := mocksorm.NewOrm(r.T())
+	mockDriver := mocksdriver.NewDriver(r.T())
+	mockGrammar := mocksdriver.NewGrammar(r.T())
+	mockProcessor := mocksdriver.NewProcessor(r.T())
+
+	mockConfig.EXPECT().Get("database.connections.analytics.via").Return(func() (contractsdriver.Driver, error) {
+		return mockDriver, nil
+	}).Once()
+	mockOrm.EXPECT().Connection("analytics").Return(mockConnectionOrm).Once()
+	mockDriver.EXPECT().Pool().Return(contractsdatabase.Pool{Writers: []contractsdatabase.Config{{Prefix: "tenant_", Schema: "reporting"}}}).Once()
+	mockDriver.EXPECT().Grammar().Return(mockGrammar).Once()
+	mockDriver.EXPECT().Processor().Return(mockProcessor).Once()
+
+	schema := &Schema{
+		config: mockConfig,
+		orm:    mockOrm,
+	}
+
+	got, ok := schema.Connection("analytics").(*Schema)
+	r.Require().True(ok)
+	r.Same(mockConnectionOrm, got.orm)
+	r.Same(mockDriver, got.driver)
+	r.Same(mockGrammar, got.grammar)
+	r.Same(mockProcessor, got.processor)
+	r.Equal("tenant_", got.prefix)
+	r.Equal("reporting", got.schema)
+}
+
+func (r *SchemaTestSuite) TestSetConnectionUsesConnectionDriver() {
+	mockConfig := mocksconfig.NewConfig(r.T())
+	mockOrm := mocksorm.NewOrm(r.T())
+	mockConnectionOrm := mocksorm.NewOrm(r.T())
+	mockDriver := mocksdriver.NewDriver(r.T())
+	mockGrammar := mocksdriver.NewGrammar(r.T())
+	mockProcessor := mocksdriver.NewProcessor(r.T())
+
+	mockConfig.EXPECT().Get("database.connections.analytics.via").Return(func() (contractsdriver.Driver, error) {
+		return mockDriver, nil
+	}).Once()
+	mockOrm.EXPECT().Connection("analytics").Return(mockConnectionOrm).Once()
+	mockDriver.EXPECT().Pool().Return(contractsdatabase.Pool{Writers: []contractsdatabase.Config{{Prefix: "tenant_", Schema: "reporting"}}}).Once()
+	mockDriver.EXPECT().Grammar().Return(mockGrammar).Once()
+	mockDriver.EXPECT().Processor().Return(mockProcessor).Once()
+
+	schema := &Schema{
+		config: mockConfig,
+		orm:    mockOrm,
+	}
+
+	schema.SetConnection("analytics")
+	r.Same(mockConnectionOrm, schema.orm)
+	r.Same(mockDriver, schema.driver)
+	r.Same(mockGrammar, schema.grammar)
+	r.Same(mockProcessor, schema.processor)
+	r.Equal("tenant_", schema.prefix)
+	r.Equal("reporting", schema.schema)
 }
 
 func getSchema() *Schema {

--- a/tests/schema_test.go
+++ b/tests/schema_test.go
@@ -2680,6 +2680,32 @@ func (s *SchemaSuite) createTableAndAssertColumnsForColumnMethods(schema contrac
 	s.Contains(columnListing, "updated_at")
 }
 
+func TestSchemaConnectionUsesConnectionDriver(t *testing.T) {
+	postgresTestQuery := NewTestQueryBuilder().Postgres("", false)
+	sqliteTestQuery := NewTestQueryBuilder().Sqlite("", false)
+	sqliteTestQuery.CreateTable(TestTableProducts)
+
+	docker, err := sqliteTestQuery.Driver().Docker()
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, docker.Shutdown())
+	}()
+
+	sqliteConfig := sqliteTestQuery.Driver().Pool().Writers[0]
+	sqliteConnection := sqliteConfig.Connection
+	mockDatabaseConfig(postgresTestQuery.MockConfig(), sqliteConfig)
+
+	schema := newSchema(postgresTestQuery, map[string]*TestQuery{
+		postgresTestQuery.Driver().Pool().Writers[0].Connection: postgresTestQuery,
+		sqliteConnection: sqliteTestQuery,
+	})
+
+	assert.True(t, schema.Connection(sqliteConnection).HasTable("products"))
+
+	schema.SetConnection(sqliteConnection)
+	assert.True(t, schema.HasTable("products"))
+}
+
 func TestPostgresSchema(t *testing.T) {
 	table := "table"
 	postgresTestQuery := NewTestQueryBuilder().Postgres("", false)


### PR DESCRIPTION
## Summary
- Schema connections now resolve the selected connection database driver before building grammar, processor, prefix, and schema metadata.
- `db:wipe --database` reuses the resolved schema connection for all wipe operations.
- Added regression coverage for schema connection driver switching and wipe connection reuse.

Closes https://github.com/goravel/goravel/issues/942

## Why
Applications can configure multiple database connections with different drivers. Schema operations should compile metadata queries using the selected connection driver instead of the default connection driver.

Before this change, `facades.Schema().Connection("OtherDBMS")` executed against the selected connection but compiled schema SQL with the default driver. After this change, both facade schema calls and `db:wipe --database` use the selected connection driver metadata.

```go
facades.Schema().Connection("OtherDBMS").HasTable("example")

facades.Artisan().Call("db:wipe", map[string]string{
	"--database": "OtherDBMS",
})
```
