### PR TITLE
feat: rename grpc.servers config key to grpc.clients

### DIFF
--- a/contracts/foundation/application_builder.go
+++ b/contracts/foundation/application_builder.go
@@ -45,7 +45,7 @@ type ApplicationBuilder interface {
 	// WithFilters sets the application's validation filters.
 	WithFilters(func() []validation.Filter) ApplicationBuilder
 	// WithGrpcClientCredentials registers groups of gRPC client transport credentials
-	// (e.g. mTLS). Keys are referenced via `grpc.servers.<name>.creds` to
+	// (e.g. mTLS). Keys are referenced via `grpc.clients.<name>.creds` to
 	// override the default insecure credentials on matching connections.
 	WithGrpcClientCredentials(func() map[string]credentials.TransportCredentials) ApplicationBuilder
 	// WithGrpcClientInterceptors sets the grouped gRPC client interceptors.

--- a/contracts/grpc/grpc.go
+++ b/contracts/grpc/grpc.go
@@ -13,7 +13,7 @@ type Grpc interface {
 	// DEPRECATED: Use Connect instead, will be removed in v1.18.
 	Client(ctx context.Context, name string) (*grpc.ClientConn, error)
 	// ClientCredentials registers groups of transport credentials for gRPC clients
-	// (e.g. mTLS). Keys are referenced via `grpc.servers.<name>.creds` and
+	// (e.g. mTLS). Keys are referenced via `grpc.clients.<name>.creds` and
 	// override the default insecure credentials on matching connections.
 	ClientCredentials(map[string]credentials.TransportCredentials)
 	// ClientStatsHandlerGroups sets the gRPC client stats handler groups.

--- a/contracts/grpc/grpc.go
+++ b/contracts/grpc/grpc.go
@@ -18,9 +18,9 @@ type Grpc interface {
 	ClientCredentials(map[string]credentials.TransportCredentials)
 	// ClientStatsHandlerGroups sets the gRPC client stats handler groups.
 	ClientStatsHandlerGroups(map[string][]stats.Handler)
-	// Connect gets a gRPC client connection to the given server.
-	// The server connection will be cached to improve performance.
-	Connect(server string) (*grpc.ClientConn, error)
+	// Connect gets a gRPC client connection to the given client.
+	// The client connection will be cached to improve performance.
+	Connect(client string) (*grpc.ClientConn, error)
 	// Listen starts the gRPC server with the given listener.
 	Listen(l net.Listener) error
 	// Run starts the gRPC server.

--- a/grpc/application.go
+++ b/grpc/application.go
@@ -54,9 +54,9 @@ func (r *Application) Client(ctx context.Context, name string) (*grpc.ClientConn
 	return r.Connect(name)
 }
 
-func (r *Application) Connect(server string) (*grpc.ClientConn, error) {
+func (r *Application) Connect(client string) (*grpc.ClientConn, error) {
 	r.mu.RLock()
-	conn, ok := r.clients[server]
+	conn, ok := r.clients[client]
 	r.mu.RUnlock()
 
 	if ok {
@@ -70,22 +70,22 @@ func (r *Application) Connect(server string) (*grpc.ClientConn, error) {
 	defer r.mu.Unlock()
 
 	// Double-Check: Someone else might have created it while we waited for the lock
-	if conn, ok = r.clients[server]; ok {
+	if conn, ok = r.clients[client]; ok {
 		if conn.GetState() != connectivity.Shutdown {
 			return conn, nil
 		}
 		// Found a Shutdown connection. Close and remove it immediately.
 		// This prevents stale connections from lingering if the subsequent creation fails.
 		_ = conn.Close()
-		delete(r.clients, server)
+		delete(r.clients, client)
 	}
 
-	host := r.config.GetString(fmt.Sprintf("grpc.clients.%s.host", server))
+	host := r.config.GetString(fmt.Sprintf("grpc.clients.%s.host", client))
 	if host == "" {
 		return nil, errors.GrpcEmptyClientHost
 	}
 	if !strings.Contains(host, ":") {
-		port := r.config.GetString(fmt.Sprintf("grpc.clients.%s.port", server))
+		port := r.config.GetString(fmt.Sprintf("grpc.clients.%s.port", client))
 		if port == "" {
 			return nil, errors.GrpcEmptyClientPort
 		}
@@ -93,19 +93,19 @@ func (r *Application) Connect(server string) (*grpc.ClientConn, error) {
 		host += ":" + port
 	}
 
-	interceptorKeys, ok := r.config.Get(fmt.Sprintf("grpc.clients.%s.interceptors", server)).([]string)
+	interceptorKeys, ok := r.config.Get(fmt.Sprintf("grpc.clients.%s.interceptors", client)).([]string)
 	if !ok {
-		return nil, errors.GrpcInvalidInterceptorsType.Args(server)
+		return nil, errors.GrpcInvalidInterceptorsType.Args(client)
 	}
 
 	var dialOpts []grpc.DialOption
-	dialOpts = append(dialOpts, grpc.WithTransportCredentials(r.resolveClientCredentials(server)))
+	dialOpts = append(dialOpts, grpc.WithTransportCredentials(r.resolveClientCredentials(client)))
 
 	if interceptors := r.getClientInterceptors(interceptorKeys); len(interceptors) > 0 {
 		dialOpts = append(dialOpts, grpc.WithChainUnaryInterceptor(interceptors...))
 	}
 
-	statsHandlerKeys, ok := r.config.Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", server)).([]string)
+	statsHandlerKeys, ok := r.config.Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", client)).([]string)
 	if ok {
 		if handlers := r.getClientStatsHandlers(statsHandlerKeys); len(handlers) > 0 {
 			for _, h := range handlers {
@@ -122,7 +122,7 @@ func (r *Application) Connect(server string) (*grpc.ClientConn, error) {
 		return nil, err
 	}
 
-	r.clients[server] = newConn
+	r.clients[client] = newConn
 
 	return newConn, nil
 }
@@ -259,23 +259,23 @@ func (r *Application) getClientInterceptors(keys []string) []grpc.UnaryClientInt
 	return result
 }
 
-// resolveClientCredentials returns the transport credentials for the given server.
+// resolveClientCredentials returns the transport credentials for the given client.
 // When a credentials group is registered and referenced via the
 // `grpc.clients.<name>.creds` config key, those credentials are used;
 // otherwise insecure credentials are returned to preserve existing behavior.
-func (r *Application) resolveClientCredentials(server string) credentials.TransportCredentials {
+func (r *Application) resolveClientCredentials(client string) credentials.TransportCredentials {
 	if len(r.clientCredentialsGroups) == 0 {
 		return insecure.NewCredentials()
 	}
 
-	credsKey := r.config.GetString(fmt.Sprintf("grpc.clients.%s.credentials", server))
+	credsKey := r.config.GetString(fmt.Sprintf("grpc.clients.%s.credentials", client))
 	if credsKey == "" {
 		return insecure.NewCredentials()
 	}
 
 	creds, ok := r.clientCredentialsGroups[credsKey]
 	if !ok {
-		color.Warningln(fmt.Sprintf("[GRPC] client credentials group %q is not registered for server %q; falling back to insecure credentials.", credsKey, server))
+		color.Warningln(fmt.Sprintf("[GRPC] client credentials group %q is not registered for client %q; falling back to insecure credentials.", credsKey, client))
 		return insecure.NewCredentials()
 	}
 

--- a/grpc/application.go
+++ b/grpc/application.go
@@ -32,15 +32,15 @@ type Application struct {
 	clientCredentialsGroups      map[string]credentials.TransportCredentials
 	clientStatsHandlerGroups     map[string][]stats.Handler
 
-	// Mutex protects the servers map
+	// Mutex protects the clients map
 	mu      sync.RWMutex
-	servers map[string]*grpc.ClientConn
+	clients map[string]*grpc.ClientConn
 }
 
 func NewApplication(config config.Config) *Application {
 	return &Application{
 		config:                       config,
-		servers:                      make(map[string]*grpc.ClientConn),
+		clients:                      make(map[string]*grpc.ClientConn),
 		unaryServerInterceptors:      make([]grpc.UnaryServerInterceptor, 0),
 		serverStatsHandlers:          make([]stats.Handler, 0),
 		unaryClientInterceptorGroups: make(map[string][]grpc.UnaryClientInterceptor),
@@ -56,7 +56,7 @@ func (r *Application) Client(ctx context.Context, name string) (*grpc.ClientConn
 
 func (r *Application) Connect(server string) (*grpc.ClientConn, error) {
 	r.mu.RLock()
-	conn, ok := r.servers[server]
+	conn, ok := r.clients[server]
 	r.mu.RUnlock()
 
 	if ok {
@@ -70,22 +70,22 @@ func (r *Application) Connect(server string) (*grpc.ClientConn, error) {
 	defer r.mu.Unlock()
 
 	// Double-Check: Someone else might have created it while we waited for the lock
-	if conn, ok = r.servers[server]; ok {
+	if conn, ok = r.clients[server]; ok {
 		if conn.GetState() != connectivity.Shutdown {
 			return conn, nil
 		}
 		// Found a Shutdown connection. Close and remove it immediately.
 		// This prevents stale connections from lingering if the subsequent creation fails.
 		_ = conn.Close()
-		delete(r.servers, server)
+		delete(r.clients, server)
 	}
 
-	host := r.config.GetString(fmt.Sprintf("grpc.servers.%s.host", server))
+	host := r.config.GetString(fmt.Sprintf("grpc.clients.%s.host", server))
 	if host == "" {
 		return nil, errors.GrpcEmptyClientHost
 	}
 	if !strings.Contains(host, ":") {
-		port := r.config.GetString(fmt.Sprintf("grpc.servers.%s.port", server))
+		port := r.config.GetString(fmt.Sprintf("grpc.clients.%s.port", server))
 		if port == "" {
 			return nil, errors.GrpcEmptyClientPort
 		}
@@ -93,7 +93,7 @@ func (r *Application) Connect(server string) (*grpc.ClientConn, error) {
 		host += ":" + port
 	}
 
-	interceptorKeys, ok := r.config.Get(fmt.Sprintf("grpc.servers.%s.interceptors", server)).([]string)
+	interceptorKeys, ok := r.config.Get(fmt.Sprintf("grpc.clients.%s.interceptors", server)).([]string)
 	if !ok {
 		return nil, errors.GrpcInvalidInterceptorsType.Args(server)
 	}
@@ -105,7 +105,7 @@ func (r *Application) Connect(server string) (*grpc.ClientConn, error) {
 		dialOpts = append(dialOpts, grpc.WithChainUnaryInterceptor(interceptors...))
 	}
 
-	statsHandlerKeys, ok := r.config.Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", server)).([]string)
+	statsHandlerKeys, ok := r.config.Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", server)).([]string)
 	if ok {
 		if handlers := r.getClientStatsHandlers(statsHandlerKeys); len(handlers) > 0 {
 			for _, h := range handlers {
@@ -122,7 +122,7 @@ func (r *Application) Connect(server string) (*grpc.ClientConn, error) {
 		return nil, err
 	}
 
-	r.servers[server] = newConn
+	r.clients[server] = newConn
 
 	return newConn, nil
 }
@@ -197,12 +197,12 @@ func (r *Application) Shutdown(force ...bool) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	for _, conn := range r.servers {
+	for _, conn := range r.clients {
 		_ = conn.Close()
 	}
 
 	// Clear the map to allow Garbage Collection
-	r.servers = make(map[string]*grpc.ClientConn)
+	r.clients = make(map[string]*grpc.ClientConn)
 
 	return nil
 }
@@ -261,14 +261,14 @@ func (r *Application) getClientInterceptors(keys []string) []grpc.UnaryClientInt
 
 // resolveClientCredentials returns the transport credentials for the given server.
 // When a credentials group is registered and referenced via the
-// `grpc.servers.<name>.creds` config key, those credentials are used;
+// `grpc.clients.<name>.creds` config key, those credentials are used;
 // otherwise insecure credentials are returned to preserve existing behavior.
 func (r *Application) resolveClientCredentials(server string) credentials.TransportCredentials {
 	if len(r.clientCredentialsGroups) == 0 {
 		return insecure.NewCredentials()
 	}
 
-	credsKey := r.config.GetString(fmt.Sprintf("grpc.servers.%s.credentials", server))
+	credsKey := r.config.GetString(fmt.Sprintf("grpc.clients.%s.credentials", server))
 	if credsKey == "" {
 		return insecure.NewCredentials()
 	}

--- a/grpc/application_test.go
+++ b/grpc/application_test.go
@@ -464,7 +464,7 @@ func TestClientCreds(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, conn)
 		})
-		assert.Contains(t, got, `[GRPC] client credentials group "unknown" is not registered for server "partial-service"`)
+		assert.Contains(t, got, `[GRPC] client credentials group "unknown" is not registered for client "partial-service"`)
 	})
 
 	t.Run("connect without registered groups skips config lookup", func(t *testing.T) {

--- a/grpc/application_test.go
+++ b/grpc/application_test.go
@@ -70,9 +70,9 @@ func TestRun(t *testing.T) {
 			name: "success",
 			setup: func() {
 				host := "127.0.0.1:3030"
-				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{"test"}).Once()
-				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{"test"}).Once()
+				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{"test"}).Once()
+				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{"test"}).Once()
 
 				go func() {
 					assert.Nil(t, app.Run(host))
@@ -120,9 +120,9 @@ func TestRun(t *testing.T) {
 			name: "error when request name = error",
 			setup: func() {
 				host := "127.0.0.1:3033"
-				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{"test"}).Once()
-				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{"test"}).Once()
+				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{"test"}).Once()
+				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{"test"}).Once()
 
 				go func() {
 					assert.Nil(t, app.Run(host))
@@ -174,9 +174,9 @@ func TestClient(t *testing.T) {
 		{
 			name: "success",
 			setup: func() {
-				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{"trace"}).Once()
-				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{"trace"}).Once()
+				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{"trace"}).Once()
+				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{"trace"}).Once()
 				app.UnaryClientInterceptorGroups(map[string][]grpc.UnaryClientInterceptor{
 					"trace": {opentracingClient},
 				})
@@ -185,9 +185,9 @@ func TestClient(t *testing.T) {
 		{
 			name: "success with stats handler",
 			setup: func() {
-				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{"otel"}).Once()
-				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{"otel"}).Once()
+				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{"otel"}).Once()
+				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{"otel"}).Once()
 				app.ClientStatsHandlerGroups(map[string][]stats.Handler{
 					"otel": {&mockStatsHandler{}},
 				})
@@ -196,32 +196,32 @@ func TestClient(t *testing.T) {
 		{
 			name: "success when interceptors is empty",
 			setup: func() {
-				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{"trace"}).Once()
-				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{"trace"}).Once()
+				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{"trace"}).Once()
+				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{"trace"}).Once()
 				app.UnaryClientInterceptorGroups(map[string][]grpc.UnaryClientInterceptor{})
 			},
 		},
 		{
 			name: "error when host is empty",
 			setup: func() {
-				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return("").Once()
+				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return("").Once()
 			},
 			expectErr: true,
 		},
 		{
 			name: "error when host doesn't have port and port is empty",
 			setup: func() {
-				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return("127.0.0.1").Once()
-				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.port", name)).Return("").Once()
+				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return("127.0.0.1").Once()
+				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.port", name)).Return("").Once()
 			},
 			expectErr: true,
 		},
 		{
 			name: "error when interceptors isn't []string",
 			setup: func() {
-				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return("trace").Once()
+				mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+				mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return("trace").Once()
 			},
 			expectErr: true,
 		},
@@ -258,9 +258,9 @@ func TestClient_Caching(t *testing.T) {
 		setup()
 
 		// We expect GetString to be called ONLY ONCE, even though we call Client() twice.
-		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{}).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{}).Once()
 
 		conn1, err := app.Client(context.Background(), name)
 		assert.NoError(t, err)
@@ -278,9 +278,9 @@ func TestClient_Caching(t *testing.T) {
 	t.Run("Concurrent Access: Should handle race conditions safely", func(t *testing.T) {
 		setup()
 
-		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{}).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{}).Once()
 
 		var wg sync.WaitGroup
 		concurrency := 50
@@ -314,9 +314,9 @@ func TestClient_Caching(t *testing.T) {
 	t.Run("Reconnect after cached connection is shutdown", func(t *testing.T) {
 		setup()
 
-		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Twice()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{}).Twice()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{}).Twice()
+		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Twice()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{}).Twice()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{}).Twice()
 
 		conn1, err := app.Client(context.Background(), name)
 		assert.NoError(t, err)
@@ -344,9 +344,9 @@ func TestShutdown_ClosesConnections(t *testing.T) {
 	mockConfig = configmock.NewConfig(t)
 	app = NewApplication(mockConfig)
 
-	mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-	mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{}).Once()
-	mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{}).Once()
+	mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+	mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{}).Once()
+	mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{}).Once()
 
 	conn, err := app.Client(context.Background(), name)
 	assert.NoError(t, err)
@@ -429,10 +429,10 @@ func TestClientCreds(t *testing.T) {
 		name := "mtls-service"
 		host := "127.0.0.1:3050"
 
-		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{}).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{}).Once()
-		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.credentials", name)).Return("mtls").Once()
+		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.credentials", name)).Return("mtls").Once()
 
 		app.ClientCredentials(map[string]credentials.TransportCredentials{
 			"mtls": credentials.NewTLS(&tls.Config{ServerName: "mtls-service"}),
@@ -450,10 +450,10 @@ func TestClientCreds(t *testing.T) {
 		name := "partial-service"
 		host := "127.0.0.1:3052"
 
-		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{}).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{}).Once()
-		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.credentials", name)).Return("unknown").Once()
+		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.credentials", name)).Return("unknown").Once()
 
 		app.ClientCredentials(map[string]credentials.TransportCredentials{
 			"mtls": credentials.NewTLS(&tls.Config{ServerName: "mtls-service"}),
@@ -475,9 +475,9 @@ func TestClientCreds(t *testing.T) {
 		host := "127.0.0.1:3051"
 
 		// No GetString for "creds" expected because no groups are registered.
-		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{}).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{}).Once()
 
 		conn, err := app.Client(context.Background(), name)
 		assert.NoError(t, err)
@@ -491,10 +491,10 @@ func TestClientCreds(t *testing.T) {
 		name := "insecure-service"
 		host := "127.0.0.1:3053"
 
-		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.host", name)).Return(host).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.interceptors", name)).Return([]string{}).Once()
-		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.servers.%s.stats_handlers", name)).Return([]string{}).Once()
-		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.servers.%s.credentials", name)).Return("").Once()
+		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.host", name)).Return(host).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.interceptors", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().Get(fmt.Sprintf("grpc.clients.%s.stats_handlers", name)).Return([]string{}).Once()
+		mockConfig.EXPECT().GetString(fmt.Sprintf("grpc.clients.%s.credentials", name)).Return("").Once()
 
 		app.ClientCredentials(map[string]credentials.TransportCredentials{
 			"mtls": credentials.NewTLS(&tls.Config{ServerName: "mtls-service"}),

--- a/grpc/setup/stubs.go
+++ b/grpc/setup/stubs.go
@@ -22,8 +22,8 @@ func init() {
 		// Configure your server port
 		"port": config.Env("GRPC_PORT"),
 
-		// Configure servers which the client will connect to
-		"servers": map[string]any{
+		// Configure clients which the framework will connect to
+		"clients": map[string]any{
 			//"user": map[string]any{
 			//	"host":           config.Env("GRPC_USER_HOST"),
 			//	"port":           config.Env("GRPC_USER_PORT"),

--- a/mocks/grpc/Grpc.go
+++ b/mocks/grpc/Grpc.go
@@ -154,9 +154,9 @@ func (_c *Grpc_ClientStatsHandlerGroups_Call) RunAndReturn(run func(map[string][
 	return _c
 }
 
-// Connect provides a mock function with given fields: server
-func (_m *Grpc) Connect(server string) (*grpc.ClientConn, error) {
-	ret := _m.Called(server)
+// Connect provides a mock function with given fields: client
+func (_m *Grpc) Connect(client string) (*grpc.ClientConn, error) {
+	ret := _m.Called(client)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Connect")
@@ -165,10 +165,10 @@ func (_m *Grpc) Connect(server string) (*grpc.ClientConn, error) {
 	var r0 *grpc.ClientConn
 	var r1 error
 	if rf, ok := ret.Get(0).(func(string) (*grpc.ClientConn, error)); ok {
-		return rf(server)
+		return rf(client)
 	}
 	if rf, ok := ret.Get(0).(func(string) *grpc.ClientConn); ok {
-		r0 = rf(server)
+		r0 = rf(client)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*grpc.ClientConn)
@@ -176,7 +176,7 @@ func (_m *Grpc) Connect(server string) (*grpc.ClientConn, error) {
 	}
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(server)
+		r1 = rf(client)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -190,12 +190,12 @@ type Grpc_Connect_Call struct {
 }
 
 // Connect is a helper method to define mock.On call
-//   - server string
-func (_e *Grpc_Expecter) Connect(server interface{}) *Grpc_Connect_Call {
-	return &Grpc_Connect_Call{Call: _e.mock.On("Connect", server)}
+//   - client string
+func (_e *Grpc_Expecter) Connect(client interface{}) *Grpc_Connect_Call {
+	return &Grpc_Connect_Call{Call: _e.mock.On("Connect", client)}
 }
 
-func (_c *Grpc_Connect_Call) Run(run func(server string)) *Grpc_Connect_Call {
+func (_c *Grpc_Connect_Call) Run(run func(client string)) *Grpc_Connect_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(string))
 	})


### PR DESCRIPTION
## Summary
- Rename gRPC config key `grpc.servers` to `grpc.clients` for semantic correctness
- Rename internal `Application.servers` cache field to `clients` to match client-side role
- Rename `Connect(server)` parameter to `Connect(client)` and update `resolveClientCredentials` accordingly

## Why
The gRPC "servers" config entries define client connection targets — host, port, credentials, and interceptors for outbound gRPC calls. The existing key name `grpc.servers` is misleading because the builder API already uses `WithGrpcClient*` naming for these options (e.g. `WithGrpcClientCredentials`, `WithGrpcClientInterceptors`). Renaming to `grpc.clients` makes the config self-documenting and consistent with the API. The `Connect` parameter and internal field are renamed for the same reason.

```go
// config/grpc.go
func init() {
    config := facades.Config()
    config.Add("grpc", map[string]any{
        // GRPC server configuration
        "host": config.Env("GRPC_HOST"),
        "port": config.Env("GRPC_PORT"),

        // Configure gRPC clients (services to connect to)
        "clients": map[string]any{
            "user": map[string]any{
                "host":           config.Env("GRPC_USER_HOST"),
                "port":           config.Env("GRPC_USER_PORT"),
                "credentials":    config.Env("GRPC_USER_CREDENTIALS"),
                "interceptors":   []string{},
                "stats_handlers": []string{},
            },
        },
    })
}
```
