### PR TITLE
fix: change Middleware from func to interface for stable WithoutMiddleware comparison

### DIFF
--- a/contracts/http/context.go
+++ b/contracts/http/context.go
@@ -4,7 +4,10 @@ import (
 	"context"
 )
 
-type Middleware func(Context)
+type Middleware interface {
+	Handle(Context)
+	Signature() string
+}
 
 type HandlerFunc func(Context) Response
 

--- a/foundation/configuration/middleware_test.go
+++ b/foundation/configuration/middleware_test.go
@@ -10,11 +10,20 @@ import (
 	contractshttp "github.com/goravel/framework/contracts/http"
 )
 
-// makeMiddleware returns a middleware function annotated with an id via closure.
+type testMiddleware struct {
+	id string
+}
+
+func (m *testMiddleware) Handle(ctx contractshttp.Context) {
+	fmt.Println(m.id)
+}
+
+func (m *testMiddleware) Signature() string {
+	return m.id
+}
+
 func makeMiddleware(id string) contractshttp.Middleware {
-	return func(ctx contractshttp.Context) {
-		fmt.Println(id)
-	}
+	return &testMiddleware{id: id}
 }
 
 type MiddlewareTestSuite struct {

--- a/http/console/middleware_make_command_test.go
+++ b/http/console/middleware_make_command_test.go
@@ -36,6 +36,6 @@ func TestMiddlewareMakeCommand(t *testing.T) {
 	assert.NoError(t, middlewareMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/http/middleware/User/auth.go"))
 	assert.True(t, file.Contain("app/http/middleware/User/auth.go", "package User"))
-	assert.True(t, file.Contain("app/http/middleware/User/auth.go", "func Auth() http.Middleware {"))
+	assert.True(t, file.Contain("app/http/middleware/User/auth.go", "type Auth struct{}"))
 	assert.Nil(t, file.Remove("app"))
 }

--- a/http/console/stubs.go
+++ b/http/console/stubs.go
@@ -91,10 +91,14 @@ import (
 	"github.com/goravel/framework/contracts/http"
 )
 
-func DummyMiddleware() http.Middleware {
-	return func(ctx http.Context) {
-		ctx.Request().Next()
-	}
+type DummyMiddleware struct{}
+
+func (m *DummyMiddleware) Signature() string {
+	return "DummyMiddleware"
+}
+
+func (m *DummyMiddleware) Handle(ctx http.Context) {
+	ctx.Request().Next()
 }
 `
 }

--- a/http/middleware/check_for_maintenance_mode.go
+++ b/http/middleware/check_for_maintenance_mode.go
@@ -8,13 +8,13 @@ import (
 	"github.com/goravel/framework/http"
 )
 
-type MaintenanceMode struct{}
+type maintenanceMode struct{}
 
-func (m *MaintenanceMode) Signature() string {
+func (m *maintenanceMode) Signature() string {
 	return "check_for_maintenance_mode"
 }
 
-func (m *MaintenanceMode) Handle(ctx contractshttp.Context) {
+func (m *maintenanceMode) Handle(ctx contractshttp.Context) {
 	config := http.App.MakeConfig()
 	cache := http.App.MakeCache()
 	storage := http.App.MakeStorage()
@@ -77,7 +77,7 @@ func (m *MaintenanceMode) Handle(ctx contractshttp.Context) {
 }
 
 func CheckForMaintenanceMode() contractshttp.Middleware {
-	return &MaintenanceMode{}
+	return &maintenanceMode{}
 }
 
 func abortMaintenanceMode(ctx contractshttp.Context, err error) {

--- a/http/middleware/check_for_maintenance_mode.go
+++ b/http/middleware/check_for_maintenance_mode.go
@@ -11,7 +11,7 @@ import (
 type maintenanceMode struct{}
 
 func (m *maintenanceMode) Signature() string {
-	return "check_for_maintenance_mode"
+	return "goravel:check_for_maintenance_mode"
 }
 
 func (m *maintenanceMode) Handle(ctx contractshttp.Context) {

--- a/http/middleware/check_for_maintenance_mode.go
+++ b/http/middleware/check_for_maintenance_mode.go
@@ -8,68 +8,76 @@ import (
 	"github.com/goravel/framework/http"
 )
 
-func CheckForMaintenanceMode() contractshttp.Middleware {
-	return func(ctx contractshttp.Context) {
-		config := http.App.MakeConfig()
-		cache := http.App.MakeCache()
-		storage := http.App.MakeStorage()
-		hash := http.App.MakeHash()
-		if config == nil || cache == nil || storage == nil || hash == nil {
+type MaintenanceMode struct{}
+
+func (m *MaintenanceMode) Signature() string {
+	return "check_for_maintenance_mode"
+}
+
+func (m *MaintenanceMode) Handle(ctx contractshttp.Context) {
+	config := http.App.MakeConfig()
+	cache := http.App.MakeCache()
+	storage := http.App.MakeStorage()
+	hash := http.App.MakeHash()
+	if config == nil || cache == nil || storage == nil || hash == nil {
+		ctx.Request().Next()
+		return
+	}
+
+	maintenance := console.NewMaintenanceMode(config, cache, storage)
+	content, exists, err := maintenance.Get()
+	if err != nil {
+		abortMaintenanceMode(ctx, err)
+		return
+	}
+	if !exists {
+		ctx.Request().Next()
+		return
+	}
+
+	var maintenanceOptions console.MaintenanceOptions
+	err = json.Unmarshal(content, &maintenanceOptions)
+
+	if err != nil {
+		abortMaintenanceMode(ctx, err)
+		return
+	}
+
+	secret := ctx.Request().Query("secret", "")
+	if secret != "" && maintenanceOptions.Secret != "" {
+		if hash.Check(secret, maintenanceOptions.Secret) {
 			ctx.Request().Next()
 			return
-		}
-
-		maintenance := console.NewMaintenanceMode(config, cache, storage)
-		content, exists, err := maintenance.Get()
-		if err != nil {
-			abortMaintenanceMode(ctx, err)
-			return
-		}
-		if !exists {
-			ctx.Request().Next()
-			return
-		}
-
-		var maintenanceOptions console.MaintenanceOptions
-		err = json.Unmarshal(content, &maintenanceOptions)
-
-		if err != nil {
-			abortMaintenanceMode(ctx, err)
-			return
-		}
-
-		secret := ctx.Request().Query("secret", "")
-		if secret != "" && maintenanceOptions.Secret != "" {
-			if hash.Check(secret, maintenanceOptions.Secret) {
-				ctx.Request().Next()
-				return
-			}
-		}
-
-		if maintenanceOptions.Redirect != "" {
-			if ctx.Request().Path() == maintenanceOptions.Redirect {
-				ctx.Request().Next()
-				return
-			}
-
-			if err = ctx.Response().Redirect(contractshttp.StatusTemporaryRedirect, maintenanceOptions.Redirect).Abort(); err != nil {
-				return
-			}
-			return
-		}
-
-		if maintenanceOptions.Render != "" {
-			ctx.Request().Abort(maintenanceOptions.Status)
-			if err = ctx.Response().View().Make(maintenanceOptions.Render).Render(); err != nil {
-				panic(err)
-			}
-			return
-		}
-
-		if err = ctx.Response().String(maintenanceOptions.Status, maintenanceOptions.Reason).Abort(); err != nil {
-			panic(err)
 		}
 	}
+
+	if maintenanceOptions.Redirect != "" {
+		if ctx.Request().Path() == maintenanceOptions.Redirect {
+			ctx.Request().Next()
+			return
+		}
+
+		if err = ctx.Response().Redirect(contractshttp.StatusTemporaryRedirect, maintenanceOptions.Redirect).Abort(); err != nil {
+			return
+		}
+		return
+	}
+
+	if maintenanceOptions.Render != "" {
+		ctx.Request().Abort(maintenanceOptions.Status)
+		if err = ctx.Response().View().Make(maintenanceOptions.Render).Render(); err != nil {
+			panic(err)
+		}
+		return
+	}
+
+	if err = ctx.Response().String(maintenanceOptions.Status, maintenanceOptions.Reason).Abort(); err != nil {
+		panic(err)
+	}
+}
+
+func CheckForMaintenanceMode() contractshttp.Middleware {
+	return &MaintenanceMode{}
 }
 
 func abortMaintenanceMode(ctx contractshttp.Context, err error) {

--- a/http/middleware/check_for_maintenance_mode_test.go
+++ b/http/middleware/check_for_maintenance_mode_test.go
@@ -100,7 +100,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_NotUnderMaintenance() {
 	s.mockStorage.EXPECT().Exists("framework/maintenance.json").Return(false).Once()
 
 	middleware := CheckForMaintenanceMode()
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_MissingConfigPassesThrough() {
@@ -109,7 +109,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_MissingConfigPassesThrough() {
 	s.mockRequest.EXPECT().Next().Once()
 
 	middleware := CheckForMaintenanceMode()
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_MissingCachePassesThrough() {
@@ -118,7 +118,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_MissingCachePassesThrough() {
 	s.mockRequest.EXPECT().Next().Once()
 
 	middleware := CheckForMaintenanceMode()
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_MissingStoragePassesThrough() {
@@ -127,7 +127,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_MissingStoragePassesThrough() 
 	s.mockRequest.EXPECT().Next().Once()
 
 	middleware := CheckForMaintenanceMode()
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_MissingHashPassesThrough() {
@@ -136,7 +136,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_MissingHashPassesThrough() {
 	s.mockRequest.EXPECT().Next().Once()
 
 	middleware := CheckForMaintenanceMode()
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_StorageFilePermissionIssue() {
@@ -152,7 +152,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_StorageFilePermissionIssue() {
 
 	middleware := CheckForMaintenanceMode()
 	assert.PanicsWithError(s.T(), err.Error(), func() {
-		middleware(s.mockCtx)
+		middleware.Handle(s.mockCtx)
 	})
 }
 
@@ -168,7 +168,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_StorageFileInvalidJSON() {
 
 	middleware := CheckForMaintenanceMode()
 	assert.PanicsWithError(s.T(), err.Error(), func() {
-		middleware(s.mockCtx)
+		middleware.Handle(s.mockCtx)
 	})
 }
 
@@ -184,7 +184,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_SecretDoesNotMatch() {
 	s.mockResponse.EXPECT().String(contractshttp.StatusServiceUnavailable, "Under Maintenance").Return(s.mockAbortableResponse).Once()
 
 	middleware := CheckForMaintenanceMode()
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_SecretMatches() {
@@ -197,7 +197,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_SecretMatches() {
 	s.mockStorage.EXPECT().GetBytes("framework/maintenance.json").Return([]byte(`{"secret":"hashed-secret", "reason": "Under Maintenance", "status": 503}`), nil).Once()
 
 	middleware := CheckForMaintenanceMode()
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_Redirect() {
@@ -212,7 +212,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_Redirect() {
 	s.mockAbortableResponse.EXPECT().Abort().Return(nil).Once()
 
 	middleware := CheckForMaintenanceMode()
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_Render() {
@@ -231,7 +231,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_Render() {
 	s.mockCtx.EXPECT().Response().Return(s.mockResponse).Once()
 
 	middleware := CheckForMaintenanceMode()
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_CacheDriver() {
@@ -245,7 +245,7 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_CacheDriver() {
 	s.mockResponse.EXPECT().String(contractshttp.StatusServiceUnavailable, "Under Maintenance").Return(s.mockAbortableResponse).Once()
 
 	middleware := CheckForMaintenanceMode()
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *MaintenanceTestSuite) TestMaintenaneMode_NamedCacheStore() {
@@ -266,5 +266,5 @@ func (s *MaintenanceTestSuite) TestMaintenaneMode_NamedCacheStore() {
 	s.mockResponse.EXPECT().String(contractshttp.StatusServiceUnavailable, "Under Maintenance").Return(s.mockAbortableResponse).Once()
 
 	middleware := CheckForMaintenanceMode()
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }

--- a/http/middleware/throttle.go
+++ b/http/middleware/throttle.go
@@ -23,45 +23,55 @@ const (
 	HeaderRetryAfter = "Retry-After"
 )
 
-func Throttle(name string) httpcontract.Middleware {
-	return func(ctx httpcontract.Context) {
-		logFacade := http.App.MakeLog()
-		rateLimiterFacade := http.App.MakeRateLimiter()
+type throttleMiddleware struct {
+	name string
+}
 
-		if logFacade == nil {
-			panic(errors.LogFacadeNotSet)
-		}
+func (t *throttleMiddleware) Signature() string {
+	return "throttle:" + t.name
+}
 
-		if rateLimiterFacade == nil {
-			panic(errors.RateLimiterFacadeNotSet)
-		}
+func (t *throttleMiddleware) Handle(ctx httpcontract.Context) {
+	logFacade := http.App.MakeLog()
+	rateLimiterFacade := http.App.MakeRateLimiter()
 
-		if limiter := rateLimiterFacade.Limiter(name); limiter != nil {
-			if limits := limiter(ctx); len(limits) > 0 {
-				for index, limit := range limits {
-					tokens, remaining, reset, ok, err := limit.GetStore().Take(ctx, key(ctx, limit, name, index))
-					if err != nil {
-						logFacade.Error(errors.HttpRateLimitFailedToCheckThrottle.Args(err))
-						break
-					}
+	if logFacade == nil {
+		panic(errors.LogFacadeNotSet)
+	}
 
-					resetTime := carbon.FromTimestampNano(int64(reset)).SetTimezone(carbon.UTC)
-					retryAfter := carbon.Now().DiffInSeconds(resetTime)
-					ctx.Response().Header(HeaderRateLimitLimit, strconv.FormatUint(tokens, 10))
-					ctx.Response().Header(HeaderRateLimitRemaining, strconv.FormatUint(remaining, 10))
+	if rateLimiterFacade == nil {
+		panic(errors.RateLimiterFacadeNotSet)
+	}
 
-					if !ok {
-						ctx.Response().Header(HeaderRateLimitReset, strconv.Itoa(int(resetTime.Timestamp())))
-						ctx.Response().Header(HeaderRetryAfter, strconv.Itoa(int(retryAfter)))
-						response(ctx, limit)
-						return
-					}
+	if limiter := rateLimiterFacade.Limiter(t.name); limiter != nil {
+		if limits := limiter(ctx); len(limits) > 0 {
+			for index, limit := range limits {
+				tokens, remaining, reset, ok, err := limit.GetStore().Take(ctx, key(ctx, limit, t.name, index))
+				if err != nil {
+					logFacade.Error(errors.HttpRateLimitFailedToCheckThrottle.Args(err))
+					break
+				}
+
+				resetTime := carbon.FromTimestampNano(int64(reset)).SetTimezone(carbon.UTC)
+				retryAfter := carbon.Now().DiffInSeconds(resetTime)
+				ctx.Response().Header(HeaderRateLimitLimit, strconv.FormatUint(tokens, 10))
+				ctx.Response().Header(HeaderRateLimitRemaining, strconv.FormatUint(remaining, 10))
+
+				if !ok {
+					ctx.Response().Header(HeaderRateLimitReset, strconv.Itoa(int(resetTime.Timestamp())))
+					ctx.Response().Header(HeaderRetryAfter, strconv.Itoa(int(retryAfter)))
+					response(ctx, limit)
+					return
 				}
 			}
 		}
-
-		ctx.Request().Next()
 	}
+
+	ctx.Request().Next()
+}
+
+func Throttle(name string) httpcontract.Middleware {
+	return &throttleMiddleware{name: name}
 }
 
 func key(ctx httpcontract.Context, limit httpcontract.Limit, name string, index int) string {

--- a/http/middleware/throttle.go
+++ b/http/middleware/throttle.go
@@ -28,7 +28,7 @@ type throttleMiddleware struct {
 }
 
 func (t *throttleMiddleware) Signature() string {
-	return "throttle:" + t.name
+	return "goravel:throttle:" + t.name
 }
 
 func (t *throttleMiddleware) Handle(ctx httpcontract.Context) {

--- a/http/middleware/throttle_test.go
+++ b/http/middleware/throttle_test.go
@@ -53,7 +53,7 @@ func (s *ThrottleTestSuite) TestThrottle_NoLimiterFound() {
 	s.mockRequest.EXPECT().Next().Once()
 
 	middleware := Throttle("test")
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *ThrottleTestSuite) TestThrottle_LimiterReturnsEmptyLimits() {
@@ -66,7 +66,7 @@ func (s *ThrottleTestSuite) TestThrottle_LimiterReturnsEmptyLimits() {
 	s.mockRequest.EXPECT().Next().Once()
 
 	middleware := Throttle("test")
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *ThrottleTestSuite) TestThrottle_RequestAllowed() {
@@ -93,7 +93,7 @@ func (s *ThrottleTestSuite) TestThrottle_RequestAllowed() {
 	s.mockResponse.EXPECT().Header("X-RateLimit-Remaining", "9").Return(s.mockResponse).Once()
 
 	middleware := Throttle("api")
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *ThrottleTestSuite) TestThrottle_RequestAllowedWithCustomKey() {
@@ -117,7 +117,7 @@ func (s *ThrottleTestSuite) TestThrottle_RequestAllowedWithCustomKey() {
 	s.mockResponse.EXPECT().Header("X-RateLimit-Remaining", "59").Return(s.mockResponse).Once()
 
 	middleware := Throttle("api")
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *ThrottleTestSuite) TestThrottle_RequestRateLimited() {
@@ -150,7 +150,7 @@ func (s *ThrottleTestSuite) TestThrottle_RequestRateLimited() {
 	s.mockLimit.EXPECT().GetResponse().Return(nil).Once()
 
 	middleware := Throttle("api")
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *ThrottleTestSuite) TestThrottle_RequestRateLimitedWithCustomCallback() {
@@ -184,7 +184,7 @@ func (s *ThrottleTestSuite) TestThrottle_RequestRateLimitedWithCustomCallback() 
 	s.mockLimit.EXPECT().GetResponse().Return(customCallback).Once()
 
 	middleware := Throttle("api")
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 
 	s.True(callbackCalled)
 }
@@ -210,7 +210,7 @@ func (s *ThrottleTestSuite) TestThrottle_StoreTakeError() {
 	s.mockLog.EXPECT().Error(errors.HttpRateLimitFailedToCheckThrottle.Args(assert.AnError)).Once()
 
 	middleware := Throttle("api")
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 func (s *ThrottleTestSuite) TestThrottle_MultipleLimits() {
@@ -245,7 +245,7 @@ func (s *ThrottleTestSuite) TestThrottle_MultipleLimits() {
 	s.mockResponse.EXPECT().Header("X-RateLimit-Remaining", "99").Return(s.mockResponse).Once()
 
 	middleware := Throttle("api")
-	middleware(s.mockCtx)
+	middleware.Handle(s.mockCtx)
 }
 
 type KeyTestSuite struct {

--- a/http/middleware/verify_csrf_token.go
+++ b/http/middleware/verify_csrf_token.go
@@ -11,15 +11,15 @@ import (
 
 const HeaderCsrfKey = "X-CSRF-TOKEN"
 
-type Csrf struct {
+type csrf struct {
 	exceptPaths []string
 }
 
-func (c *Csrf) Signature() string {
+func (c *csrf) Signature() string {
 	return "verify_csrf_token"
 }
 
-func (c *Csrf) Handle(ctx contractshttp.Context) {
+func (c *csrf) Handle(ctx contractshttp.Context) {
 	if isReading(ctx.Request().Method()) || isExcept(c.exceptPaths, ctx.Request().Path()) || isTokenMatch(ctx) {
 		ctx.Response().Header(HeaderCsrfKey, ctx.Request().Session().Token())
 		ctx.Request().Next()
@@ -34,7 +34,7 @@ func VerifyCsrfToken(excepts ...[]string) contractshttp.Middleware {
 		exceptPaths = parseExceptPaths(excepts[0])
 	}
 
-	return &Csrf{exceptPaths: exceptPaths}
+	return &csrf{exceptPaths: exceptPaths}
 }
 
 func isTokenMatch(ctx contractshttp.Context) bool {

--- a/http/middleware/verify_csrf_token.go
+++ b/http/middleware/verify_csrf_token.go
@@ -11,20 +11,30 @@ import (
 
 const HeaderCsrfKey = "X-CSRF-TOKEN"
 
+type Csrf struct {
+	exceptPaths []string
+}
+
+func (c *Csrf) Signature() string {
+	return "verify_csrf_token"
+}
+
+func (c *Csrf) Handle(ctx contractshttp.Context) {
+	if isReading(ctx.Request().Method()) || isExcept(c.exceptPaths, ctx.Request().Path()) || isTokenMatch(ctx) {
+		ctx.Response().Header(HeaderCsrfKey, ctx.Request().Session().Token())
+		ctx.Request().Next()
+	} else {
+		ctx.Request().Abort(contractshttp.StatusTokenMismatch)
+	}
+}
+
 func VerifyCsrfToken(excepts ...[]string) contractshttp.Middleware {
 	var exceptPaths []string
 	if len(excepts) > 0 {
 		exceptPaths = parseExceptPaths(excepts[0])
 	}
 
-	return func(ctx contractshttp.Context) {
-		if isReading(ctx.Request().Method()) || isExcept(exceptPaths, ctx.Request().Path()) || isTokenMatch(ctx) {
-			ctx.Response().Header(HeaderCsrfKey, ctx.Request().Session().Token())
-			ctx.Request().Next()
-		} else {
-			ctx.Request().Abort(contractshttp.StatusTokenMismatch)
-		}
-	}
+	return &Csrf{exceptPaths: exceptPaths}
 }
 
 func isTokenMatch(ctx contractshttp.Context) bool {

--- a/http/middleware/verify_csrf_token.go
+++ b/http/middleware/verify_csrf_token.go
@@ -16,7 +16,7 @@ type csrf struct {
 }
 
 func (c *csrf) Signature() string {
-	return "verify_csrf_token"
+	return "goravel:verify_csrf_token"
 }
 
 func (c *csrf) Handle(ctx contractshttp.Context) {

--- a/mocks/http/Middleware.go
+++ b/mocks/http/Middleware.go
@@ -20,36 +20,81 @@ func (_m *Middleware) EXPECT() *Middleware_Expecter {
 	return &Middleware_Expecter{mock: &_m.Mock}
 }
 
-// Execute provides a mock function with given fields: _a0
-func (_m *Middleware) Execute(_a0 http.Context) {
+// Handle provides a mock function with given fields: _a0
+func (_m *Middleware) Handle(_a0 http.Context) {
 	_m.Called(_a0)
 }
 
-// Middleware_Execute_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Execute'
-type Middleware_Execute_Call struct {
+// Middleware_Handle_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Handle'
+type Middleware_Handle_Call struct {
 	*mock.Call
 }
 
-// Execute is a helper method to define mock.On call
+// Handle is a helper method to define mock.On call
 //   - _a0 http.Context
-func (_e *Middleware_Expecter) Execute(_a0 interface{}) *Middleware_Execute_Call {
-	return &Middleware_Execute_Call{Call: _e.mock.On("Execute", _a0)}
+func (_e *Middleware_Expecter) Handle(_a0 interface{}) *Middleware_Handle_Call {
+	return &Middleware_Handle_Call{Call: _e.mock.On("Handle", _a0)}
 }
 
-func (_c *Middleware_Execute_Call) Run(run func(_a0 http.Context)) *Middleware_Execute_Call {
+func (_c *Middleware_Handle_Call) Run(run func(_a0 http.Context)) *Middleware_Handle_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(http.Context))
 	})
 	return _c
 }
 
-func (_c *Middleware_Execute_Call) Return() *Middleware_Execute_Call {
+func (_c *Middleware_Handle_Call) Return() *Middleware_Handle_Call {
 	_c.Call.Return()
 	return _c
 }
 
-func (_c *Middleware_Execute_Call) RunAndReturn(run func(http.Context)) *Middleware_Execute_Call {
+func (_c *Middleware_Handle_Call) RunAndReturn(run func(http.Context)) *Middleware_Handle_Call {
 	_c.Run(run)
+	return _c
+}
+
+// Signature provides a mock function with no fields
+func (_m *Middleware) Signature() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Signature")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// Middleware_Signature_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Signature'
+type Middleware_Signature_Call struct {
+	*mock.Call
+}
+
+// Signature is a helper method to define mock.On call
+func (_e *Middleware_Expecter) Signature() *Middleware_Signature_Call {
+	return &Middleware_Signature_Call{Call: _e.mock.On("Signature")}
+}
+
+func (_c *Middleware_Signature_Call) Run(run func()) *Middleware_Signature_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Middleware_Signature_Call) Return(_a0 string) *Middleware_Signature_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Middleware_Signature_Call) RunAndReturn(run func() string) *Middleware_Signature_Call {
+	_c.Call.Return(run)
 	return _c
 }
 

--- a/session/middleware/start_session.go
+++ b/session/middleware/start_session.go
@@ -9,7 +9,7 @@ import (
 type startSessionMiddleware struct{}
 
 func (s *startSessionMiddleware) Signature() string {
-	return "start_session"
+	return "goravel:start_session"
 }
 
 func (s *startSessionMiddleware) Handle(ctx http.Context) {

--- a/session/middleware/start_session.go
+++ b/session/middleware/start_session.go
@@ -6,50 +6,50 @@ import (
 	"github.com/goravel/framework/support/color"
 )
 
-func StartSession() http.Middleware {
-	return func(ctx http.Context) {
-		req := ctx.Request()
+type startSessionMiddleware struct{}
 
-		// Check if session exists
-		if req.HasSession() || session.ConfigFacade.GetString("session.default") == "" {
-			req.Next()
-			return
-		}
+func (s *startSessionMiddleware) Signature() string {
+	return "start_session"
+}
 
-		// Retrieve session driver
-		driver, err := session.SessionFacade.Driver()
-		if err != nil {
-			color.Errorln(err)
-			req.Next()
-			return
-		}
+func (s *startSessionMiddleware) Handle(ctx http.Context) {
+	req := ctx.Request()
 
-		// Build session
-		s, err := session.SessionFacade.BuildSession(driver)
-		if err != nil {
-			color.Errorln(err)
-			req.Next()
-			return
-		}
-
-		s.SetID(req.Cookie(s.GetName()))
-
-		// Start session
-		s.Start()
-		req.SetSession(s)
-
-		// Set session cookie in response
-		session.WriteCookie(ctx, s)
-
-		// Continue processing request
+	if req.HasSession() || session.ConfigFacade.GetString("session.default") == "" {
 		req.Next()
-
-		// Save session
-		if err = s.Save(); err != nil {
-			color.Errorf("Error saving session: %s\n", err)
-		}
-
-		// Release session
-		session.SessionFacade.ReleaseSession(s)
+		return
 	}
+
+	driver, err := session.SessionFacade.Driver()
+	if err != nil {
+		color.Errorln(err)
+		req.Next()
+		return
+	}
+
+	sess, err := session.SessionFacade.BuildSession(driver)
+	if err != nil {
+		color.Errorln(err)
+		req.Next()
+		return
+	}
+
+	sess.SetID(req.Cookie(sess.GetName()))
+
+	sess.Start()
+	req.SetSession(sess)
+
+	session.WriteCookie(ctx, sess)
+
+	req.Next()
+
+	if err = sess.Save(); err != nil {
+		color.Errorf("Error saving session: %s\n", err)
+	}
+
+	session.SessionFacade.ReleaseSession(sess)
+}
+
+func StartSession() http.Middleware {
+	return &startSessionMiddleware{}
 }

--- a/session/middleware/start_session_test.go
+++ b/session/middleware/start_session_test.go
@@ -23,7 +23,7 @@ import (
 func testHttpSessionMiddleware(next nethttp.Handler, mockConfig *configmocks.Config) nethttp.Handler {
 	return nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
 		mockConfigFacade(mockConfig)
-		StartSession()(NewTestContext(r.Context(), next, w, r))
+		StartSession().Handle(NewTestContext(r.Context(), next, w, r))
 	})
 }
 

--- a/telemetry/instrumentation/http/middleware.go
+++ b/telemetry/instrumentation/http/middleware.go
@@ -28,7 +28,7 @@ const (
 
 type disabledTelemetry struct{}
 
-func (d *disabledTelemetry) Signature() string { return "telemetry" }
+func (d *disabledTelemetry) Signature() string { return "goravel:telemetry" }
 func (d *disabledTelemetry) Handle(ctx http.Context) { ctx.Request().Next() }
 
 // Telemetry creates HTTP server telemetry middleware that instruments incoming
@@ -102,7 +102,7 @@ type MiddlewareHandler struct {
 	excludedMethods map[string]bool
 }
 
-func (r *MiddlewareHandler) Signature() string { return "telemetry" }
+func (r *MiddlewareHandler) Signature() string { return "goravel:telemetry" }
 
 func (r *MiddlewareHandler) Handle(ctx http.Context) {
 	req := ctx.Request()

--- a/telemetry/instrumentation/http/middleware.go
+++ b/telemetry/instrumentation/http/middleware.go
@@ -28,7 +28,7 @@ const (
 
 type disabledTelemetry struct{}
 
-func (d *disabledTelemetry) Signature() string { return "telemetry_disabled" }
+func (d *disabledTelemetry) Signature() string { return "telemetry" }
 func (d *disabledTelemetry) Handle(ctx http.Context) { ctx.Request().Next() }
 
 // Telemetry creates HTTP server telemetry middleware that instruments incoming

--- a/telemetry/instrumentation/http/middleware.go
+++ b/telemetry/instrumentation/http/middleware.go
@@ -26,6 +26,11 @@ const (
 	unitBytes   = "By"
 )
 
+type disabledTelemetry struct{}
+
+func (d *disabledTelemetry) Signature() string { return "telemetry_disabled" }
+func (d *disabledTelemetry) Handle(ctx http.Context) { ctx.Request().Next() }
+
 // Telemetry creates HTTP server telemetry middleware that instruments incoming
 // requests with tracing and metrics. The optional opts parameters allow
 // customizing the server configuration (such as span naming and enabling or
@@ -35,17 +40,13 @@ const (
 // initialized.
 func Telemetry(opts ...Option) http.Middleware {
 	if telemetry.ConfigFacade == nil || telemetry.Facade == nil {
-		return func(ctx http.Context) {
-			ctx.Request().Next()
-		}
+		return &disabledTelemetry{}
 	}
 
 	var cfg ServerConfig
 	if err := telemetry.ConfigFacade.UnmarshalKey("telemetry.instrumentation.http_server", &cfg); err != nil {
 		color.Warningln("Failed to load http server telemetry instrumentation config:", err)
-		return func(ctx http.Context) {
-			ctx.Request().Next()
-		}
+		return &disabledTelemetry{}
 	}
 
 	for _, opt := range opts {
@@ -53,9 +54,7 @@ func Telemetry(opts ...Option) http.Middleware {
 	}
 
 	if !cfg.Enabled {
-		return func(ctx http.Context) {
-			ctx.Request().Next()
-		}
+		return &disabledTelemetry{}
 	}
 
 	if cfg.SpanNameFormatter == nil {
@@ -87,7 +86,7 @@ func Telemetry(opts ...Option) http.Middleware {
 		excludedMethods:  excludedMethods,
 	}
 
-	return h.Handle
+	return h
 }
 
 type MiddlewareHandler struct {
@@ -102,6 +101,8 @@ type MiddlewareHandler struct {
 	excludedPaths   map[string]bool
 	excludedMethods map[string]bool
 }
+
+func (r *MiddlewareHandler) Signature() string { return "telemetry" }
 
 func (r *MiddlewareHandler) Handle(ctx http.Context) {
 	req := ctx.Request()

--- a/telemetry/instrumentation/http/middleware_test.go
+++ b/telemetry/instrumentation/http/middleware_test.go
@@ -169,8 +169,7 @@ func (s *MiddlewareTestSuite) TestTelemetry() {
 func testMiddleware(next nethttp.Handler, opts ...Option) nethttp.Handler {
 	mw := Telemetry(opts...)
 	return nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
-		ctx := NewTestContext(r.Context(), next, w, r)
-		mw(ctx)
+		mw.Handle(NewTestContext(r.Context(), next, w, r))
 	})
 }
 


### PR DESCRIPTION
## Summary
- `contractshttp.Middleware` changed from `func(Context)` to `interface{Handle(Context); Signature() string}` for stable middleware identity
- All framework middlewares now return structs with deterministic `Signature()` strings (e.g., `"throttle:api"`, `"check_for_maintenance_mode"`, `"telemetry"`)
- Artisan `make:middleware` generates the new struct-based pattern

## Why
The `WithoutMiddleware` feature in the gin and fiber route drivers uses `reflect.TypeOf` to identify which middleware to exclude. Since `contractshttp.Middleware` was a bare `func(Context)`, every middleware closure shared the same type — making `WithoutMiddleware(Cors())` silently exclude **all** middleware, not just `Cors()`. Go cannot distinguish closures via reflection.

Changing `Middleware` to an interface with a `Signature()` method gives every middleware a stable, comparable identity. The gin and fiber drivers can then compare `excluded.Signature() == current.Signature()` — a trivial string comparison that is always correct, even for parameterized middleware like `Throttle("api")` vs `Throttle("web")`.

```go
// Artisan make:middleware now generates:
// (no user code changes for framework-provided middlewares)

// Before: WithoutMiddleware(Cors()) silently excluded ALL middlewares
facades.Route().Middleware(Cors(), Timeout(3*time.Second)).Group(func(r route.Router) {
    r.Get("/api/internal", internalHandler).WithoutMiddleware(Cors())
    // BUG: both Cors() and Timeout(3s) were excluded
})

// After: only Cors() is excluded, Timeout(3s) still applies
facades.Route().Middleware(Cors(), Timeout(3*time.Second)).Group(func(r route.Router) {
    r.Get("/api/internal", internalHandler).WithoutMiddleware(Cors())
    // Correct: only Cors() excluded
})
```

This is a contract-level change. The gin and fiber route drivers must be updated separately to use `Signature()` comparison and call `.Handle()` instead of invoking middleware as a function.
