### PR TITLE
feat: [#962] allow extension packages to register view directories

### DIFF
--- a/contracts/view/view.go
+++ b/contracts/view/view.go
@@ -3,6 +3,12 @@ package view
 type View interface {
 	// Exists checks if a view with the specified name exists.
 	Exists(view string) bool
+	// LoadViewsFrom registers a package view directory for template fallback.
+	// Templates from registered directories are loaded after app views; if a
+	// template name is already defined by an app view or an earlier package, it is skipped.
+	LoadViewsFrom(path string)
+	// RegisteredViews returns the absolute paths of all registered package view directories.
+	RegisteredViews() []string
 	// Share associates a key-value pair, where the key is a string and the value is of any type,
 	// with the current view context. This shared data can be accessed by other parts of the application.
 	Share(key string, value any)

--- a/mocks/view/View.go
+++ b/mocks/view/View.go
@@ -110,6 +110,86 @@ func (_c *View_GetShared_Call) RunAndReturn(run func() map[string]interface{}) *
 	return _c
 }
 
+// LoadViewsFrom provides a mock function with given fields: path
+func (_m *View) LoadViewsFrom(path string) {
+	_m.Called(path)
+}
+
+// View_LoadViewsFrom_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LoadViewsFrom'
+type View_LoadViewsFrom_Call struct {
+	*mock.Call
+}
+
+// LoadViewsFrom is a helper method to define mock.On call
+//   - path string
+func (_e *View_Expecter) LoadViewsFrom(path interface{}) *View_LoadViewsFrom_Call {
+	return &View_LoadViewsFrom_Call{Call: _e.mock.On("LoadViewsFrom", path)}
+}
+
+func (_c *View_LoadViewsFrom_Call) Run(run func(path string)) *View_LoadViewsFrom_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *View_LoadViewsFrom_Call) Return() *View_LoadViewsFrom_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *View_LoadViewsFrom_Call) RunAndReturn(run func(string)) *View_LoadViewsFrom_Call {
+	_c.Run(run)
+	return _c
+}
+
+// RegisteredViews provides a mock function with no fields
+func (_m *View) RegisteredViews() []string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for RegisteredViews")
+	}
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	return r0
+}
+
+// View_RegisteredViews_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RegisteredViews'
+type View_RegisteredViews_Call struct {
+	*mock.Call
+}
+
+// RegisteredViews is a helper method to define mock.On call
+func (_e *View_Expecter) RegisteredViews() *View_RegisteredViews_Call {
+	return &View_RegisteredViews_Call{Call: _e.mock.On("RegisteredViews")}
+}
+
+func (_c *View_RegisteredViews_Call) Run(run func()) *View_RegisteredViews_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *View_RegisteredViews_Call) Return(_a0 []string) *View_RegisteredViews_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *View_RegisteredViews_Call) RunAndReturn(run func() []string) *View_RegisteredViews_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Share provides a mock function with given fields: key, value
 func (_m *View) Share(key string, value interface{}) {
 	_m.Called(key, value)

--- a/view/view.go
+++ b/view/view.go
@@ -9,6 +9,8 @@ import (
 )
 
 type View struct {
+	mu     sync.RWMutex
+	paths  []string
 	shared sync.Map
 }
 
@@ -17,7 +19,33 @@ func NewView() *View {
 }
 
 func (r *View) Exists(view string) bool {
-	return file.Exists(paths.Abs(support.Config.Paths.Resources, "views", view))
+	if file.Exists(paths.Abs(support.Config.Paths.Resources, "views", view)) {
+		return true
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, p := range r.paths {
+		if file.Exists(paths.Abs(p, view)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *View) LoadViewsFrom(path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.paths = append(r.paths, path)
+}
+
+func (r *View) RegisteredViews() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, len(r.paths))
+	copy(out, r.paths)
+	return out
 }
 
 func (r *View) Share(key string, value any) {


### PR DESCRIPTION
## Summary
- Extension packages can call `facades.View().LoadViewsFrom(path)` to register their own views directory
- `Exists()` now checks registered package view paths in addition to `resources/views/`
- `RegisteredViews()` exposes registered paths for driver-side template loading

Closes https://github.com/goravel/goravel/issues/962

## Why
Extension packages currently must place templates under the main project's `resources/views/` directory, which clutters the user's project. With `LoadViewsFrom()`, a package registers its own `views/` directory. When the driver loads templates, app views take priority (user can override), and package views serve as defaults.

```go
// In an extension package's service_provider.go:
func (r *ServiceProvider) Boot(app foundation.Application) {
    facades.View().LoadViewsFrom("/path/to/package/views")
}
```