### PR TITLE
feat: [#959] add WithCommandsFilter builder to scope registered Artisan commands

### DIFF
--- a/console/application.go
+++ b/console/application.go
@@ -86,8 +86,7 @@ func (r *Application) CallAndExit(command string) {
 	_ = r.Run(append(commands, strings.Split(command, " ")...), true)
 }
 
-// Register commands to the application. Filtering is the caller's
-// responsibility; this method appends without consulting any allowlist.
+// Register commands to the application.
 func (r *Application) Register(commands []console.Command) {
 	r.commands = append(r.commands, commands...)
 }

--- a/console/application.go
+++ b/console/application.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	stdpath "path"
 	"slices"
 	"strings"
 	"syscall"
@@ -173,6 +174,57 @@ func shutdownCommand(shutdownable console.Shutdownable, cmd *cli.Command, argume
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer shutdownCancel()
 	return shutdownable.Shutdown(NewCliContext(shutdownCtx, cmd, arguments))
+}
+
+// FilterCommandsByAllowlist returns the subset of commands whose Signature()
+// matches at least one entry in allowlist. Each entry is matched in one of
+// two ways:
+//
+//   - Exact match (no wildcard) — checked against command.Signature().
+//   - Glob match (the entry contains '*') — checked against
+//     command.Signature() using stdpath.Match. '*' matches any sequence of
+//     non-'/' characters. '?' is not a wildcard.
+//
+// Category is never consulted. The filter is signature-only.
+//
+// Special cases:
+//   - allowlist == nil            → every command is kept (no filter applied).
+//   - allowlist resolves to no usable entries → every command is dropped.
+func FilterCommandsByAllowlist(commands []console.Command, allowlist []string) []console.Command {
+	if allowlist == nil {
+		return commands
+	}
+	exact := make(map[string]struct{}, len(allowlist))
+	var globs []string
+	for _, s := range allowlist {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if strings.Contains(s, "*") {
+			globs = append(globs, s)
+		} else {
+			exact[s] = struct{}{}
+		}
+	}
+	if len(exact) == 0 && len(globs) == 0 {
+		return nil
+	}
+	kept := make([]console.Command, 0, len(commands))
+	for _, cmd := range commands {
+		sig := cmd.Signature()
+		if _, ok := exact[sig]; ok {
+			kept = append(kept, cmd)
+			continue
+		}
+		for _, pattern := range globs {
+			if ok, _ := stdpath.Match(pattern, sig); ok {
+				kept = append(kept, cmd)
+				break
+			}
+		}
+	}
+	return kept
 }
 
 func commandsToCliCommands(commands []console.Command) ([]*cli.Command, error) {

--- a/console/application.go
+++ b/console/application.go
@@ -86,7 +86,8 @@ func (r *Application) CallAndExit(command string) {
 	_ = r.Run(append(commands, strings.Split(command, " ")...), true)
 }
 
-// Register commands to the application.
+// Register commands to the application. Filtering is the caller's
+// responsibility; this method appends without consulting any allowlist.
 func (r *Application) Register(commands []console.Command) {
 	r.commands = append(r.commands, commands...)
 }
@@ -177,15 +178,13 @@ func shutdownCommand(shutdownable console.Shutdownable, cmd *cli.Command, argume
 }
 
 // FilterCommandsByAllowlist returns the subset of commands whose Signature()
-// matches at least one entry in allowlist. Each entry is matched in one of
-// two ways:
+// matches at least one entry in allowlist.
 //
-//   - Exact match (no wildcard) — checked against command.Signature().
-//   - Glob match (the entry contains '*') — checked against
-//     command.Signature() using stdpath.Match. '*' matches any sequence of
-//     non-'/' characters. '?' is not a wildcard.
-//
-// Category is never consulted. The filter is signature-only.
+// Matching is signature-only (category never consulted):
+//   - Entries without '*' are exact-matched against command.Signature().
+//   - Entries containing '*' use glob matching via path.Match against
+//     command.Signature() (only '*' triggers the glob path; '?' is matched
+//     literally as an exact match).
 //
 // Special cases:
 //   - allowlist == nil            → every command is kept (no filter applied).

--- a/console/application_test.go
+++ b/console/application_test.go
@@ -607,3 +607,100 @@ func (receiver *TestBlockingCommand) Handle(ctx console.Context) error {
 	<-ctx.Done()
 	return nil
 }
+
+func TestFilterCommandsByAllowlist(t *testing.T) {
+	mkCmd := func(sig string) console.Command {
+		return &filterTestCommand{signature: sig}
+	}
+	commands := []console.Command{
+		mkCmd("env:encrypt"),
+		mkCmd("env:decrypt"),
+		mkCmd("make:controller"),
+		mkCmd("make:job"),
+		mkCmd("make:test"),
+		mkCmd("package:install"),
+		mkCmd("vendor:publish"),
+		mkCmd("up"),
+		mkCmd("down"),
+	}
+
+	tests := []struct {
+		name     string
+		allow    []string
+		expected []string
+	}{
+		{
+			name:     "nil allowlist returns the input slice as-is",
+			allow:    nil,
+			expected: []string{"env:encrypt", "env:decrypt", "make:controller", "make:job", "make:test", "package:install", "vendor:publish", "up", "down"},
+		},
+		{
+			name:     "empty allowlist drops everything",
+			allow:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "exact signature",
+			allow:    []string{"env:encrypt"},
+			expected: []string{"env:encrypt"},
+		},
+		{
+			name:     "glob prefix matches sub-commands",
+			allow:    []string{"env:*"},
+			expected: []string{"env:encrypt", "env:decrypt"},
+		},
+		{
+			name:     "glob prefix matches bare signature too",
+			allow:    []string{"make*"},
+			expected: []string{"make:controller", "make:job", "make:test"},
+		},
+		{
+			name:     "mixed exact and glob",
+			allow:    []string{"vendor:publish", "env:*"},
+			expected: []string{"env:encrypt", "env:decrypt", "vendor:publish"},
+		},
+		{
+			name:     "question mark is literal, not a wildcard",
+			allow:    []string{"env:?ncrypt"},
+			expected: []string{},
+		},
+		{
+			name:     "whitespace-only and empty entries are ignored",
+			allow:    []string{"  ", ""},
+			expected: []string{},
+		},
+		{
+			name:     "category is not consulted",
+			allow:    []string{"make"},
+			expected: []string{},
+		},
+		{
+			name:     "wildcard star matches everything",
+			allow:    []string{"*"},
+			expected: []string{"env:encrypt", "env:decrypt", "make:controller", "make:job", "make:test", "package:install", "vendor:publish", "up", "down"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterCommandsByAllowlist(commands, tt.allow)
+			gotSigs := make([]string, 0, len(got))
+			for _, c := range got {
+				gotSigs = append(gotSigs, c.Signature())
+			}
+			assert.Equal(t, tt.expected, gotSigs)
+		})
+	}
+}
+
+type filterTestCommand struct {
+	console.Command
+	signature string
+}
+
+func (f *filterTestCommand) Signature() string  { return f.signature }
+func (f *filterTestCommand) Description() string { return f.signature }
+func (f *filterTestCommand) Extend() command.Extend {
+	return command.Extend{}
+}
+func (f *filterTestCommand) Handle(_ console.Context) error { return nil }

--- a/console/service_provider.go
+++ b/console/service_provider.go
@@ -73,5 +73,5 @@ func (r *ServiceProvider) registerCommands(app foundation.Application) {
 		// 	"static": config.Env("DEPLOY_STATIC", true),
 		// },
 		// console.NewDeployCommand(configFacade, artisanFacade),
-	}, app.ConsoleCommandsFilter()))
+	}, app.CommandsFilter()))
 }

