### PR TITLE
fix: return the requested key on a translation miss instead of a stale cached key

### DIFF
--- a/translation/translator.go
+++ b/translation/translator.go
@@ -24,7 +24,6 @@ type Translator struct {
 	selector   *MessageSelector
 	locale     string
 	fallback   string
-	key        string
 	mu         sync.Mutex
 }
 
@@ -72,10 +71,6 @@ func (t *Translator) Choice(key string, number int, options ...translationcontra
 }
 
 func (t *Translator) Get(key string, options ...translationcontract.Option) string {
-	if t.key == "" {
-		t.key = key
-	}
-
 	locale := t.CurrentLocale()
 	// Check if a custom locale is provided in options.
 	if len(options) > 0 && options[0].Locale != "" {
@@ -118,7 +113,7 @@ func (t *Translator) Get(key string, options ...translationcontract.Option) stri
 	}
 
 	// Return the original key if no translation is found.
-	return t.key
+	return key
 }
 
 func (t *Translator) GetFallback() string {
@@ -167,10 +162,10 @@ func (t *Translator) getLine(locale string, group string, key string, options ..
 			return ""
 		}
 		if errors.Is(err, errors.LangNoLoaderAvailable) {
-			return t.key
+			return ""
 		}
 		t.logger.Panic(err)
-		return t.key
+		return ""
 	}
 
 	keyValue := getValue(loaded[locale][group], key)

--- a/translation/translator_test.go
+++ b/translation/translator_test.go
@@ -310,9 +310,9 @@ func (s *TranslatorTestSuite) TestHas() {
 
 	// Case: Reused translator with distinct missing keys
 	translator = NewTranslator(s.ctx, nil, s.mockLoader, "en", "en", s.mockLog)
-	s.mockLoader.On("Load", "en", "*").Times(3).Return(map[string]any{}, errors.LangFileNotExist)
-	s.mockLoader.On("Load", "en", "account").Once().Return(map[string]any{"name": "Bowen"}, nil)
-	s.mockLoader.On("Load", "en", "post").Once().Return(map[string]any{"title": "Hello"}, nil)
+	s.mockLoader.EXPECT().Load("en", "*").Return(map[string]any{}, errors.LangFileNotExist).Times(3)
+	s.mockLoader.EXPECT().Load("en", "account").Return(map[string]any{"name": "Bowen"}, nil).Once()
+	s.mockLoader.EXPECT().Load("en", "post").Return(map[string]any{"title": "Hello"}, nil).Once()
 	s.False(translator.Has("account.email"))
 	s.False(translator.Has("post.body"))
 	s.Equal("post.body", translator.Get("post.body"))

--- a/translation/translator_test.go
+++ b/translation/translator_test.go
@@ -307,6 +307,15 @@ func (s *TranslatorTestSuite) TestHas() {
 		Locale: "fr",
 	})
 	s.True(hasKey)
+
+	// Case: Reused translator with distinct missing keys
+	translator = NewTranslator(s.ctx, nil, s.mockLoader, "en", "en", s.mockLog)
+	s.mockLoader.On("Load", "en", "*").Times(3).Return(map[string]any{}, errors.LangFileNotExist)
+	s.mockLoader.On("Load", "en", "account").Once().Return(map[string]any{"name": "Bowen"}, nil)
+	s.mockLoader.On("Load", "en", "post").Once().Return(map[string]any{"title": "Hello"}, nil)
+	s.False(translator.Has("account.email"))
+	s.False(translator.Has("post.body"))
+	s.Equal("post.body", translator.Get("post.body"))
 }
 
 func (s *TranslatorTestSuite) TestSetFallback() {


### PR DESCRIPTION
## Problem

`Translator` caches the first key it ever resolves in a `t.key` field and returns that cached key whenever a later lookup misses. A single `Translator` instance is reused across many lookups, so once the first key is cached, every following miss returns the **first** key's value instead of the requested one, and `Has()` reports `true` for keys that do not exist.

```go
func (t *Translator) Get(key string, options ...Option) string {
    if t.key == "" {
        t.key = key      // remembers the first key forever
    }
    ...
    return t.key         // returns the first key on every later miss
}
```

`getLine` has the same problem in its error branches (`return t.key`).

## Impact

Any code that holds a translator and queries more than one key is affected:

```go
lang := facades.Lang(ctx)

lang.Get("greeting")     // missing -> returns "greeting", caches t.key = "greeting"
lang.Has("user.email")   // missing -> BEFORE: true (wrong)   AFTER: false
lang.Get("user.email")   // missing -> BEFORE: "greeting"     AFTER: "user.email"
```

The most visible victim is validation, which resolves one translator and queries it for every failing field. With no published `validation` lang file, the first field gets the right message and every later field gets the first field's message:

```
age   -> "The age field must be an integer."   (correct, first key seen)
email -> "validation.integer"                  (wrong, leaked first key)
```

## What is changing

- `Get` returns the `key` parameter on a miss instead of the cached `t.key`.
- `getLine` returns `""` on its error branches and lets `Get` supply the original key.
- The `t.key` field is removed.

`getLine` only ever sees the bare item (`"email"`) in the group path, never the full key (`"user.email"`); `Get` is the only place that holds the full key, and its final `return key` already provides it, so the cached field is unnecessary.

## Example (after the fix)

```go
lang := facades.Lang(ctx)
lang.Get("user.email")   // "user.email"
lang.Get("post.title")   // "post.title"  (no longer "user.email")
lang.Has("post.title")   // false
```

## Tests

Extended `TestHas` with a reused-translator case that queries two distinct missing keys. It fails on the current code (`Get("post.body")` returns `"account.email"`) and passes with the fix. `go vet` and the full module unit test suite are green.
