### PR TITLE
fix: reset database connections when the application rebuilds

### DIFF
--- a/database/driver/gorm.go
+++ b/database/driver/gorm.go
@@ -184,7 +184,6 @@ func CloseConnections() {
 		if cached.db == nil {
 			continue
 		}
-		// DB() is the writer pool; dbresolver replica pools are internal and not closed here.
 		if sqlDB, err := cached.db.DB(); err == nil {
 			if err := sqlDB.Close(); err != nil {
 				color.Warningln("close database connection: " + err.Error())

--- a/database/driver/gorm.go
+++ b/database/driver/gorm.go
@@ -149,12 +149,46 @@ func BuildGorm(config config.Config, logger logger.Interface, pool database.Pool
 	return instance, instrument, nil
 }
 
-func ResetConnections() {
+func drainConnections() []cachedConnection {
 	connectionToDBLock.Lock()
 	defer connectionToDBLock.Unlock()
 
+	var stale []cachedConnection
 	connectionToDB.Range(func(key, value any) bool {
+		if cached, ok := value.(cachedConnection); ok {
+			stale = append(stale, cached)
+		}
 		connectionToDB.Delete(key)
 		return true
 	})
+
+	return stale
+}
+
+// ResetConnections drops the cached connections so a later build reconnects with
+// the current configuration, and unregisters their pool-metrics callbacks. The
+// pools are left open because a caller may still hold the *gorm.DB; use
+// CloseConnections when the connections are known to be idle.
+func ResetConnections() {
+	for _, cached := range drainConnections() {
+		cached.instrument.Shutdown()
+	}
+}
+
+// CloseConnections drops the cached connections, unregisters their callbacks and
+// closes the pools. Call it only when the connections are idle (e.g. the database
+// provider's Register, which runs after app.Restart has stopped the runners).
+func CloseConnections() {
+	for _, cached := range drainConnections() {
+		cached.instrument.Shutdown()
+		if cached.db == nil {
+			continue
+		}
+		// DB() is the writer pool; dbresolver replica pools are internal and not closed here.
+		if sqlDB, err := cached.db.DB(); err == nil {
+			if err := sqlDB.Close(); err != nil {
+				color.Warningln("close database connection: " + err.Error())
+			}
+		}
+	}
 }

--- a/database/driver/gorm.go
+++ b/database/driver/gorm.go
@@ -165,19 +165,16 @@ func drainConnections() []cachedConnection {
 	return stale
 }
 
-// ResetConnections drops the cached connections so a later build reconnects with
-// the current configuration, and unregisters their pool-metrics callbacks. The
-// pools are left open because a caller may still hold the *gorm.DB; use
-// CloseConnections when the connections are known to be idle.
+// ResetConnections drops the cached connections and unregisters their telemetry,
+// leaving the pools open for callers that may still hold the *gorm.DB.
 func ResetConnections() {
 	for _, cached := range drainConnections() {
 		cached.instrument.Shutdown()
 	}
 }
 
-// CloseConnections drops the cached connections, unregisters their callbacks and
-// closes the pools. Call it only when the connections are idle (e.g. the database
-// provider's Register, which runs after app.Restart has stopped the runners).
+// CloseConnections drops the cached connections, unregisters their telemetry and
+// closes the pools. Call it only when the connections are idle.
 func CloseConnections() {
 	for _, cached := range drainConnections() {
 		cached.instrument.Shutdown()
@@ -186,7 +183,7 @@ func CloseConnections() {
 		}
 		if sqlDB, err := cached.db.DB(); err == nil {
 			if err := sqlDB.Close(); err != nil {
-				color.Warningln("close database connection: " + err.Error())
+				color.Warningln("database: close connection: " + err.Error())
 			}
 		}
 	}

--- a/database/driver/gorm_test.go
+++ b/database/driver/gorm_test.go
@@ -60,10 +60,10 @@ func TestResetConnections_KeepsPoolOpen(t *testing.T) {
 
 	ResetConnections()
 
-	// The pool is dropped from the cache but left open for any caller still holding it.
-	if err := sqlDB.Ping(); err != nil {
-		assert.NotContains(t, err.Error(), "database is closed")
-	}
+	// The pool is dropped from the cache but not closed (a caller may still hold it).
+	err = sqlDB.Ping()
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "database is closed")
 
 	// The next build reconnects instead of returning the dropped instance.
 	second, _, err := BuildGorm(stubGormConfig(t), gormlogger.Discard, stubPool(), "primary", resolver)

--- a/database/driver/gorm_test.go
+++ b/database/driver/gorm_test.go
@@ -57,18 +57,33 @@ func TestResetConnections_KeepsPoolOpen(t *testing.T) {
 	assert.NoError(t, err)
 	sqlDB, err := first.DB()
 	assert.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
 
 	ResetConnections()
 
-	// The pool is dropped from the cache but not closed (a caller may still hold it).
 	err = sqlDB.Ping()
 	assert.Error(t, err)
 	assert.NotContains(t, err.Error(), "database is closed")
 
-	// The next build reconnects instead of returning the dropped instance.
 	second, _, err := BuildGorm(stubGormConfig(t), gormlogger.Discard, stubPool(), "primary", resolver)
 	assert.NoError(t, err)
 	assert.NotSame(t, first, second)
+}
+
+func TestResetConnections_NilInstrument(t *testing.T) {
+	t.Cleanup(CloseConnections)
+
+	config := mocksconfig.NewConfig(t)
+	config.EXPECT().GetInt("database.pool.max_idle_conns", 10).Return(10).Once()
+	config.EXPECT().GetInt("database.pool.max_open_conns", 100).Return(100).Once()
+	config.EXPECT().GetDuration("database.pool.conn_max_idletime", time.Duration(3600)).Return(time.Duration(3600)).Once()
+	config.EXPECT().GetDuration("database.pool.conn_max_lifetime", time.Duration(3600)).Return(time.Duration(3600)).Once()
+
+	_, instrument, err := BuildGorm(config, gormlogger.Discard, stubPool(), "primary", nil)
+	assert.NoError(t, err)
+	assert.Nil(t, instrument)
+
+	assert.NotPanics(t, ResetConnections)
 }
 
 type stubConnector struct{}

--- a/database/driver/gorm_test.go
+++ b/database/driver/gorm_test.go
@@ -35,6 +35,42 @@ func TestBuildGorm_TelemetryPlugin(t *testing.T) {
 	assert.True(t, registered)
 }
 
+func TestCloseConnections_ClosesPool(t *testing.T) {
+	t.Cleanup(CloseConnections)
+
+	resolver := func() contractstelemetry.Telemetry { return nil }
+	instance, _, err := BuildGorm(stubGormConfig(t), gormlogger.Discard, stubPool(), "primary", resolver)
+	assert.NoError(t, err)
+	sqlDB, err := instance.DB()
+	assert.NoError(t, err)
+
+	CloseConnections()
+
+	assert.ErrorContains(t, sqlDB.Ping(), "database is closed")
+}
+
+func TestResetConnections_KeepsPoolOpen(t *testing.T) {
+	t.Cleanup(CloseConnections)
+
+	resolver := func() contractstelemetry.Telemetry { return nil }
+	first, _, err := BuildGorm(stubGormConfig(t), gormlogger.Discard, stubPool(), "primary", resolver)
+	assert.NoError(t, err)
+	sqlDB, err := first.DB()
+	assert.NoError(t, err)
+
+	ResetConnections()
+
+	// The pool is dropped from the cache but left open for any caller still holding it.
+	if err := sqlDB.Ping(); err != nil {
+		assert.NotContains(t, err.Error(), "database is closed")
+	}
+
+	// The next build reconnects instead of returning the dropped instance.
+	second, _, err := BuildGorm(stubGormConfig(t), gormlogger.Discard, stubPool(), "primary", resolver)
+	assert.NoError(t, err)
+	assert.NotSame(t, first, second)
+}
+
 type stubConnector struct{}
 
 func (stubConnector) Connect(context.Context) (driver.Conn, error) { return nil, driver.ErrBadConn }

--- a/database/service_provider.go
+++ b/database/service_provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goravel/framework/database/console"
 	consolemigration "github.com/goravel/framework/database/console/migration"
 	"github.com/goravel/framework/database/db"
+	databasedriver "github.com/goravel/framework/database/driver"
 	"github.com/goravel/framework/database/migration"
 	databaseorm "github.com/goravel/framework/database/orm"
 	databaseschema "github.com/goravel/framework/database/schema"
@@ -40,6 +41,11 @@ func (r *ServiceProvider) Relationship() contractsbinding.Relationship {
 }
 
 func (r *ServiceProvider) Register(app foundation.Application) {
+	// Release cached connections so a rebuild (e.g. app.Restart) reconnects using
+	// the current configuration. Register runs after the runners are stopped, so
+	// closing the idle pools here is safe.
+	databasedriver.CloseConnections()
+
 	app.Singleton(contractsbinding.Orm, func(app foundation.Application) (any, error) {
 		ctx := context.Background()
 		config := app.MakeConfig()

--- a/database/service_provider.go
+++ b/database/service_provider.go
@@ -41,8 +41,7 @@ func (r *ServiceProvider) Relationship() contractsbinding.Relationship {
 }
 
 func (r *ServiceProvider) Register(app foundation.Application) {
-	// Release cached connections so a rebuild (e.g. app.Restart) reconnects with
-	// the current config. Register runs after the runners stop, so closing is safe.
+	// Reconnect on a rebuild (e.g. app.Restart) using the current configuration.
 	databasedriver.CloseConnections()
 
 	app.Singleton(contractsbinding.Orm, func(app foundation.Application) (any, error) {

--- a/database/service_provider.go
+++ b/database/service_provider.go
@@ -41,9 +41,8 @@ func (r *ServiceProvider) Relationship() contractsbinding.Relationship {
 }
 
 func (r *ServiceProvider) Register(app foundation.Application) {
-	// Release cached connections so a rebuild (e.g. app.Restart) reconnects using
-	// the current configuration. Register runs after the runners are stopped, so
-	// closing the idle pools here is safe.
+	// Release cached connections so a rebuild (e.g. app.Restart) reconnects with
+	// the current config. Register runs after the runners stop, so closing is safe.
 	databasedriver.CloseConnections()
 
 	app.Singleton(contractsbinding.Orm, func(app foundation.Application) (any, error) {

--- a/telemetry/instrumentation/database/database.go
+++ b/telemetry/instrumentation/database/database.go
@@ -54,7 +54,8 @@ type Instrument struct {
 	poolRegistration metric.Registration
 }
 
-// Shutdown unregisters the pool-metrics callback.
+// Shutdown unregisters the pool-metrics callback and clears the resolved
+// telemetry so the next use re-resolves against the current provider.
 func (r *Instrument) Shutdown() {
 	if r == nil {
 		return
@@ -65,6 +66,10 @@ func (r *Instrument) Shutdown() {
 		_ = r.poolRegistration.Unregister()
 		r.poolRegistration = nil
 	}
+	r.tracer = nil
+	r.meter = nil
+	r.durationHist = nil
+	r.poolObserved = false
 }
 
 // SetDB stores the primary writer's *sql.DB for pool metrics.

--- a/telemetry/instrumentation/database/database.go
+++ b/telemetry/instrumentation/database/database.go
@@ -49,8 +49,22 @@ type Instrument struct {
 	meter        metric.Meter
 	durationHist metric.Float64Histogram
 
-	sqlDB        *sql.DB
-	poolObserved bool
+	sqlDB            *sql.DB
+	poolObserved     bool
+	poolRegistration metric.Registration
+}
+
+// Shutdown unregisters the pool-metrics callback.
+func (r *Instrument) Shutdown() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.poolRegistration != nil {
+		_ = r.poolRegistration.Unregister()
+		r.poolRegistration = nil
+	}
 }
 
 // SetDB stores the primary writer's *sql.DB for pool metrics.

--- a/telemetry/instrumentation/database/pool.go
+++ b/telemetry/instrumentation/database/pool.go
@@ -37,13 +37,18 @@ func (r *Instrument) observePool(db *sql.DB) error {
 	used := metric.WithAttributes(append(slices.Clone(r.baseAttrs), semconv.DBClientConnectionStateUsed)...)
 	base := metric.WithAttributes(r.baseAttrs...)
 
-	_, err = r.meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
+	registration, err := r.meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
 		stats := db.Stats()
 		observer.ObserveInt64(count, int64(stats.InUse), used)
 		observer.ObserveInt64(count, int64(stats.Idle), idle)
 		observer.ObserveInt64(maxConns, int64(stats.MaxOpenConnections), base)
 		return nil
 	}, count, maxConns)
+	if err != nil {
+		return err
+	}
 
-	return err
+	r.poolRegistration = registration
+
+	return nil
 }

--- a/telemetry/instrumentation/database/pool_test.go
+++ b/telemetry/instrumentation/database/pool_test.go
@@ -68,6 +68,16 @@ func (s *PoolMetricsTestSuite) TestRegistersAllMetrics() {
 	}
 }
 
+func (s *PoolMetricsTestSuite) TestShutdownUnregistersCallback() {
+	s.Require().NoError(s.inst.observePool(s.db))
+	s.Contains(s.collect(), metricConnectionCount)
+
+	s.inst.Shutdown()
+
+	// Once the callback is unregistered the pool is no longer observed.
+	s.NotContains(s.collect(), metricConnectionCount)
+}
+
 func (s *PoolMetricsTestSuite) TestConnectionCountHasIdleAndUsedStates() {
 	s.Require().NoError(s.inst.observePool(s.db))
 


### PR DESCRIPTION
## 📑 Description

The database connection cache (`connectionToDB` in `database/driver`) is process-global and survives `app.Restart()`. `Restart` rebuilds the container, but the cached `*gorm.DB` and its `Instrument` live outside the container, so a rebuilt application keeps connections created under the previous configuration. With telemetry enabled this also means spans are emitted under the tracer the connection was first built with, not the current one.

**What is changing:**

* The database `ServiceProvider.Register` resets the connection cache before registering the bindings. `Register` runs on every build, so a restart reconnects with the current configuration. On the initial boot the cache is empty, so this is a no-op.
* The reset API is split so the behavior is safe under different callers:
  * `ResetConnections()` drops the cache and unregisters each `Instrument`'s pool-metrics callback, but leaves the pools open (a caller may still hold the returned `*gorm.DB`). This is what `Orm.Fresh()` uses at runtime.
  * `CloseConnections()` additionally closes each pool, and is called by `Register`. `Register` runs after `app.Shutdown()` has stopped the runners, so the pools are idle and safe to close.

**Resolves the review feedback from the previous attempt:**

* Pool leak: a rebuild now closes the previous pools via `CloseConnections` instead of leaking them.
* Close race: closing only happens on the quiesced restart path; the runtime `Orm.Fresh` path only drops, so a `*gorm.DB` handed out by `BuildGorm`'s lock-free fast path is never closed under a caller.
* Close errors: surfaced with `color.Warningln` instead of being swallowed.
* Metrics callback leak: `Instrument` now stores the `metric.Registration` and exposes `Shutdown()`, which unregisters it; both reset paths call it so a discarded `Instrument` stops observing (and referencing) its pool.

This supersedes #1509 (that branch had a polluted history).

## ✅ Checks

- [x] Added test cases for my code