--- a/console/service_provider.go
+++ b/console/service_provider.go
@@ -36,9 +36,14 @@ func (r *ServiceProvider) Boot(app foundation.Application) {
 
 func (r *ServiceProvider) registerCommands(app foundation.Application) {
 	artisanFacade := app.MakeArtisan()
+	if artisanFacade == nil {
+		return
+	}
+
 	configFacade := app.MakeConfig()
 	processFacade := app.MakeProcess()
-	artisanFacade.Register([]consolecontract.Command{
+
+	artisanFacade.Register(FilterCommandsByAllowlist([]consolecontract.Command{
 		console.NewListCommand(),
 		console.NewKeyGenerateCommand(configFacade),
 		console.NewMakeCommand(),
@@ -68,5 +73,5 @@ func (r *ServiceProvider) registerCommands(app foundation.Application) {
 		// 	"static": config.Env("DEPLOY_STATIC", true),
 		// },
 		// console.NewDeployCommand(configFacade, artisanFacade),
-	})
+	}, app.ConsoleCommandsFilter()))
 }

--- a/console/service_provider_test.go
+++ b/console/service_provider_test.go
@@ -63,9 +63,9 @@ func TestServiceProviderBootNilAllowlistRegistersAll(t *testing.T) {
 
 	// nil allowlist means all four console/console/* commands are registered.
 	app.EXPECT().MakeArtisan().Return(artisan).Once()
-	app.EXPECT().MakeConfig().Return(configFacade).Maybe()
-	app.EXPECT().MakeProcess().Return(processFacade).Maybe()
-	app.EXPECT().ConsoleCommandsFilter().Return(nil).Once()
+	app.EXPECT().MakeConfig().Return(configFacade).Once()
+	app.EXPECT().MakeProcess().Return(processFacade).Once()
+	app.EXPECT().CommandsFilter().Return(nil).Once()
 	artisan.EXPECT().Register(mock.MatchedBy(func(commands []contractsconsole.Command) bool {
 		return len(commands) == 4
 	})).Once()
@@ -82,9 +82,9 @@ func TestServiceProviderBootEmptyAllowlistRegistersNothing(t *testing.T) {
 
 	// empty allowlist means all commands are dropped.
 	app.EXPECT().MakeArtisan().Return(artisan).Once()
-	app.EXPECT().MakeConfig().Return(configFacade).Maybe()
-	app.EXPECT().MakeProcess().Return(processFacade).Maybe()
-	app.EXPECT().ConsoleCommandsFilter().Return([]string{}).Once()
+	app.EXPECT().MakeConfig().Return(configFacade).Once()
+	app.EXPECT().MakeProcess().Return(processFacade).Once()
+	app.EXPECT().CommandsFilter().Return([]string{}).Once()
 	artisan.EXPECT().Register(mock.MatchedBy(func(commands []contractsconsole.Command) bool {
 		return len(commands) == 0
 	})).Once()
@@ -100,12 +100,10 @@ func TestServiceProviderBootAllowlistApplies(t *testing.T) {
 	processFacade := mocksprocess.NewProcess(t)
 
 	// glob pattern keep-list: only "list" and the make sub-command survive.
-	// The framework still constructs every command before filtering, so
-	// MakeConfig and MakeProcess are called for the dropped commands too.
 	app.EXPECT().MakeArtisan().Return(artisan).Once()
-	app.EXPECT().MakeConfig().Return(configFacade).Maybe()
-	app.EXPECT().MakeProcess().Return(processFacade).Maybe()
-	app.EXPECT().ConsoleCommandsFilter().Return([]string{"list", "make:*"}).Once()
+	app.EXPECT().MakeConfig().Return(configFacade).Once()
+	app.EXPECT().MakeProcess().Return(processFacade).Once()
+	app.EXPECT().CommandsFilter().Return([]string{"list", "make:*"}).Once()
 	artisan.EXPECT().Register(mock.MatchedBy(func(commands []contractsconsole.Command) bool {
 		got := signaturesOf(commands)
 		want := []string{"list", "make:command"}

--- a/console/service_provider_test.go
+++ b/console/service_provider_test.go
@@ -1,0 +1,125 @@
+package console
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/goravel/framework/contracts/binding"
+	contractsconsole "github.com/goravel/framework/contracts/console"
+	contractsfoundation "github.com/goravel/framework/contracts/foundation"
+	mocksconfig "github.com/goravel/framework/mocks/config"
+	mocksconsole "github.com/goravel/framework/mocks/console"
+	mocksfoundation "github.com/goravel/framework/mocks/foundation"
+	mocksprocess "github.com/goravel/framework/mocks/process"
+)
+
+func TestServiceProviderRelationship(t *testing.T) {
+	provider := &ServiceProvider{}
+
+	relationship := provider.Relationship()
+
+	assert.Equal(t, []string{binding.Artisan}, relationship.Bindings)
+	assert.Equal(t, binding.Bindings[binding.Artisan].Dependencies, relationship.Dependencies)
+	assert.Empty(t, relationship.ProvideFor)
+}
+
+func TestServiceProviderRegister(t *testing.T) {
+	provider := &ServiceProvider{}
+
+	t.Run("register artisan singleton", func(t *testing.T) {
+		app := mocksfoundation.NewApplication(t)
+		app.EXPECT().Singleton(binding.Artisan, mock.AnythingOfType("func(foundation.Application) (interface {}, error)")).Run(func(_ any, callback func(contractsfoundation.Application) (any, error)) {
+			callbackApp := mocksfoundation.NewApplication(t)
+			callbackApp.EXPECT().Version().Return("v1.18.0").Once()
+
+			instance, err := callback(callbackApp)
+
+			assert.NoError(t, err)
+			assert.IsType(t, &Application{}, instance)
+		}).Once()
+
+		provider.Register(app)
+	})
+}
+
+func signaturesOf(commands []contractsconsole.Command) []string {
+	sigs := make([]string, 0, len(commands))
+	for _, c := range commands {
+		sigs = append(sigs, c.Signature())
+	}
+	sort.Strings(sigs)
+	return sigs
+}
+
+func TestServiceProviderBootNilAllowlistRegistersAll(t *testing.T) {
+	provider := &ServiceProvider{}
+	app := mocksfoundation.NewApplication(t)
+	artisan := mocksconsole.NewArtisan(t)
+	configFacade := mocksconfig.NewConfig(t)
+	processFacade := mocksprocess.NewProcess(t)
+
+	// nil allowlist means all four console/console/* commands are registered.
+	app.EXPECT().MakeArtisan().Return(artisan).Once()
+	app.EXPECT().MakeConfig().Return(configFacade).Maybe()
+	app.EXPECT().MakeProcess().Return(processFacade).Maybe()
+	app.EXPECT().ConsoleCommandsFilter().Return(nil).Once()
+	artisan.EXPECT().Register(mock.MatchedBy(func(commands []contractsconsole.Command) bool {
+		return len(commands) == 4
+	})).Once()
+
+	provider.Boot(app)
+}
+
+func TestServiceProviderBootEmptyAllowlistRegistersNothing(t *testing.T) {
+	provider := &ServiceProvider{}
+	app := mocksfoundation.NewApplication(t)
+	artisan := mocksconsole.NewArtisan(t)
+	configFacade := mocksconfig.NewConfig(t)
+	processFacade := mocksprocess.NewProcess(t)
+
+	// empty allowlist means all commands are dropped.
+	app.EXPECT().MakeArtisan().Return(artisan).Once()
+	app.EXPECT().MakeConfig().Return(configFacade).Maybe()
+	app.EXPECT().MakeProcess().Return(processFacade).Maybe()
+	app.EXPECT().ConsoleCommandsFilter().Return([]string{}).Once()
+	artisan.EXPECT().Register(mock.MatchedBy(func(commands []contractsconsole.Command) bool {
+		return len(commands) == 0
+	})).Once()
+
+	provider.Boot(app)
+}
+
+func TestServiceProviderBootAllowlistApplies(t *testing.T) {
+	provider := &ServiceProvider{}
+	app := mocksfoundation.NewApplication(t)
+	artisan := mocksconsole.NewArtisan(t)
+	configFacade := mocksconfig.NewConfig(t)
+	processFacade := mocksprocess.NewProcess(t)
+
+	// glob pattern keep-list: only "list" and the make sub-command survive.
+	// The framework still constructs every command before filtering, so
+	// MakeConfig and MakeProcess are called for the dropped commands too.
+	app.EXPECT().MakeArtisan().Return(artisan).Once()
+	app.EXPECT().MakeConfig().Return(configFacade).Maybe()
+	app.EXPECT().MakeProcess().Return(processFacade).Maybe()
+	app.EXPECT().ConsoleCommandsFilter().Return([]string{"list", "make:*"}).Once()
+	artisan.EXPECT().Register(mock.MatchedBy(func(commands []contractsconsole.Command) bool {
+		got := signaturesOf(commands)
+		want := []string{"list", "make:command"}
+		sort.Strings(want)
+		if len(got) != len(want) {
+			return false
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				return false
+			}
+		}
+		return true
+	})).Once()
+
+	provider.Boot(app)
+}

--- a/contracts/foundation/application.go
+++ b/contracts/foundation/application.go
@@ -65,6 +65,9 @@ type Application interface {
 	Build() Application
 	// Commands register the given commands with the console application.
 	Commands([]console.Command)
+	// ConsoleCommandsFilter returns the captured positive-list of command
+	// signatures to keep (set via WithCommandsFilter). nil means no filter.
+	ConsoleCommandsFilter() []string
 	// Context gets the application context.
 	Context() context.Context
 	// GetJson get the JSON implementation.

--- a/contracts/foundation/application.go
+++ b/contracts/foundation/application.go
@@ -65,9 +65,9 @@ type Application interface {
 	Build() Application
 	// Commands register the given commands with the console application.
 	Commands([]console.Command)
-	// ConsoleCommandsFilter returns the captured positive-list of command
-	// signatures to keep (set via WithCommandsFilter). nil means no filter.
-	ConsoleCommandsFilter() []string
+	// CommandsFilter returns the positive-list of command signatures to keep
+	// (set via WithCommandsFilter). nil means no filter.
+	CommandsFilter() []string
 	// Context gets the application context.
 	Context() context.Context
 	// GetJson get the JSON implementation.

--- a/contracts/foundation/application_builder.go
+++ b/contracts/foundation/application_builder.go
@@ -23,26 +23,20 @@ type ApplicationBuilder interface {
 	// WithCommands sets the application's commands.
 	WithCommands(func() []console.Command) ApplicationBuilder
 	// WithCommandsFilter registers a callback that returns the positive list of
-	// command signatures to keep when the framework registers its own Artisan
-	// commands. The callback runs once at Build() time.
+	// command signatures to keep when the framework registers Artisan commands.
+	// The callback runs once at Build() time.
 	//
-	// Each entry in the returned slice is matched in one of two ways:
-	//   - Exact match (no wildcard) — checked against command.Signature().
-	//   - Glob match (the entry contains '*') — checked against
-	//     command.Signature() using stdpath.Match. '*' matches any sequence
-	//     of non-'/' characters. '?' is not a wildcard.
-	//
-	// Category is never consulted. The filter is signature-only.
+	// Matching is signature-only (category never consulted):
+	//   - Entries without '*' are exact-matched against command.Signature().
+	//   - Entries containing '*' use glob matching via path.Match against
+	//     command.Signature() (only '*' triggers the glob path; '?' is
+	//     matched literally as an exact match).
 	//
 	// Semantics:
 	//   - Method not called           → keep every command (default).
 	//   - Callback returns nil        → keep every command (no filter).
-	//   - Callback returns []string{} → drop every command (filter, no matches).
-	//   - Callback returns entries    → keep only commands whose signature
-	//     matches an entry (exact or glob).
-	//
-	// The filter applies to user-added commands from WithCommands as well,
-	// so the user cannot bypass the filter by adding commands.
+	//   - Callback returns []string{} → drop every command.
+	//   - Callback returns entries    → keep only commands matching an entry.
 	WithCommandsFilter(func() []string) ApplicationBuilder
 	// WithConfig sets a callback function to configure the application.
 	WithConfig(func()) ApplicationBuilder

--- a/contracts/foundation/application_builder.go
+++ b/contracts/foundation/application_builder.go
@@ -22,6 +22,28 @@ type ApplicationBuilder interface {
 	WithCallback(func()) ApplicationBuilder
 	// WithCommands sets the application's commands.
 	WithCommands(func() []console.Command) ApplicationBuilder
+	// WithCommandsFilter registers a callback that returns the positive list of
+	// command signatures to keep when the framework registers its own Artisan
+	// commands. The callback runs once at Build() time.
+	//
+	// Each entry in the returned slice is matched in one of two ways:
+	//   - Exact match (no wildcard) — checked against command.Signature().
+	//   - Glob match (the entry contains '*') — checked against
+	//     command.Signature() using stdpath.Match. '*' matches any sequence
+	//     of non-'/' characters. '?' is not a wildcard.
+	//
+	// Category is never consulted. The filter is signature-only.
+	//
+	// Semantics:
+	//   - Method not called           → keep every command (default).
+	//   - Callback returns nil        → keep every command (no filter).
+	//   - Callback returns []string{} → drop every command (filter, no matches).
+	//   - Callback returns entries    → keep only commands whose signature
+	//     matches an entry (exact or glob).
+	//
+	// The filter applies to user-added commands from WithCommands as well,
+	// so the user cannot bypass the filter by adding commands.
+	WithCommandsFilter(func() []string) ApplicationBuilder
 	// WithConfig sets a callback function to configure the application.
 	WithConfig(func()) ApplicationBuilder
 	// WithEvents sets event listeners for the application.

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -76,7 +76,7 @@ type Application struct {
 	publishGroups         map[string]map[string]string
 	json                  foundation.Json
 	bootedRunners         []string
-	consoleCommandsFilter []string
+	commandsFilter []string
 	runnerWg              sync.WaitGroup
 	runnersToRun          []*RunnerWithInfo
 }
@@ -114,8 +114,8 @@ func (r *Application) Build() foundation.Application {
 	r.setTimezone()
 	r.configurePaths()
 	r.configureCustomConfig()
-	if r.builder.consoleCommandsFilter != nil {
-		r.consoleCommandsFilter = r.builder.consoleCommandsFilter()
+	if r.builder.commandsFilter != nil {
+		r.commandsFilter = r.builder.commandsFilter()
 	}
 	r.configureServiceProviders()
 	r.providerRepository.Register(r)
@@ -331,12 +331,12 @@ func (r *Application) SetBuilder(builder foundation.ApplicationBuilder) foundati
 	return r
 }
 
-// ConsoleCommandsFilter returns the captured positive-list of command
-// signatures to keep. nil means no filter is applied. Used by the console
-// service provider so its own command batch goes through the same gate as
-// the framework's defaultCommands batch.
-func (r *Application) ConsoleCommandsFilter() []string {
-	return r.consoleCommandsFilter
+// CommandsFilter returns the positive-list of command signatures to keep.
+// nil means no filter is applied. Used by the console service provider so
+// its own command batch goes through the same gate as the framework's
+// defaultCommands batch.
+func (r *Application) CommandsFilter() []string {
+	return r.commandsFilter
 }
 
 func (r *Application) SetJson(j foundation.Json) {
@@ -476,7 +476,7 @@ func (r *Application) configureCommands() {
 			if artisanFacade == nil {
 				color.Errorln("Artisan facade not found, please install it first: ./artisan package:install Artisan")
 			} else {
-				artisanFacade.Register(frameworkconsole.FilterCommandsByAllowlist(commands, r.consoleCommandsFilter))
+				artisanFacade.Register(frameworkconsole.FilterCommandsByAllowlist(commands, r.commandsFilter))
 			}
 		}
 	}
@@ -769,7 +769,7 @@ func (r *Application) defaultCommands() []contractsconsole.Command {
 		commands = append(commands, console.NewUpCommand(maintenance), console.NewDownCommand(view, hash, maintenance))
 	}
 
-	return frameworkconsole.FilterCommandsByAllowlist(commands, r.consoleCommandsFilter)
+	return frameworkconsole.FilterCommandsByAllowlist(commands, r.commandsFilter)
 }
 
 func (r *Application) baseServiceProviders() []foundation.ServiceProvider {

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -472,12 +472,7 @@ func (r *Application) configureCallback() {
 func (r *Application) configureCommands() {
 	if r.builder.commands != nil {
 		if commands := r.builder.commands(); len(commands) > 0 {
-			artisanFacade := r.MakeArtisan()
-			if artisanFacade == nil {
-				color.Errorln("Artisan facade not found, please install it first: ./artisan package:install Artisan")
-			} else {
-				artisanFacade.Register(frameworkconsole.FilterCommandsByAllowlist(commands, r.commandsFilter))
-			}
+			r.registerCommands(commands)
 		}
 	}
 }
@@ -769,7 +764,7 @@ func (r *Application) defaultCommands() []contractsconsole.Command {
 		commands = append(commands, console.NewUpCommand(maintenance), console.NewDownCommand(view, hash, maintenance))
 	}
 
-	return frameworkconsole.FilterCommandsByAllowlist(commands, r.commandsFilter)
+	return commands
 }
 
 func (r *Application) baseServiceProviders() []foundation.ServiceProvider {
@@ -787,7 +782,7 @@ func (r *Application) registerCommands(commands []contractsconsole.Command) {
 		return
 	}
 
-	artisanFacade.Register(commands)
+	artisanFacade.Register(frameworkconsole.FilterCommandsByAllowlist(commands, r.commandsFilter))
 }
 
 func (r *Application) setTimezone() {

--- a/foundation/application.go
+++ b/foundation/application.go
@@ -68,16 +68,17 @@ func init() {
 
 type Application struct {
 	*Container
-	ctx                context.Context
-	cancel             context.CancelFunc
-	builder            *ApplicationBuilder
-	providerRepository foundation.ProviderRepository
-	publishes          map[string]map[string]string
-	publishGroups      map[string]map[string]string
-	json               foundation.Json
-	bootedRunners      []string
-	runnerWg           sync.WaitGroup
-	runnersToRun       []*RunnerWithInfo
+	ctx                   context.Context
+	cancel                context.CancelFunc
+	builder               *ApplicationBuilder
+	providerRepository    foundation.ProviderRepository
+	publishes             map[string]map[string]string
+	publishGroups         map[string]map[string]string
+	json                  foundation.Json
+	bootedRunners         []string
+	consoleCommandsFilter []string
+	runnerWg              sync.WaitGroup
+	runnersToRun          []*RunnerWithInfo
 }
 
 func NewApplication() foundation.Application {
@@ -113,6 +114,9 @@ func (r *Application) Build() foundation.Application {
 	r.setTimezone()
 	r.configurePaths()
 	r.configureCustomConfig()
+	if r.builder.consoleCommandsFilter != nil {
+		r.consoleCommandsFilter = r.builder.consoleCommandsFilter()
+	}
 	r.configureServiceProviders()
 	r.providerRepository.Register(r)
 	r.providerRepository.Boot(r)
@@ -327,6 +331,14 @@ func (r *Application) SetBuilder(builder foundation.ApplicationBuilder) foundati
 	return r
 }
 
+// ConsoleCommandsFilter returns the captured positive-list of command
+// signatures to keep. nil means no filter is applied. Used by the console
+// service provider so its own command batch goes through the same gate as
+// the framework's defaultCommands batch.
+func (r *Application) ConsoleCommandsFilter() []string {
+	return r.consoleCommandsFilter
+}
+
 func (r *Application) SetJson(j foundation.Json) {
 	if j != nil {
 		r.json = j
@@ -464,7 +476,7 @@ func (r *Application) configureCommands() {
 			if artisanFacade == nil {
 				color.Errorln("Artisan facade not found, please install it first: ./artisan package:install Artisan")
 			} else {
-				artisanFacade.Register(commands)
+				artisanFacade.Register(frameworkconsole.FilterCommandsByAllowlist(commands, r.consoleCommandsFilter))
 			}
 		}
 	}
@@ -757,7 +769,7 @@ func (r *Application) defaultCommands() []contractsconsole.Command {
 		commands = append(commands, console.NewUpCommand(maintenance), console.NewDownCommand(view, hash, maintenance))
 	}
 
-	return commands
+	return frameworkconsole.FilterCommandsByAllowlist(commands, r.consoleCommandsFilter)
 }
 
 func (r *Application) baseServiceProviders() []foundation.ServiceProvider {

--- a/foundation/application_builder.go
+++ b/foundation/application_builder.go
@@ -26,7 +26,7 @@ type ApplicationBuilder struct {
 	commands                   func() []console.Command
 	config                     func()
 	configuredServiceProviders func() []foundation.ServiceProvider
-	commandsFilter      func() []string
+	commandsFilter             func() []string
 	eventToListeners           func() map[event.Event][]event.Listener
 	filters                    func() []validation.Filter
 	grpcClientCredentials      func() map[string]credentials.TransportCredentials

--- a/foundation/application_builder.go
+++ b/foundation/application_builder.go
@@ -26,6 +26,7 @@ type ApplicationBuilder struct {
 	commands                   func() []console.Command
 	config                     func()
 	configuredServiceProviders func() []foundation.ServiceProvider
+	consoleCommandsFilter      func() []string
 	eventToListeners           func() map[event.Event][]event.Listener
 	filters                    func() []validation.Filter
 	grpcClientCredentials      func() map[string]credentials.TransportCredentials
@@ -63,6 +64,40 @@ func (r *ApplicationBuilder) WithCallback(callback func()) foundation.Applicatio
 
 func (r *ApplicationBuilder) WithCommands(fn func() []console.Command) foundation.ApplicationBuilder {
 	r.commands = fn
+
+	return r
+}
+
+// WithCommandsFilter registers a callback that returns the positive list of
+// command signatures to keep when the framework registers its own Artisan
+// commands. The callback runs once at Build() time; the user can call
+// facades.Config() inside it to read app.env or any other setting without
+// needing a parameter.
+//
+// Each entry in the returned slice is matched in one of two ways:
+//
+//   - Exact match (no wildcard) — checked against command.Signature().
+//   - Glob match (the entry contains '*') — checked against
+//     command.Signature() using stdpath.Match. '*' matches any sequence
+//     of non-'/' characters. '?' is not a wildcard.
+//
+// Category is never consulted. The filter is signature-only.
+//
+// Semantics:
+//
+//   - Method not called           → keep every command (default).
+//   - Callback returns nil        → keep every command (no filter).
+//   - Callback returns []string{} → drop every command (filter, no matches).
+//   - Callback returns entries    → keep only commands whose signature
+//     matches an entry (exact or glob).
+//
+// Composition with WithCommands:
+//
+// WithCommands adds extra commands to the framework's set; WithCommandsFilter
+// then trims the combined set. The filter applies to user-added commands
+// too, so the user cannot bypass the filter by adding commands.
+func (r *ApplicationBuilder) WithCommandsFilter(fn func() []string) foundation.ApplicationBuilder {
+	r.consoleCommandsFilter = fn
 
 	return r
 }

--- a/foundation/application_builder.go
+++ b/foundation/application_builder.go
@@ -26,7 +26,7 @@ type ApplicationBuilder struct {
 	commands                   func() []console.Command
 	config                     func()
 	configuredServiceProviders func() []foundation.ServiceProvider
-	consoleCommandsFilter      func() []string
+	commandsFilter      func() []string
 	eventToListeners           func() map[event.Event][]event.Listener
 	filters                    func() []validation.Filter
 	grpcClientCredentials      func() map[string]credentials.TransportCredentials
@@ -69,35 +69,22 @@ func (r *ApplicationBuilder) WithCommands(fn func() []console.Command) foundatio
 }
 
 // WithCommandsFilter registers a callback that returns the positive list of
-// command signatures to keep when the framework registers its own Artisan
-// commands. The callback runs once at Build() time; the user can call
-// facades.Config() inside it to read app.env or any other setting without
-// needing a parameter.
+// command signatures to keep when the framework registers Artisan commands.
+// The callback runs once at Build() time.
 //
-// Each entry in the returned slice is matched in one of two ways:
-//
-//   - Exact match (no wildcard) — checked against command.Signature().
-//   - Glob match (the entry contains '*') — checked against
-//     command.Signature() using stdpath.Match. '*' matches any sequence
-//     of non-'/' characters. '?' is not a wildcard.
-//
-// Category is never consulted. The filter is signature-only.
+// Matching is signature-only (category never consulted):
+//   - Entries without '*' are exact-matched against command.Signature().
+//   - Entries containing '*' use glob matching via path.Match against
+//     command.Signature() (only '*' triggers the glob path; '?' is matched
+//     literally as an exact match).
 //
 // Semantics:
-//
 //   - Method not called           → keep every command (default).
 //   - Callback returns nil        → keep every command (no filter).
-//   - Callback returns []string{} → drop every command (filter, no matches).
-//   - Callback returns entries    → keep only commands whose signature
-//     matches an entry (exact or glob).
-//
-// Composition with WithCommands:
-//
-// WithCommands adds extra commands to the framework's set; WithCommandsFilter
-// then trims the combined set. The filter applies to user-added commands
-// too, so the user cannot bypass the filter by adding commands.
+//   - Callback returns []string{} → drop every command.
+//   - Callback returns entries    → keep only commands matching an entry.
 func (r *ApplicationBuilder) WithCommandsFilter(fn func() []string) foundation.ApplicationBuilder {
-	r.consoleCommandsFilter = fn
+	r.commandsFilter = fn
 
 	return r
 }

--- a/foundation/application_builder_test.go
+++ b/foundation/application_builder_test.go
@@ -288,4 +288,29 @@ func (s *ApplicationBuilderTestSuite) TestWithCallback() {
 	s.True(called)
 }
 
+func (s *ApplicationBuilderTestSuite) TestWithCommandsFilter() {
+	called := false
+	fn := func() []string {
+		called = true
+		return []string{"up", "down"}
+	}
+
+	builder := s.builder.WithCommandsFilter(fn)
+
+	s.NotNil(builder)
+	s.NotNil(s.builder.consoleCommandsFilter)
+
+	// Verify the stored callback is the same one and can be invoked
+	got := s.builder.consoleCommandsFilter()
+	s.Equal([]string{"up", "down"}, got)
+	s.True(called)
+}
+
+func (s *ApplicationBuilderTestSuite) TestWithCommandsFilterNil() {
+	builder := s.builder.WithCommandsFilter(nil)
+
+	s.NotNil(builder)
+	s.Nil(s.builder.consoleCommandsFilter)
+}
+
 type mockStatsHandler struct{ stats.Handler }

--- a/foundation/application_builder_test.go
+++ b/foundation/application_builder_test.go
@@ -298,10 +298,10 @@ func (s *ApplicationBuilderTestSuite) TestWithCommandsFilter() {
 	builder := s.builder.WithCommandsFilter(fn)
 
 	s.NotNil(builder)
-	s.NotNil(s.builder.consoleCommandsFilter)
+	s.NotNil(s.builder.commandsFilter)
 
 	// Verify the stored callback is the same one and can be invoked
-	got := s.builder.consoleCommandsFilter()
+	got := s.builder.commandsFilter()
 	s.Equal([]string{"up", "down"}, got)
 	s.True(called)
 }
@@ -310,7 +310,7 @@ func (s *ApplicationBuilderTestSuite) TestWithCommandsFilterNil() {
 	builder := s.builder.WithCommandsFilter(nil)
 
 	s.NotNil(builder)
-	s.Nil(s.builder.consoleCommandsFilter)
+	s.Nil(s.builder.commandsFilter)
 }
 
 type mockStatsHandler struct{ stats.Handler }

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -171,7 +171,7 @@ func (s *ApplicationTestSuite) TestDefaultCommandsDoesNotRegisterMaintenanceComm
 	s.NotContains(commandSignatures(commands), "down")
 }
 
-func (s *ApplicationTestSuite) TestDefaultCommandsAppliesAllowlistFilter() {
+func (s *ApplicationTestSuite) TestCommandsAppliesAllowlistFilter() {
 	tests := []struct {
 		name     string
 		allow    []string
@@ -240,15 +240,24 @@ func (s *ApplicationTestSuite) TestDefaultCommandsAppliesAllowlistFilter() {
 			s.app.SetJson(foundationjson.New())
 			s.app.commandsFilter = tt.allow
 
-			commands := s.app.defaultCommands()
-			got := commandSignatures(commands)
+			mockArtisan := mocksconsole.NewArtisan(s.T())
+			mockArtisan.EXPECT().Register(mock.MatchedBy(func(cmds []console.Command) bool {
+				got := commandSignatures(cmds)
+				for _, expected := range tt.expected {
+					if !slices.Contains(got, expected) {
+						return false
+					}
+				}
+				for _, notExpected := range tt.notHave {
+					if slices.Contains(got, notExpected) {
+						return false
+					}
+				}
+				return true
+			})).Once()
+			s.app.Instance(binding.Artisan, mockArtisan)
 
-			for _, expected := range tt.expected {
-				s.Contains(got, expected)
-			}
-			for _, notExpected := range tt.notHave {
-				s.NotContains(got, notExpected)
-			}
+			s.app.Commands(s.app.defaultCommands())
 		})
 	}
 }

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -238,7 +238,7 @@ func (s *ApplicationTestSuite) TestDefaultCommandsAppliesAllowlistFilter() {
 		s.Run(tt.name, func() {
 			s.SetupTest()
 			s.app.SetJson(foundationjson.New())
-			s.app.consoleCommandsFilter = tt.allow
+			s.app.commandsFilter = tt.allow
 
 			commands := s.app.defaultCommands()
 			got := commandSignatures(commands)
@@ -251,19 +251,6 @@ func (s *ApplicationTestSuite) TestDefaultCommandsAppliesAllowlistFilter() {
 			}
 		})
 	}
-}
-
-func (s *ApplicationTestSuite) TestDefaultCommandsUpDownBySignature() {
-	s.app.SetJson(foundationjson.New())
-	s.app.Instance(binding.Route, mocksroute.NewRoute(s.T()))
-	s.app.consoleCommandsFilter = []string{"up", "down"}
-
-	commands := s.app.defaultCommands()
-	got := commandSignatures(commands)
-
-	s.Contains(got, "up")
-	s.Contains(got, "down")
-	s.NotContains(got, "about")
 }
 
 func (s *ApplicationTestSuite) TestConfigureCommandsAppliesFilter() {
@@ -292,11 +279,11 @@ func (s *ApplicationTestSuite) TestConfigureCommandsAppliesFilter() {
 	builder.commands = func() []console.Command {
 		return []console.Command{userCmdA, userCmdB, userCmdC}
 	}
-	builder.consoleCommandsFilter = func() []string {
+	builder.commandsFilter = func() []string {
 		return []string{"user:a", "user:c"}
 	}
 	s.app.builder = builder
-	s.app.consoleCommandsFilter = builder.consoleCommandsFilter()
+	s.app.commandsFilter = builder.commandsFilter()
 
 	s.app.configureCommands()
 }

--- a/foundation/application_test.go
+++ b/foundation/application_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -25,6 +27,7 @@ import (
 	"github.com/goravel/framework/contracts/validation"
 	foundationjson "github.com/goravel/framework/foundation/json"
 	mocksconfig "github.com/goravel/framework/mocks/config"
+	mocksconsole "github.com/goravel/framework/mocks/console"
 	mocksfoundation "github.com/goravel/framework/mocks/foundation"
 	mocksroute "github.com/goravel/framework/mocks/route"
 	"github.com/goravel/framework/support"
@@ -167,6 +170,143 @@ func (s *ApplicationTestSuite) TestDefaultCommandsDoesNotRegisterMaintenanceComm
 	s.NotContains(commandSignatures(commands), "up")
 	s.NotContains(commandSignatures(commands), "down")
 }
+
+func (s *ApplicationTestSuite) TestDefaultCommandsAppliesAllowlistFilter() {
+	tests := []struct {
+		name     string
+		allow    []string
+		expected []string
+		notHave  []string
+	}{
+		{
+			name:     "nil allowlist keeps all",
+			allow:    nil,
+			expected: []string{"about", "env:encrypt", "env:decrypt", "make:test", "make:package", "make:provider", "package:install", "package:uninstall", "vendor:publish"},
+			notHave:  nil,
+		},
+		{
+			name:     "empty allowlist drops all",
+			allow:    []string{},
+			expected: []string{},
+			notHave:  []string{"about", "env:encrypt", "make:test"},
+		},
+		{
+			name:     "exact signature",
+			allow:    []string{"env:encrypt"},
+			expected: []string{"env:encrypt"},
+			notHave:  []string{"env:decrypt", "about", "make:test"},
+		},
+		{
+			name:     "glob prefix",
+			allow:    []string{"env:*"},
+			expected: []string{"env:encrypt", "env:decrypt"},
+			notHave:  []string{"about", "make:test", "vendor:publish"},
+		},
+		{
+			name:     "glob prefix including bare",
+			allow:    []string{"make:*"},
+			expected: []string{"make:test", "make:package", "make:provider"},
+			notHave:  []string{"env:encrypt", "about"},
+		},
+		{
+			name:     "mixed exact and glob",
+			allow:    []string{"vendor:publish", "env:*"},
+			expected: []string{"env:encrypt", "env:decrypt", "vendor:publish"},
+			notHave:  []string{"about", "make:test"},
+		},
+		{
+			name:     "question mark is literal",
+			allow:    []string{"env:?ncrypt"},
+			expected: []string{},
+			notHave:  []string{"env:encrypt", "env:decrypt"},
+		},
+		{
+			name:     "whitespace only entries are ignored",
+			allow:    []string{"  ", ""},
+			expected: []string{},
+			notHave:  []string{"about", "env:encrypt"},
+		},
+		{
+			name:     "category is not matched",
+			allow:    []string{"make"},
+			expected: []string{},
+			notHave:  []string{"make:test", "make:package", "make:provider"},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.SetupTest()
+			s.app.SetJson(foundationjson.New())
+			s.app.consoleCommandsFilter = tt.allow
+
+			commands := s.app.defaultCommands()
+			got := commandSignatures(commands)
+
+			for _, expected := range tt.expected {
+				s.Contains(got, expected)
+			}
+			for _, notExpected := range tt.notHave {
+				s.NotContains(got, notExpected)
+			}
+		})
+	}
+}
+
+func (s *ApplicationTestSuite) TestDefaultCommandsUpDownBySignature() {
+	s.app.SetJson(foundationjson.New())
+	s.app.Instance(binding.Route, mocksroute.NewRoute(s.T()))
+	s.app.consoleCommandsFilter = []string{"up", "down"}
+
+	commands := s.app.defaultCommands()
+	got := commandSignatures(commands)
+
+	s.Contains(got, "up")
+	s.Contains(got, "down")
+	s.NotContains(got, "about")
+}
+
+func (s *ApplicationTestSuite) TestConfigureCommandsAppliesFilter() {
+	mockConfig := mocksconfig.NewConfig(s.T())
+	s.app.Instance(binding.Config, mockConfig)
+
+	userCmdA := &fakeCommand{signature: "user:a"}
+	userCmdB := &fakeCommand{signature: "user:b"}
+	userCmdC := &fakeCommand{signature: "user:c"}
+
+	mockArtisan := mocksconsole.NewArtisan(s.T())
+	// Only userCmdA and userCmdC survive the filter; the assertion verifies
+	// that userCmdB is dropped.
+	mockArtisan.EXPECT().Register(mock.MatchedBy(func(cmds []console.Command) bool {
+		sigs := make([]string, 0, len(cmds))
+		for _, c := range cmds {
+			sigs = append(sigs, c.Signature())
+		}
+		return slices.Contains(sigs, "user:a") &&
+			slices.Contains(sigs, "user:c") &&
+			!slices.Contains(sigs, "user:b")
+	})).Once()
+	s.app.Instance(binding.Artisan, mockArtisan)
+
+	builder := NewApplicationBuilder(s.app)
+	builder.commands = func() []console.Command {
+		return []console.Command{userCmdA, userCmdB, userCmdC}
+	}
+	builder.consoleCommandsFilter = func() []string {
+		return []string{"user:a", "user:c"}
+	}
+	s.app.builder = builder
+	s.app.consoleCommandsFilter = builder.consoleCommandsFilter()
+
+	s.app.configureCommands()
+}
+
+type fakeCommand struct {
+	console.Command
+	signature string
+}
+
+func (f *fakeCommand) Signature() string { return f.signature }
 
 func commandSignatures(commands []console.Command) []string {
 	signatures := make([]string, 0, len(commands))

--- a/mocks/foundation/Application.go
+++ b/mocks/foundation/Application.go
@@ -518,6 +518,53 @@ func (_c *Application_ConfigPath_Call) RunAndReturn(run func(...string) string) 
 	return _c
 }
 
+// ConsoleCommandsFilter provides a mock function with no fields
+func (_m *Application) ConsoleCommandsFilter() []string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConsoleCommandsFilter")
+	}
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	return r0
+}
+
+// Application_ConsoleCommandsFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConsoleCommandsFilter'
+type Application_ConsoleCommandsFilter_Call struct {
+	*mock.Call
+}
+
+// ConsoleCommandsFilter is a helper method to define mock.On call
+func (_e *Application_Expecter) ConsoleCommandsFilter() *Application_ConsoleCommandsFilter_Call {
+	return &Application_ConsoleCommandsFilter_Call{Call: _e.mock.On("ConsoleCommandsFilter")}
+}
+
+func (_c *Application_ConsoleCommandsFilter_Call) Run(run func()) *Application_ConsoleCommandsFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Application_ConsoleCommandsFilter_Call) Return(_a0 []string) *Application_ConsoleCommandsFilter_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Application_ConsoleCommandsFilter_Call) RunAndReturn(run func() []string) *Application_ConsoleCommandsFilter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Context provides a mock function with no fields
 func (_m *Application) Context() context.Context {
 	ret := _m.Called()

--- a/mocks/foundation/Application.go
+++ b/mocks/foundation/Application.go
@@ -459,6 +459,53 @@ func (_c *Application_Commands_Call) RunAndReturn(run func([]console.Command)) *
 	return _c
 }
 
+// CommandsFilter provides a mock function with no fields
+func (_m *Application) CommandsFilter() []string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CommandsFilter")
+	}
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	return r0
+}
+
+// Application_CommandsFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CommandsFilter'
+type Application_CommandsFilter_Call struct {
+	*mock.Call
+}
+
+// CommandsFilter is a helper method to define mock.On call
+func (_e *Application_Expecter) CommandsFilter() *Application_CommandsFilter_Call {
+	return &Application_CommandsFilter_Call{Call: _e.mock.On("CommandsFilter")}
+}
+
+func (_c *Application_CommandsFilter_Call) Run(run func()) *Application_CommandsFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Application_CommandsFilter_Call) Return(_a0 []string) *Application_CommandsFilter_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Application_CommandsFilter_Call) RunAndReturn(run func() []string) *Application_CommandsFilter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ConfigPath provides a mock function with given fields: path
 func (_m *Application) ConfigPath(path ...string) string {
 	_va := make([]interface{}, len(path))
@@ -514,53 +561,6 @@ func (_c *Application_ConfigPath_Call) Return(_a0 string) *Application_ConfigPat
 }
 
 func (_c *Application_ConfigPath_Call) RunAndReturn(run func(...string) string) *Application_ConfigPath_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ConsoleCommandsFilter provides a mock function with no fields
-func (_m *Application) ConsoleCommandsFilter() []string {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for ConsoleCommandsFilter")
-	}
-
-	var r0 []string
-	if rf, ok := ret.Get(0).(func() []string); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
-		}
-	}
-
-	return r0
-}
-
-// Application_ConsoleCommandsFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConsoleCommandsFilter'
-type Application_ConsoleCommandsFilter_Call struct {
-	*mock.Call
-}
-
-// ConsoleCommandsFilter is a helper method to define mock.On call
-func (_e *Application_Expecter) ConsoleCommandsFilter() *Application_ConsoleCommandsFilter_Call {
-	return &Application_ConsoleCommandsFilter_Call{Call: _e.mock.On("ConsoleCommandsFilter")}
-}
-
-func (_c *Application_ConsoleCommandsFilter_Call) Run(run func()) *Application_ConsoleCommandsFilter_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *Application_ConsoleCommandsFilter_Call) Return(_a0 []string) *Application_ConsoleCommandsFilter_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Application_ConsoleCommandsFilter_Call) RunAndReturn(run func() []string) *Application_ConsoleCommandsFilter_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/foundation/ApplicationBuilder.go
+++ b/mocks/foundation/ApplicationBuilder.go
@@ -185,6 +185,54 @@ func (_c *ApplicationBuilder_WithCommands_Call) RunAndReturn(run func(func() []c
 	return _c
 }
 
+// WithCommandsFilter provides a mock function with given fields: _a0
+func (_m *ApplicationBuilder) WithCommandsFilter(_a0 func() []string) foundation.ApplicationBuilder {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithCommandsFilter")
+	}
+
+	var r0 foundation.ApplicationBuilder
+	if rf, ok := ret.Get(0).(func(func() []string) foundation.ApplicationBuilder); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(foundation.ApplicationBuilder)
+		}
+	}
+
+	return r0
+}
+
+// ApplicationBuilder_WithCommandsFilter_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithCommandsFilter'
+type ApplicationBuilder_WithCommandsFilter_Call struct {
+	*mock.Call
+}
+
+// WithCommandsFilter is a helper method to define mock.On call
+//   - _a0 func() []string
+func (_e *ApplicationBuilder_Expecter) WithCommandsFilter(_a0 interface{}) *ApplicationBuilder_WithCommandsFilter_Call {
+	return &ApplicationBuilder_WithCommandsFilter_Call{Call: _e.mock.On("WithCommandsFilter", _a0)}
+}
+
+func (_c *ApplicationBuilder_WithCommandsFilter_Call) Run(run func(_a0 func() []string)) *ApplicationBuilder_WithCommandsFilter_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(func() []string))
+	})
+	return _c
+}
+
+func (_c *ApplicationBuilder_WithCommandsFilter_Call) Return(_a0 foundation.ApplicationBuilder) *ApplicationBuilder_WithCommandsFilter_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *ApplicationBuilder_WithCommandsFilter_Call) RunAndReturn(run func(func() []string) foundation.ApplicationBuilder) *ApplicationBuilder_WithCommandsFilter_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // WithConfig provides a mock function with given fields: _a0
 func (_m *ApplicationBuilder) WithConfig(_a0 func()) foundation.ApplicationBuilder {
 	ret := _m.Called(_a0)


### PR DESCRIPTION
## Why

Closes goravel/goravel#959. The framework currently registers every Artisan dev command (about, env:*, package:*, vendor:publish, make:*, etc.) on every binary, including production server-only builds. There was no supported way to scope this down — `./app --help` in production revealed dev commands, and the surface was always the same regardless of environment.

## What

Introduces a new `WithCommandsFilter(func() []string)` builder method on `ApplicationBuilder`. The callback runs once at `Build()` time and returns the **positive list** of command signatures to keep. The list is captured on the `Application` and applied uniformly to both the framework's `defaultCommands` batch (`foundation/application.go:defaultCommands`) and the `console/console/*` batch registered by `console.ServiceProvider.Boot`.

Matching rules (signature-only — category is never consulted):
- exact match (no wildcard) — checked against `command.Signature()`
- glob match (entry contains `*`) — checked against `command.Signature()` via `path.Match` (`*` matches any sequence of non-`/` characters, `?` is a literal character)

Semantics:
| Callback returns | Result |
| --- | --- |
| method not called | keep every command (default — no migration) |
| `nil` | keep every command (no filter applied) |
| `[]string{}` | drop every command |
| entries | keep only commands whose signature matches |

The filter also trims the user-added commands registered via `WithCommands(...)`, so the user cannot bypass the filter by adding commands. The implementation of `add first, then filter` lives in two places — `foundation/application.go:configureCommands` filters user-added commands, and `console.ServiceProvider.Boot` filters its own batch.

## User-facing API

```go
return foundation.Setup().
    WithCommandsFilter(func() []string {
        if facades.Config().GetString("app.env") == "production" {
            return []string{
                "up", "down", "key:generate", "about",
                "env:*",     // glob
                "make*",     // glob (matches make, make:controller, make:test, ...)
                "package:*", // glob
                "vendor:publish",
            }
        }
        return nil // dev/staging: keep everything
    }).
    // ...
```

The user can also drive the list from build tags or `ldflags` instead of `facades.Config()` — the framework doesn't care, it just consumes the returned slice.

## Files

- `console/application.go` — new `FilterCommandsByAllowlist` helper (signature-only, `*`-only glob)
- `console/service_provider.go` — apply filter to the `console/console/*` batch via the new `Application.ConsoleCommandsFilter()` getter
- `foundation/application.go` — new `consoleCommandsFilter` field, `Build()` capture, `defaultCommands` and `configureCommands` apply the filter
- `foundation/application_builder.go` — new `WithCommandsFilter` method
- `contracts/foundation/application.go` + `application_builder.go` — interface extensions
- `mocks/foundation/Application.go` + `ApplicationBuilder.go` — regenerated via `go tool mockery`
- Tests added in `console/application_test.go`, `console/service_provider_test.go` (new), `foundation/application_test.go`, `foundation/application_builder_test.go`

## Breaking changes

None. Default behavior is unchanged for every existing app — `WithCommandsFilter` is opt-in.

## Test plan

- `go build ./...` — clean
- `go test ./...` — all pass (foundation, console, console/console, plus every downstream package that uses mocks/foundation)
- `go vet ./...` — clean
- New tests cover: nil/empty/exact/glob/mixed/question-mark-literal/whitespace-only/category-not-matched/`up`-`down`-by-signature, the "add first, then filter" composition between `WithCommands` and `WithCommandsFilter`, and the `nil`/`[]string{}`/entries distinction on both registration paths.