### PR TITLE
fix: reorder configureMiddleware before Boot so provider routes survive engine rebuild (#975)

### DIFF
--- a/foundation/application.go
+++ b/foundation/application.go
@@ -119,8 +119,8 @@ func (r *Application) Build() foundation.Application {
 	}
 	r.configureServiceProviders()
 	r.providerRepository.Register(r)
-	r.providerRepository.Boot(r)
 	r.configureMiddleware()
+	r.providerRepository.Boot(r)
 	r.configureEventListeners()
 	r.configureCommands()
 	r.configureSchedule()


### PR DESCRIPTION
## Summary

Fixes goravel/goravel#975

Routes registered inside a `ServiceProvider.Boot()` (e.g. `app.MakeRoute().Get(...)`) were silently discarded when the application registered any global middleware via `WithMiddleware()` in `bootstrap/app.go`. The routes returned 404 at runtime with no error.

## Root Cause

In `Build()`, `configureMiddleware()` was called **after** `Boot()`. When `WithMiddleware` is used, `SetGlobalMiddleware` rebuilds the route engine (`gin.New()` / equivalent). Routes registered by providers during `Boot()` were on the **old** engine and lost.

## Fix

Reorder `configureMiddleware()` to run **between `Register()` and `Boot()`** instead of after `Boot()`:

- Providers register their IoC bindings (including Route facade) → `Register()`
- Middleware configured, engine initialized with global middleware → `configureMiddleware()` (moved here)
- Providers register routes on the already-configured engine → `Boot()`
- App routes via `WithRouting` also register on the same engine → `configureRoutes()`

This is a one-line move in `foundation/application.go`.