### PR TITLE
test: add regression coverage for full generator import paths

### DIFF
--- a/database/migration/creator_test.go
+++ b/database/migration/creator_test.go
@@ -100,6 +100,50 @@ func (r *M202410131203CreateUsersTable) Down() error {
 `,
 		},
 		{
+			name: "Create stub with full facades import path",
+			stub: Stubs{}.Create(),
+			data: StubData{
+				Package:        "migrations",
+				StructName:     "M202410131203CreateUsersTable",
+				Signature:      "202410131203_create_users_table",
+				Table:          "users",
+				FacadesPackage: "facades",
+				FacadesImport:  "gitlab.com/ijobs.uz/medclinic.uz/api/app/facades",
+			},
+			expected: `package migrations
+
+import (
+	"github.com/goravel/framework/contracts/database/schema"
+
+	"gitlab.com/ijobs.uz/medclinic.uz/api/app/facades"
+)
+
+type M202410131203CreateUsersTable struct{}
+
+// Signature The unique signature for the migration.
+func (r *M202410131203CreateUsersTable) Signature() string {
+	return "202410131203_create_users_table"
+}
+
+// Up Run the migrations.
+func (r *M202410131203CreateUsersTable) Up() error {
+	if !facades.Schema().HasTable("users") {
+		return facades.Schema().Create("users", func(table schema.Blueprint) {
+			table.ID()
+			table.TimestampsTz()
+		})
+	}
+
+	return nil
+}
+
+// Down Reverse the migrations.
+func (r *M202410131203CreateUsersTable) Down() error {
+	return facades.Schema().DropIfExists("users")
+}
+`,
+		},
+		{
 			name: "Create stub with schema fields",
 			stub: Stubs{}.Create(),
 			data: StubData{

--- a/foundation/console/stubs_test.go
+++ b/foundation/console/stubs_test.go
@@ -1,0 +1,21 @@
+package console
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPackageMakeCommandStubsFacadesUsesFullMainImportPath(t *testing.T) {
+	stubs := PackageMakeCommandStubs{
+		main: "gitlab.com/ijobs.uz/medclinic.uz/api",
+		pkg:  "sms",
+		root: "packages/sms",
+		name: "sms",
+	}
+
+	content := stubs.Facades()
+
+	assert.Contains(t, content, `"gitlab.com/ijobs.uz/medclinic.uz/api/packages/sms"`)
+	assert.Contains(t, content, `"gitlab.com/ijobs.uz/medclinic.uz/api/packages/sms/contracts"`)
+}

--- a/foundation/console/test_make_command_test.go
+++ b/foundation/console/test_make_command_test.go
@@ -96,7 +96,7 @@ func (s *TestMakeCommandTestSuite) TestTestHandle() {
 	s.True(file.Contain("tests/user/user_test.go", "package user"))
 	s.True(file.Contain("tests/user/user_test.go", "type UserTestSuite struct"))
 	s.True(file.Contain("tests/user/user_test.go", "func (s *UserTestSuite) SetupTest() {"))
-	s.True(file.Contain("tests/user/user_test.go", "framework/tests"))
+	s.True(file.Contain("tests/user/user_test.go", `"github.com/goravel/framework/tests"`))
 	s.True(file.Contain("tests/user/user_test.go", "tests.TestCase"))
 	s.NoError(file.Remove("tests"))
 }


### PR DESCRIPTION
## Summary
- Add regression test for migration stubs generated with fully-qualified facades import paths
- Add unit test validating package facades stubs use the full main import path
- Tighten test assertion to match the complete `github.com/goravel/framework/tests` import path

Closes https://github.com/goravel/goravel/issues/973

## Why
When using a fully-qualified import path for facades (e.g. `gitlab.com/ijobs.uz/medclinic.uz/api/app/facades`), the migration stub generator and package make command stubs were not properly verified to produce correct output. This PR adds regression coverage to ensure these stubs always use the correct, full import path.

```go
// Before: the test assertion for test make command was loose
s.True(file.Contain("tests/user/user_test.go", "framework/tests"))

// After: the assertion now checks for the full import path
s.True(file.Contain("tests/user/user_test.go", `"github.com/goravel/framework/tests"`))
```
