### PR TITLE
fix: reset database connections when the application rebuilds

### DIFF
--- a/database/service_provider.go
+++ b/database/service_provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goravel/framework/database/console"
 	consolemigration "github.com/goravel/framework/database/console/migration"
 	"github.com/goravel/framework/database/db"
+	databasedriver "github.com/goravel/framework/database/driver"
 	"github.com/goravel/framework/database/migration"
 	databaseorm "github.com/goravel/framework/database/orm"
 	databaseschema "github.com/goravel/framework/database/schema"
@@ -40,6 +41,10 @@ func (r *ServiceProvider) Relationship() contractsbinding.Relationship {
 }
 
 func (r *ServiceProvider) Register(app foundation.Application) {
+	// Drop cached connections so a rebuild (e.g. app.Restart) reconnects using the
+	// current configuration instead of a connection bound to the previous one.
+	databasedriver.ResetConnections()
+
 	app.Singleton(contractsbinding.Orm, func(app foundation.Application) (any, error) {
 		ctx := context.Background()
 		config := app.MakeConfig()


### PR DESCRIPTION
## 📑 Description

The database connection cache (`connectionToDB` in `database/driver`) is process-global and survives `app.Restart()`. `Restart` rebuilds the container (clearing instances), but the cached `*gorm.DB` and its `Instrument` live outside the container, so a rebuilt application keeps connections created under the previous configuration. After a config-changing restart this means queries run on stale connections, and (with telemetry enabled) spans are emitted under the tracer the connection was first built with, not the current one.

**What is changing:**

* The database `ServiceProvider.Register` now calls `driver.ResetConnections()` before registering the bindings. `Register` runs on every build, so a restart drops the cached connections and the next query reconnects with the current configuration. On the initial boot the cache is empty, so this is a no-op; within a single build connections are still created lazily and shared between `facades.Orm()` and `facades.DB()` as before.

**Example:**

```go
facades.Config().Add("telemetry.service.name", "billing")
facades.App().Restart()

// Before: the next query reused a connection bound to the old service name.
// After: it reconnects, so the span reports under "billing".
facades.DB().Table("users").Get(&users)
```

This makes `app.Restart()` reset database connections, which is what callers already expect and removes the need for manual `Orm().Fresh()` / `App().Fresh(binding.DB)` resets after a restart.

## ✅ Checks

- [x] Added test cases for my code
