### PR TITLE
fix: SIGSEGV on artisan migrate when database connection is unavailable

### DIFF
--- a/database/console/model_make_command.go
+++ b/database/console/model_make_command.go
@@ -72,6 +72,11 @@ func (r *ModelMakeCommand) Extend() command.Extend {
 }
 
 func (r *ModelMakeCommand) Handle(ctx console.Context) error {
+	if orm := r.schema.Orm(); orm == nil || orm.Query() == nil {
+		ctx.Error(errors.SchemaOrmNotAvailable.Error())
+		return nil
+	}
+
 	m, err := supportconsole.NewMake(ctx, "model", ctx.Argument(0), support.Config.Paths.Models)
 	if err != nil {
 		ctx.Error(err.Error())

--- a/database/console/model_make_command.go
+++ b/database/console/model_make_command.go
@@ -72,8 +72,7 @@ func (r *ModelMakeCommand) Extend() command.Extend {
 }
 
 func (r *ModelMakeCommand) Handle(ctx console.Context) error {
-	if orm := r.schema.Orm(); orm == nil || orm.Query() == nil {
-		ctx.Error(errors.SchemaOrmNotAvailable.Error())
+	if !requireSchemaOrm(ctx, r.schema) {
 		return nil
 	}
 

--- a/database/console/model_make_command_test.go
+++ b/database/console/model_make_command_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/goravel/framework/contracts/database/driver"
 	"github.com/goravel/framework/contracts/database/schema"
 	mocksconsole "github.com/goravel/framework/mocks/console"
+	mocksorm "github.com/goravel/framework/mocks/database/orm"
 	mocksschema "github.com/goravel/framework/mocks/database/schema"
 	"github.com/goravel/framework/support/file"
 )
@@ -18,11 +19,15 @@ import (
 func TestModelMakeCommand(t *testing.T) {
 	mockSchema := mocksschema.NewSchema(t)
 	mockArtisan := mocksconsole.NewArtisan(t)
+	mockOrm := mocksorm.NewOrm(t)
+	mockQuery := mocksorm.NewQuery(t)
 
 	modelMakeCommand := NewModelMakeCommand(mockArtisan, mockSchema)
 	mockContext := mocksconsole.NewContext(t)
 
 	// Test: Empty model name
+	mockSchema.EXPECT().Orm().Return(mockOrm).Maybe()
+	mockOrm.EXPECT().Query().Return(mockQuery).Maybe()
 	mockContext.EXPECT().Argument(0).Return("").Once()
 	mockContext.EXPECT().Ask("Enter the model name", mock.Anything).Return("", errors.New("the model name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the model name cannot be empty").Once()
@@ -30,6 +35,8 @@ func TestModelMakeCommand(t *testing.T) {
 	assert.False(t, file.Exists("app/models/user.go"))
 
 	// Test: Create model successfully
+	mockSchema.EXPECT().Orm().Return(mockOrm).Maybe()
+	mockOrm.EXPECT().Query().Return(mockQuery).Maybe()
 	mockContext.EXPECT().Argument(0).Return("User").Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Option("table").Return("").Once()
@@ -53,12 +60,16 @@ type User struct {
 	assert.Equal(t, expectedUserContent, userModel)
 
 	// Test: Model already exists
+	mockSchema.EXPECT().Orm().Return(mockOrm).Maybe()
+	mockOrm.EXPECT().Query().Return(mockQuery).Maybe()
 	mockContext.EXPECT().Argument(0).Return("User").Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the model already exists. Use the --force or -f flag to overwrite").Once()
 	assert.Nil(t, modelMakeCommand.Handle(mockContext))
 
 	// Test: Create model in subdirectory
+	mockSchema.EXPECT().Orm().Return(mockOrm).Maybe()
+	mockOrm.EXPECT().Query().Return(mockQuery).Maybe()
 	mockContext.EXPECT().Argument(0).Return("User/Phone").Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Option("table").Return("").Once()
@@ -84,6 +95,8 @@ type Phone struct {
 	assert.Equal(t, expectedPhoneContent, phoneModel)
 
 	// Test: Create model from table schema
+	mockSchema.EXPECT().Orm().Return(mockOrm).Maybe()
+	mockOrm.EXPECT().Query().Return(mockQuery).Maybe()
 	mockContext.EXPECT().Argument(0).Return("Product").Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Option("table").Return("products").Once()
@@ -140,6 +153,8 @@ func (r *Product) TableName() string {
 	assert.Equal(t, expectedContent, model)
 
 	// Test: Table doesn't exist
+	mockSchema.EXPECT().Orm().Return(mockOrm).Maybe()
+	mockOrm.EXPECT().Query().Return(mockQuery).Maybe()
 	mockContext.EXPECT().Argument(0).Return("Invalid").Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Option("table").Return("nonexistent").Once()
@@ -148,6 +163,8 @@ func (r *Product) TableName() string {
 	assert.Nil(t, modelMakeCommand.Handle(mockContext))
 
 	//Test: Error fetching columns
+	mockSchema.EXPECT().Orm().Return(mockOrm).Maybe()
+	mockOrm.EXPECT().Query().Return(mockQuery).Maybe()
 	mockContext.EXPECT().Argument(0).Return("Error").Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Option("table").Return("error_table").Once()

--- a/database/console/show_command.go
+++ b/database/console/show_command.go
@@ -10,7 +10,6 @@ import (
 	"github.com/goravel/framework/contracts/console/command"
 	"github.com/goravel/framework/contracts/database/driver"
 	"github.com/goravel/framework/contracts/database/schema"
-	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support/str"
 )
 
@@ -70,8 +69,7 @@ func (r *ShowCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *ShowCommand) Handle(ctx console.Context) error {
-	if orm := r.schema.Orm(); orm == nil || orm.Query() == nil {
-		ctx.Error(errors.SchemaOrmNotAvailable.Error())
+	if !requireSchemaOrm(ctx, r.schema) {
 		return nil
 	}
 

--- a/database/console/show_command.go
+++ b/database/console/show_command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/goravel/framework/contracts/console/command"
 	"github.com/goravel/framework/contracts/database/driver"
 	"github.com/goravel/framework/contracts/database/schema"
+	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support/str"
 )
 
@@ -69,6 +70,11 @@ func (r *ShowCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *ShowCommand) Handle(ctx console.Context) error {
+	if orm := r.schema.Orm(); orm == nil || orm.Query() == nil {
+		ctx.Error(errors.SchemaOrmNotAvailable.Error())
+		return nil
+	}
+
 	if got := ctx.Argument(0); len(got) > 0 {
 		ctx.Error(fmt.Sprintf("No arguments expected for '%s' command, got '%s'.", r.Signature(), got))
 		return nil

--- a/database/console/show_command_test.go
+++ b/database/console/show_command_test.go
@@ -51,6 +51,8 @@ func TestShowCommand(t *testing.T) {
 		{
 			name: "invalid argument",
 			setup: func() {
+				mockSchema.EXPECT().Orm().Return(mockOrm).Once()
+				mockOrm.EXPECT().Query().Return(mockQuery).Once()
 				mockContext.EXPECT().Argument(0).Return("test").Once()
 				mockContext.EXPECT().Error("No arguments expected for 'db:show' command, got 'test'.").Once()
 			},
@@ -58,6 +60,8 @@ func TestShowCommand(t *testing.T) {
 		{
 			name: "get tables failed",
 			setup: func() {
+				mockSchema.EXPECT().Orm().Return(mockOrm).Once()
+				mockOrm.EXPECT().Query().Return(mockQuery).Once()
 				// Handle
 				mockContext.EXPECT().Argument(0).Return("").Once()
 				mockContext.EXPECT().Option("database").Return("test").Once()
@@ -83,6 +87,8 @@ func TestShowCommand(t *testing.T) {
 		{
 			name: "get views failed",
 			setup: func() {
+				mockSchema.EXPECT().Orm().Return(mockOrm).Once()
+				mockOrm.EXPECT().Query().Return(mockQuery).Once()
 				mockContext.EXPECT().Argument(0).Return("").Once()
 				mockContext.EXPECT().Option("database").Return("test").Once()
 				mockSchema.EXPECT().Connection("test").Return(mockSchema).Once()
@@ -109,6 +115,8 @@ func TestShowCommand(t *testing.T) {
 		{
 			name: "success",
 			setup: func() {
+				mockSchema.EXPECT().Orm().Return(mockOrm).Once()
+				mockOrm.EXPECT().Query().Return(mockQuery).Once()
 				mockContext.EXPECT().Argument(0).Return("").Once()
 				mockContext.EXPECT().Option("database").Return("test").Once()
 				mockSchema.EXPECT().Connection("test").Return(mockSchema).Once()

--- a/database/console/table_command.go
+++ b/database/console/table_command.go
@@ -9,7 +9,6 @@ import (
 	"github.com/goravel/framework/contracts/console/command"
 	"github.com/goravel/framework/contracts/database/driver"
 	"github.com/goravel/framework/contracts/database/schema"
-	"github.com/goravel/framework/errors"
 )
 
 type TableCommand struct {
@@ -51,8 +50,7 @@ func (r *TableCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *TableCommand) Handle(ctx console.Context) error {
-	if orm := r.schema.Orm(); orm == nil || orm.Query() == nil {
-		ctx.Error(errors.SchemaOrmNotAvailable.Error())
+	if !requireSchemaOrm(ctx, r.schema) {
 		return nil
 	}
 

--- a/database/console/table_command.go
+++ b/database/console/table_command.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goravel/framework/contracts/console/command"
 	"github.com/goravel/framework/contracts/database/driver"
 	"github.com/goravel/framework/contracts/database/schema"
+	"github.com/goravel/framework/errors"
 )
 
 type TableCommand struct {
@@ -50,6 +51,11 @@ func (r *TableCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *TableCommand) Handle(ctx console.Context) error {
+	if orm := r.schema.Orm(); orm == nil || orm.Query() == nil {
+		ctx.Error(errors.SchemaOrmNotAvailable.Error())
+		return nil
+	}
+
 	ctx.NewLine()
 	r.schema = r.schema.Connection(ctx.Option("database"))
 	table := ctx.Argument(0)

--- a/database/console/table_command_test.go
+++ b/database/console/table_command_test.go
@@ -28,8 +28,8 @@ func TestTableCommand(t *testing.T) {
 		mockSchema = mocksschema.NewSchema(t)
 		mockOrm = mocksorm.NewOrm(t)
 		mockQuery = mocksorm.NewQuery(t)
-		mockSchema.EXPECT().Orm().Return(mockOrm).Maybe()
-		mockOrm.EXPECT().Query().Return(mockQuery).Maybe()
+		mockSchema.EXPECT().Orm().Return(mockOrm).Once()
+		mockOrm.EXPECT().Query().Return(mockQuery).Once()
 	}
 	successCaseExpected := [][2]string{
 		{"<fg=green;op=bold>public.test</>", "<fg=gray>test_comment</>"},

--- a/database/console/table_command_test.go
+++ b/database/console/table_command_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/goravel/framework/contracts/database/driver"
 	mocksconfig "github.com/goravel/framework/mocks/config"
 	mocksconsole "github.com/goravel/framework/mocks/console"
+	mocksorm "github.com/goravel/framework/mocks/database/orm"
 	mocksschema "github.com/goravel/framework/mocks/database/schema"
 )
 
@@ -18,11 +19,17 @@ func TestTableCommand(t *testing.T) {
 		mockContext *mocksconsole.Context
 		mockConfig  *mocksconfig.Config
 		mockSchema  *mocksschema.Schema
+		mockOrm     *mocksorm.Orm
+		mockQuery   *mocksorm.Query
 	)
 	beforeEach := func() {
 		mockContext = mocksconsole.NewContext(t)
 		mockConfig = mocksconfig.NewConfig(t)
 		mockSchema = mocksschema.NewSchema(t)
+		mockOrm = mocksorm.NewOrm(t)
+		mockQuery = mocksorm.NewQuery(t)
+		mockSchema.EXPECT().Orm().Return(mockOrm).Maybe()
+		mockOrm.EXPECT().Query().Return(mockQuery).Maybe()
 	}
 	successCaseExpected := [][2]string{
 		{"<fg=green;op=bold>public.test</>", "<fg=gray>test_comment</>"},

--- a/database/console/utils.go
+++ b/database/console/utils.go
@@ -1,0 +1,16 @@
+package console
+
+import (
+	"github.com/goravel/framework/contracts/console"
+	"github.com/goravel/framework/contracts/database/schema"
+	"github.com/goravel/framework/errors"
+)
+
+func requireSchemaOrm(ctx console.Context, s schema.Schema) bool {
+	if orm := s.Orm(); orm == nil || orm.Query() == nil {
+		ctx.Error(errors.SchemaOrmNotAvailable.Error())
+		return false
+	}
+
+	return true
+}

--- a/database/console/wipe_command.go
+++ b/database/console/wipe_command.go
@@ -62,6 +62,11 @@ func (r *WipeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *WipeCommand) Handle(ctx console.Context) error {
+	if orm := r.schema.Orm(); orm == nil || orm.Query() == nil {
+		ctx.Error(errors.SchemaOrmNotAvailable.Error())
+		return nil
+	}
+
 	if !supportconsole.ConfirmToProceed(ctx, r.config.GetString("app.env")) {
 		ctx.Warning(errors.ConsoleRunInProduction.Error())
 		return nil

--- a/database/console/wipe_command.go
+++ b/database/console/wipe_command.go
@@ -62,8 +62,7 @@ func (r *WipeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *WipeCommand) Handle(ctx console.Context) error {
-	if orm := r.schema.Orm(); orm == nil || orm.Query() == nil {
-		ctx.Error(errors.SchemaOrmNotAvailable.Error())
+	if !requireSchemaOrm(ctx, r.schema) {
 		return nil
 	}
 

--- a/database/console/wipe_command_test.go
+++ b/database/console/wipe_command_test.go
@@ -27,8 +27,8 @@ func TestWipeCommand(t *testing.T) {
 		mockSchema = mocksschema.NewSchema(t)
 		mockOrm = mocksorm.NewOrm(t)
 		mockQuery = mocksorm.NewQuery(t)
-		mockSchema.EXPECT().Orm().Return(mockOrm).Maybe()
-		mockOrm.EXPECT().Query().Return(mockQuery).Maybe()
+		mockSchema.EXPECT().Orm().Return(mockOrm).Once()
+		mockOrm.EXPECT().Query().Return(mockQuery).Once()
 	}
 
 	tests := []struct {

--- a/database/console/wipe_command_test.go
+++ b/database/console/wipe_command_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/goravel/framework/errors"
 	mocksconfig "github.com/goravel/framework/mocks/config"
 	mocksconsole "github.com/goravel/framework/mocks/console"
+	mocksorm "github.com/goravel/framework/mocks/database/orm"
 	mocksschema "github.com/goravel/framework/mocks/database/schema"
 )
 
@@ -16,12 +17,18 @@ func TestWipeCommand(t *testing.T) {
 		mockContext *mocksconsole.Context
 		mockConfig  *mocksconfig.Config
 		mockSchema  *mocksschema.Schema
+		mockOrm     *mocksorm.Orm
+		mockQuery   *mocksorm.Query
 	)
 
 	beforeEach := func() {
 		mockContext = mocksconsole.NewContext(t)
 		mockConfig = mocksconfig.NewConfig(t)
 		mockSchema = mocksschema.NewSchema(t)
+		mockOrm = mocksorm.NewOrm(t)
+		mockQuery = mocksorm.NewQuery(t)
+		mockSchema.EXPECT().Orm().Return(mockOrm).Maybe()
+		mockOrm.EXPECT().Query().Return(mockQuery).Maybe()
 	}
 
 	tests := []struct {

--- a/database/migration/migrator.go
+++ b/database/migration/migrator.go
@@ -36,7 +36,6 @@ func NewMigrator(artisan console.Artisan, schema contractsschema.Schema, table s
 func (r *Migrator) requireOrm() error {
 	orm := r.schema.Orm()
 	if orm == nil || orm.Query() == nil {
-		color.Warningln(errors.SchemaOrmNotAvailable.Error())
 		return errors.SchemaOrmNotAvailable
 	}
 

--- a/database/migration/migrator.go
+++ b/database/migration/migrator.go
@@ -33,6 +33,16 @@ func NewMigrator(artisan console.Artisan, schema contractsschema.Schema, table s
 	}
 }
 
+func (r *Migrator) requireOrm() error {
+	orm := r.schema.Orm()
+	if orm == nil || orm.Query() == nil {
+		color.Warningln(errors.SchemaOrmNotAvailable.Error())
+		return errors.SchemaOrmNotAvailable
+	}
+
+	return nil
+}
+
 func (r *Migrator) Create(name string, modelName string) (string, error) {
 	table, create := TableGuesser{}.Guess(name)
 
@@ -82,6 +92,10 @@ func (r *Migrator) Create(name string, modelName string) (string, error) {
 }
 
 func (r *Migrator) Fresh() error {
+	if err := r.requireOrm(); err != nil {
+		return err
+	}
+
 	if err := r.artisan.Call("db:wipe --force"); err != nil {
 		return err
 	}
@@ -93,6 +107,10 @@ func (r *Migrator) Fresh() error {
 }
 
 func (r *Migrator) Reset() error {
+	if err := r.requireOrm(); err != nil {
+		return err
+	}
+
 	if !r.repository.RepositoryExists() {
 		color.Warningln("Migration table not found")
 
@@ -108,6 +126,10 @@ func (r *Migrator) Reset() error {
 }
 
 func (r *Migrator) Rollback(step, batch int) error {
+	if err := r.requireOrm(); err != nil {
+		return err
+	}
+
 	if !r.repository.RepositoryExists() {
 		color.Warningln("Migration table not found")
 
@@ -145,6 +167,10 @@ func (r *Migrator) Rollback(step, batch int) error {
 }
 
 func (r *Migrator) Run() error {
+	if err := r.requireOrm(); err != nil {
+		return err
+	}
+
 	if err := r.prepareDatabase(); err != nil {
 		return err
 	}
@@ -160,6 +186,10 @@ func (r *Migrator) Run() error {
 }
 
 func (r *Migrator) Status() ([]contractsmigration.Status, error) {
+	if err := r.requireOrm(); err != nil {
+		return nil, err
+	}
+
 	if !r.repository.RepositoryExists() {
 		color.Warningln("Migration table not found")
 

--- a/database/migration/migrator_test.go
+++ b/database/migration/migrator_test.go
@@ -101,17 +101,29 @@ func (s *MigratorSuite) TestCreate() {
 
 func (s *MigratorSuite) TestFresh() {
 	// Success
+	mockOrm := mocksorm.NewOrm(s.T())
+	mockQuery := mocksorm.NewQuery(s.T())
+	s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+	mockOrm.On("Query").Return(mockQuery).Maybe()
 	s.mockArtisan.EXPECT().Call("db:wipe --force").Return(nil).Once()
 	s.mockArtisan.EXPECT().Call("migrate").Return(nil).Once()
 
 	s.NoError(s.migrator.Fresh())
 
 	// db:wipe returns error
+	mockOrm = mocksorm.NewOrm(s.T())
+	mockQuery = mocksorm.NewQuery(s.T())
+	s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+	mockOrm.On("Query").Return(mockQuery).Maybe()
 	s.mockArtisan.EXPECT().Call("db:wipe --force").Return(assert.AnError).Once()
 
 	s.EqualError(s.migrator.Fresh(), assert.AnError.Error())
 
 	// migrate returns error
+	mockOrm = mocksorm.NewOrm(s.T())
+	mockQuery = mocksorm.NewQuery(s.T())
+	s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+	mockOrm.On("Query").Return(mockQuery).Maybe()
 	s.mockArtisan.EXPECT().Call("db:wipe --force").Return(nil).Once()
 	s.mockArtisan.EXPECT().Call("migrate").Return(assert.AnError).Once()
 
@@ -244,12 +256,20 @@ func (s *MigratorSuite) TestReset() {
 		{
 			name: "Get ran failed",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				s.mockRepository.EXPECT().RepositoryExists().Return(false).Once()
 			},
 		},
 		{
 			name: "failed to get ran",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetRan().Return(nil, assert.AnError).Once()
 			},
@@ -270,7 +290,7 @@ func (s *MigratorSuite) TestReset() {
 				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return([]migration.File{{Migration: testMigration.Signature()}}, nil).Once()
 
 				mockOrm := mocksorm.NewOrm(s.T())
-				s.mockRunDown(mockOrm, previousConnection, testMigration.Signature(), "users", nil)
+				s.mockRunDown(mockOrm, previousConnection, testMigration.Signature(), "users", nil, 2)
 			},
 		},
 	}
@@ -299,6 +319,10 @@ func (s *MigratorSuite) TestRollback() {
 		{
 			name: "happy path - no files",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return(nil, nil).Once()
 			},
@@ -317,12 +341,16 @@ func (s *MigratorSuite) TestRollback() {
 				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return([]migration.File{{Migration: testMigration.Signature()}}, nil).Once()
 
 				mockOrm := mocksorm.NewOrm(s.T())
-				s.mockRunDown(mockOrm, previousConnection, testMigration.Signature(), "users", nil)
+				s.mockRunDown(mockOrm, previousConnection, testMigration.Signature(), "users", nil, 1)
 			},
 		},
 		{
 			name: "happy path - missing migration",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return([]migration.File{{Migration: "20240817214502_create_users_table"}}, nil).Once()
 			},
@@ -341,13 +369,17 @@ func (s *MigratorSuite) TestRollback() {
 				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return([]migration.File{{Migration: testMigration.Signature()}}, nil).Once()
 
 				mockOrm := mocksorm.NewOrm(s.T())
-				s.mockRunDown(mockOrm, previousConnection, testMigration.Signature(), "users", assert.AnError)
+				s.mockRunDown(mockOrm, previousConnection, testMigration.Signature(), "users", assert.AnError, 1)
 			},
 			expectErr: assert.AnError.Error(),
 		},
 		{
 			name: "failed to get migrations by step",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return(nil, assert.AnError).Once()
 			},
@@ -356,6 +388,10 @@ func (s *MigratorSuite) TestRollback() {
 		{
 			name: "repository doesn't exist",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				s.mockRepository.EXPECT().RepositoryExists().Return(false).Once()
 			},
 		},
@@ -399,7 +435,7 @@ func (s *MigratorSuite) TestRun() {
 				}).Once()
 
 				mockOrm := mocksorm.NewOrm(s.T())
-				s.mockRunUp(mockOrm, previousConnection, testMigration.Signature(), "users", 1, nil)
+				s.mockRunUp(mockOrm, previousConnection, testMigration.Signature(), "users", 1, nil, 1)
 			},
 		},
 		{
@@ -416,13 +452,17 @@ func (s *MigratorSuite) TestRun() {
 				s.mockRepository.EXPECT().GetNextBatchNumber().Return(1, nil).Once()
 
 				mockOrm := mocksorm.NewOrm(s.T())
-				s.mockRunUp(mockOrm, previousConnection, testMigration.Signature(), "users", 1, assert.AnError)
+				s.mockRunUp(mockOrm, previousConnection, testMigration.Signature(), "users", 1, assert.AnError, 1)
 			},
 			expectError: assert.AnError.Error(),
 		},
 		{
 			name: "Sad path - GetNextBatchNumber returns error",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetRan().Return([]string{testConnectionMigration.Signature()}, nil).Once()
 				s.mockSchema.EXPECT().Migrations().Return([]contractsschema.Migration{
@@ -436,6 +476,10 @@ func (s *MigratorSuite) TestRun() {
 		{
 			name: "Sad path - GetRan returns error",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetRan().Return(nil, assert.AnError).Once()
 			},
@@ -481,14 +525,14 @@ func (s *MigratorSuite) TestRunDown() {
 			name:      "Happy path",
 			migration: testMigration,
 			setup: func() {
-				s.mockRunDown(mockOrm, previousConnection, testMigration.Signature(), "users", nil)
+				s.mockRunDown(mockOrm, previousConnection, testMigration.Signature(), "users", nil, 0)
 			},
 		},
 		{
 			name:      "Happy path - with connection",
 			migration: testConnectionMigration,
 			setup: func() {
-				s.mockRunDown(mockOrm, previousConnection, testConnectionMigration.Signature(), "agents", nil)
+				s.mockRunDown(mockOrm, previousConnection, testConnectionMigration.Signature(), "agents", nil, 0)
 			},
 		},
 		{
@@ -548,7 +592,7 @@ func (s *MigratorSuite) TestRunPending() {
 				mockOrm := mocksorm.NewOrm(s.T())
 
 				s.mockRepository.EXPECT().GetNextBatchNumber().Return(1, nil).Once()
-				s.mockRunUp(mockOrm, previousConnection, testMigration.Signature(), "users", 1, nil)
+				s.mockRunUp(mockOrm, previousConnection, testMigration.Signature(), "users", 1, nil, 0)
 			},
 		},
 		{
@@ -576,7 +620,7 @@ func (s *MigratorSuite) TestRunPending() {
 				mockOrm := mocksorm.NewOrm(s.T())
 
 				s.mockRepository.EXPECT().GetNextBatchNumber().Return(1, nil).Once()
-				s.mockRunUp(mockOrm, previousConnection, testMigration.Signature(), "users", 1, assert.AnError)
+				s.mockRunUp(mockOrm, previousConnection, testMigration.Signature(), "users", 1, assert.AnError, 0)
 			},
 			expectError: assert.AnError.Error(),
 		},
@@ -621,14 +665,14 @@ func (s *MigratorSuite) TestRunUp() {
 			name:      "Happy path",
 			migration: testMigration,
 			setup: func() {
-				s.mockRunUp(mockOrm, previousConnection, testMigration.Signature(), "users", batch, nil)
+				s.mockRunUp(mockOrm, previousConnection, testMigration.Signature(), "users", batch, nil, 0)
 			},
 		},
 		{
 			name:      "Happy path - with connection",
 			migration: testConnectionMigration,
 			setup: func() {
-				s.mockRunUp(mockOrm, previousConnection, testConnectionMigration.Signature(), "agents", batch, nil)
+				s.mockRunUp(mockOrm, previousConnection, testConnectionMigration.Signature(), "agents", batch, nil, 0)
 			},
 		},
 		{
@@ -679,6 +723,10 @@ func (s *MigratorSuite) TestStatus() {
 		{
 			name: "The migration table doesn't exist",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				s.mockRepository.EXPECT().RepositoryExists().Return(false).Once()
 			},
 			assert: func() {
@@ -692,6 +740,10 @@ func (s *MigratorSuite) TestStatus() {
 		{
 			name: "Get migration batches failed",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetMigrations().Return(nil, assert.AnError).Once()
 			},
@@ -704,6 +756,10 @@ func (s *MigratorSuite) TestStatus() {
 		{
 			name: "No migrations found",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockSchema.EXPECT().Migrations().Return(nil).Once()
 				s.mockRepository.EXPECT().GetMigrations().Return(nil, nil).Once()
@@ -719,6 +775,10 @@ func (s *MigratorSuite) TestStatus() {
 		{
 			name: "Success",
 			setup: func() {
+				mockOrm := mocksorm.NewOrm(s.T())
+				mockQuery := mocksorm.NewQuery(s.T())
+				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
+				mockOrm.On("Query").Return(mockQuery).Maybe()
 				testMigration := NewTestMigration(s.mockSchema)
 				testConnectionMigration := NewTestConnectionMigration(s.mockSchema)
 
@@ -762,12 +822,13 @@ func (s *MigratorSuite) mockRunDown(
 	mockOrm *mocksorm.Orm,
 	previousConnection, migrationSignature, table string,
 	err error,
+	extraOrmCalls int,
 ) {
 	s.mockSchema.EXPECT().GetConnection().Return(previousConnection).Once()
-	s.mockSchema.EXPECT().Orm().Return(mockOrm).Times(5)
+	s.mockSchema.EXPECT().Orm().Return(mockOrm).Times(5 + extraOrmCalls)
 
 	mockQuery := mocksorm.NewQuery(s.T())
-	mockOrm.EXPECT().Query().Return(mockQuery).Once()
+	mockOrm.EXPECT().Query().Return(mockQuery).Times(1 + extraOrmCalls)
 
 	testConnectionMigration := &TestConnectionMigration{}
 	if testConnectionMigration.Signature() == migrationSignature {
@@ -790,12 +851,13 @@ func (s *MigratorSuite) mockRunUp(
 	previousConnection, migrationSignature, table string,
 	batch int,
 	err error,
+	extraOrmCalls int,
 ) {
 	s.mockSchema.EXPECT().GetConnection().Return(previousConnection).Once()
-	s.mockSchema.EXPECT().Orm().Return(mockOrm).Times(5)
+	s.mockSchema.EXPECT().Orm().Return(mockOrm).Times(5 + extraOrmCalls)
 
 	mockQuery := mocksorm.NewQuery(s.T())
-	mockOrm.EXPECT().Query().Return(mockQuery).Once()
+	mockOrm.EXPECT().Query().Return(mockQuery).Times(1 + extraOrmCalls)
 
 	testConnectionMigration := &TestConnectionMigration{}
 	if testConnectionMigration.Signature() == migrationSignature {

--- a/database/migration/migrator_test.go
+++ b/database/migration/migrator_test.go
@@ -103,8 +103,8 @@ func (s *MigratorSuite) TestFresh() {
 	// Success
 	mockOrm := mocksorm.NewOrm(s.T())
 	mockQuery := mocksorm.NewQuery(s.T())
-	s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-	mockOrm.On("Query").Return(mockQuery).Maybe()
+	s.mockSchema.On("Orm").Return(mockOrm).Once()
+	mockOrm.On("Query").Return(mockQuery).Once()
 	s.mockArtisan.EXPECT().Call("db:wipe --force").Return(nil).Once()
 	s.mockArtisan.EXPECT().Call("migrate").Return(nil).Once()
 
@@ -113,8 +113,8 @@ func (s *MigratorSuite) TestFresh() {
 	// db:wipe returns error
 	mockOrm = mocksorm.NewOrm(s.T())
 	mockQuery = mocksorm.NewQuery(s.T())
-	s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-	mockOrm.On("Query").Return(mockQuery).Maybe()
+	s.mockSchema.On("Orm").Return(mockOrm).Once()
+	mockOrm.On("Query").Return(mockQuery).Once()
 	s.mockArtisan.EXPECT().Call("db:wipe --force").Return(assert.AnError).Once()
 
 	s.EqualError(s.migrator.Fresh(), assert.AnError.Error())
@@ -122,8 +122,8 @@ func (s *MigratorSuite) TestFresh() {
 	// migrate returns error
 	mockOrm = mocksorm.NewOrm(s.T())
 	mockQuery = mocksorm.NewQuery(s.T())
-	s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-	mockOrm.On("Query").Return(mockQuery).Maybe()
+	s.mockSchema.On("Orm").Return(mockOrm).Once()
+	mockOrm.On("Query").Return(mockQuery).Once()
 	s.mockArtisan.EXPECT().Call("db:wipe --force").Return(nil).Once()
 	s.mockArtisan.EXPECT().Call("migrate").Return(assert.AnError).Once()
 
@@ -258,8 +258,8 @@ func (s *MigratorSuite) TestReset() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(false).Once()
 			},
 		},
@@ -268,8 +268,8 @@ func (s *MigratorSuite) TestReset() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetRan().Return(nil, assert.AnError).Once()
 			},
@@ -321,8 +321,8 @@ func (s *MigratorSuite) TestRollback() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return(nil, nil).Once()
 			},
@@ -349,8 +349,8 @@ func (s *MigratorSuite) TestRollback() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return([]migration.File{{Migration: "20240817214502_create_users_table"}}, nil).Once()
 			},
@@ -378,8 +378,8 @@ func (s *MigratorSuite) TestRollback() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetMigrationsByStep(1).Return(nil, assert.AnError).Once()
 			},
@@ -390,8 +390,8 @@ func (s *MigratorSuite) TestRollback() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(false).Once()
 			},
 		},
@@ -461,8 +461,8 @@ func (s *MigratorSuite) TestRun() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetRan().Return([]string{testConnectionMigration.Signature()}, nil).Once()
 				s.mockSchema.EXPECT().Migrations().Return([]contractsschema.Migration{
@@ -478,8 +478,8 @@ func (s *MigratorSuite) TestRun() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetRan().Return(nil, assert.AnError).Once()
 			},
@@ -725,8 +725,8 @@ func (s *MigratorSuite) TestStatus() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(false).Once()
 			},
 			assert: func() {
@@ -742,8 +742,8 @@ func (s *MigratorSuite) TestStatus() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockRepository.EXPECT().GetMigrations().Return(nil, assert.AnError).Once()
 			},
@@ -758,8 +758,8 @@ func (s *MigratorSuite) TestStatus() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				s.mockRepository.EXPECT().RepositoryExists().Return(true).Once()
 				s.mockSchema.EXPECT().Migrations().Return(nil).Once()
 				s.mockRepository.EXPECT().GetMigrations().Return(nil, nil).Once()
@@ -777,8 +777,8 @@ func (s *MigratorSuite) TestStatus() {
 			setup: func() {
 				mockOrm := mocksorm.NewOrm(s.T())
 				mockQuery := mocksorm.NewQuery(s.T())
-				s.mockSchema.On("Orm").Return(mockOrm).Maybe().Once()
-				mockOrm.On("Query").Return(mockQuery).Maybe()
+				s.mockSchema.On("Orm").Return(mockOrm).Once()
+				mockOrm.On("Query").Return(mockQuery).Once()
 				testMigration := NewTestMigration(s.mockSchema)
 				testConnectionMigration := NewTestConnectionMigration(s.mockSchema)
 

--- a/database/schema/schema.go
+++ b/database/schema/schema.go
@@ -413,6 +413,15 @@ func (r *Schema) Orm() contractsorm.Orm {
 	return r.orm
 }
 
+func (r *Schema) RequireOrm() error {
+	if r.orm == nil || r.orm.Query() == nil {
+		color.Warningln(errors.SchemaOrmNotAvailable.Error())
+		return errors.SchemaOrmNotAvailable
+	}
+
+	return nil
+}
+
 func (r *Schema) Prune() error {
 	if sql := r.grammar.CompilePrune(r.orm.DatabaseName()); len(sql) > 0 {
 		_, err := r.orm.Query().Exec(sql)

--- a/database/schema/schema.go
+++ b/database/schema/schema.go
@@ -413,15 +413,6 @@ func (r *Schema) Orm() contractsorm.Orm {
 	return r.orm
 }
 
-func (r *Schema) RequireOrm() error {
-	if r.orm == nil || r.orm.Query() == nil {
-		color.Warningln(errors.SchemaOrmNotAvailable.Error())
-		return errors.SchemaOrmNotAvailable
-	}
-
-	return nil
-}
-
 func (r *Schema) Prune() error {
 	if sql := r.grammar.CompilePrune(r.orm.DatabaseName()); len(sql) > 0 {
 		_, err := r.orm.Query().Exec(sql)

--- a/errors/list.go
+++ b/errors/list.go
@@ -273,6 +273,7 @@ var (
 	SchemaFailedToDropColumns  = New("failed to drop %s table columns: %v")
 	SchemaFailedToGetTables    = New("failed to get %s tables: %v")
 	SchemaFailedToRenameTable  = New("failed to rename %s table: %v")
+	SchemaOrmNotAvailable      = New("database connection is not available, please check your database configuration")
 	SchemaInvalidModel         = New("model must be a struct or pointer to struct")
 	SchemaModelNotFound        = New("model %s not found in registered models")
 	SchemaTableNotFound        = New("table %s not found")


### PR DESCRIPTION
## Summary
- Add `WithCommandsFilter` builder example to scope registered Artisan commands by environment
- Add integration tests verifying filter returns nil in local env and built-in commands survive
- Add production env test using config override + `Restart()` to verify filter activation

## Why
This adds an example demonstrating the `WithCommandsFilter` builder method introduced in goravel/framework#1500. The filter callback returns a positive list of command signatures to keep in production (using exact and glob matching), and returns nil to keep all commands in dev/local environments.

```go
func CommandsFilter() []string {
	if facades.Config().GetString("app.env") == "production" {
		return []string{
			"up",
			"down",
			"make:*",
			"vendor:publish",
		}
	}

	return nil
}
```

The filter is wired into the builder chain in `bootstrap/app.go`:

```go
return foundation.Setup().
	// ...
	WithCommands(Commands).
	WithCommandsFilter(CommandsFilter).
	// ...
```
