### PR TITLE
fix: [#945] ignore empty cache prefix

### DIFF
--- a/cache/utils.go
+++ b/cache/utils.go
@@ -5,5 +5,10 @@ import (
 )
 
 func prefix(config config.Config) string {
-	return config.GetString("cache.prefix") + ":"
+	p := config.GetString("cache.prefix")
+	if p == "" {
+		return ""
+	}
+
+	return p + ":"
 }

--- a/cache/utils_test.go
+++ b/cache/utils_test.go
@@ -16,10 +16,10 @@ func TestPrefix(t *testing.T) {
 		assert.Equal(t, "myprefix:", got)
 	})
 
-	t.Run("empty", func(t *testing.T) {
+	t.Run("empty prefix is ignored", func(t *testing.T) {
 		mockConfig := mocksconfig.NewConfig(t)
 		mockConfig.EXPECT().GetString("cache.prefix").Return("").Once()
 		got := prefix(mockConfig)
-		assert.Equal(t, ":", got)
+		assert.Equal(t, "", got)
 	})
 }


### PR DESCRIPTION
The cache key prefix helper joins the configured `cache.prefix` to every key with a `:` separator. The separator was added unconditionally, so when `cache.prefix` is empty every key still received a leading `:` (for example `:name`) instead of being stored without a prefix. That makes keys longer than necessary and inconsistent with using the store directly.

## What is changing

- `prefix` returns an empty string when `cache.prefix` is not configured, instead of a bare `:`.
- When a prefix is configured the behavior is unchanged: the helper still returns `<prefix>:`, so the in-memory driver keeps producing `<prefix>:name`.

## Example

With `cache.prefix` empty:

```
Before: facades.Cache().Put("name", ...) -> key ":name"
After:  facades.Cache().Put("name", ...) -> key "name"
```

With `cache.prefix = "goravel_cache"` the key is still `goravel_cache:name`.

The Redis driver carries the same fix in goravel/redis#144 so both drivers behave consistently.

Ref: goravel/goravel#945
