### PR TITLE
feat: add WithTitle option to AI attachment options

### DIFF
--- a/ai/document/file.go
+++ b/ai/document/file.go
@@ -16,6 +16,10 @@ func WithDisk(disk string) contractsai.AttachmentOption {
 	return frameworkai.WithDisk(disk)
 }
 
+func WithTitle(title string) contractsai.AttachmentOption {
+	return frameworkai.WithTitle(title)
+}
+
 func FromByte(content []byte, options ...contractsai.AttachmentOption) contractsai.Attachment {
 	return frameworkai.DocumentFromByte(content, options...)
 }

--- a/ai/file.go
+++ b/ai/file.go
@@ -54,6 +54,12 @@ func WithDisk(disk string) contractsai.AttachmentOption {
 	}
 }
 
+func WithTitle(title string) contractsai.AttachmentOption {
+	return func(options *contractsai.AttachmentOptions) {
+		options.Title = title
+	}
+}
+
 func DocumentFromByte(content []byte, options ...contractsai.AttachmentOption) contractsai.Attachment {
 	return fromBytes(contractsai.AttachmentKindFile, content, resolveAttachmentOptions(options))
 }
@@ -136,6 +142,7 @@ func resolveAttachmentOptions(options []contractsai.AttachmentOption) contractsa
 func newAttachment(kind contractsai.AttachmentKind, resolver resolver, metadata contractsai.AttachmentOptions) contractsai.Attachment {
 	return &resolved{
 		kind:     kind,
+		filename: metadata.Title,
 		mimeType: metadata.MimeType,
 		resolver: resolver,
 	}
@@ -412,7 +419,7 @@ func (r *resolved) Content(ctx context.Context) ([]byte, error) {
 		}
 
 		r.content = content
-		if r.filename == "" {
+		if filename != "" {
 			r.filename = filename
 		}
 		if r.mimeType == "" {

--- a/ai/file_test.go
+++ b/ai/file_test.go
@@ -437,6 +437,31 @@ func TestDocumentFromIDReturnsErrorWhenFacadeNotSet(t *testing.T) {
 	assert.Equal(t, errors.AIFacadeNotSet, attachment.Delete(context.Background()))
 }
 
+func TestDocumentFromPathOverridesTitle(t *testing.T) {
+	tempFile, err := os.CreateTemp(t.TempDir(), "report-*.txt")
+	require.NoError(t, err)
+	_, err = tempFile.WriteString("report")
+	require.NoError(t, err)
+	require.NoError(t, tempFile.Close())
+
+	attachment := DocumentFromPath(tempFile.Name(), WithTitle("custom-title"))
+	content, err := attachment.Content(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []byte("report"), content)
+	assert.Equal(t, filepathBase(tempFile.Name()), attachment.FileName())
+}
+
+func TestDocumentFromStringWithTitle(t *testing.T) {
+	attachment := DocumentFromString("report", WithTitle("report-2025-06-14.txt"), WithMimeType("text/plain"))
+
+	assert.Equal(t, "report-2025-06-14.txt", attachment.FileName())
+	assert.Equal(t, "text/plain", attachment.MimeType())
+	content, err := attachment.Content(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []byte("report"), content)
+	assert.Equal(t, "report-2025-06-14.txt", attachment.FileName())
+}
+
 func filepathBase(path string) string {
 	index := bytes.LastIndexByte([]byte(path), os.PathSeparator)
 	if index == -1 {

--- a/ai/image/file.go
+++ b/ai/image/file.go
@@ -16,6 +16,10 @@ func WithDisk(disk string) contractsai.AttachmentOption {
 	return frameworkai.WithDisk(disk)
 }
 
+func WithTitle(title string) contractsai.AttachmentOption {
+	return frameworkai.WithTitle(title)
+}
+
 func FromByte(content []byte, options ...contractsai.AttachmentOption) contractsai.Attachment {
 	return frameworkai.ImageFromByte(content, options...)
 }

--- a/ai/transcription/transcription.go
+++ b/ai/transcription/transcription.go
@@ -14,6 +14,10 @@ func WithDisk(disk string) contractsai.AttachmentOption {
 	return frameworkai.WithDisk(disk)
 }
 
+func WithTitle(title string) contractsai.AttachmentOption {
+	return frameworkai.WithTitle(title)
+}
+
 func FromPath(path string, options ...contractsai.AttachmentOption) contractsai.Attachment {
 	return frameworkai.DocumentFromPath(path, options...)
 }

--- a/contracts/ai/attachment.go
+++ b/contracts/ai/attachment.go
@@ -13,6 +13,10 @@ type AttachmentOptions struct {
 	MimeType string
 	// Only used by FromStorage.
 	Disk string
+	// Title provides a display name for attachments created from
+	// sources without a natural filename (e.g. fromString, fromByte).
+	// Providers such as Anthropic require a non-empty document title.
+	Title string
 }
 
 type AttachmentOption func(options *AttachmentOptions)


### PR DESCRIPTION
## Summary
- Document attachments can now carry a display title via the `WithTitle` option
- Natural filenames (from path, URL, storage, upload) override the title after content resolution
- Anthropic provider no longer rejects inline document attachments with empty titles

## Why
When creating document attachments from strings or byte slices using `DocumentFromString` or `DocumentFromByte`, the attachment had no filename. The Anthropic API requires `document.title` to have at least one character, causing a 400 error when sending inline document attachments. The new `WithTitle` option lets users provide a descriptive title for these attachments.

```go
attachment := frameworkai.DocumentFromString(
    "The alpha release ships on July 1, 2026.",
    frameworkai.WithMimeType("text/plain"),
    frameworkai.WithTitle("Release Schedule"),
)

response, err := conversation.Prompt(
    "When does the alpha ship?",
    frameworkai.WithAttachments(attachment),
)
```
