### PR TITLE
feat: optimize v1.18.0

### DIFF
--- a/.github/workflows/test_example.yml
+++ b/.github/workflows/test_example.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  test-in-example:
+  unit:
     strategy:
       matrix:
         go: [ "1.25", "1.26" ]
@@ -52,4 +52,49 @@ jobs:
 
       - name: Run tests
         working-directory: example
-        run: go test -timeout 10m -p 1 ./...
+        run: go test -timeout 10m -run "^TestMainTestSuite$" . ./app/...
+
+  integration:
+    strategy:
+      matrix:
+        go: [ "1.25", "1.26" ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout framework
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: framework
+
+      - name: Checkout goravel/example
+        uses: actions/checkout@v7
+        with:
+          repository: goravel/example
+          ref: master
+          path: example
+
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Go mod cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('example/**/go.sum', 'framework/**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.go }}-
+
+      - name: Replace framework with local checkout
+        working-directory: example
+        run: |
+          go mod edit -replace github.com/goravel/framework=../framework
+          go mod tidy
+
+      - name: Run tests
+        working-directory: example
+        run: go test -timeout 10m ./tests/...

--- a/ai/setup/setup.go
+++ b/ai/setup/setup.go
@@ -16,6 +16,9 @@ func main() {
 	modulePath := setup.Paths().Module().Import()
 	aiServiceProvider := "&ai.ServiceProvider{}"
 	facadesPackage := setup.Paths().Facades().Package()
+	env := `
+AI_PROVIDER=
+`
 
 	setup.Install(
 		// Add the ai service provider to the providers array in bootstrap/providers.go
@@ -26,7 +29,12 @@ func main() {
 
 		// Add the AI facade
 		modify.File(aiFacadePath).Overwrite(stubs.AIFacade(facadesPackage)),
+
+		// Add configurations to the .env and .env.example files
+		modify.WhenFileExists(path.Base(".env"), modify.WhenFileNotContains(path.Base(".env"), "AI_PROVIDER", modify.File(path.Base(".env")).Append(env))),
+		modify.WhenFileExists(path.Base(".env.example"), modify.WhenFileNotContains(path.Base(".env.example"), "AI_PROVIDER", modify.File(path.Base(".env.example")).Append(env))),
 	).Uninstall(
+
 		// Remove the AI facade
 		modify.File(aiFacadePath).Remove(),
 

--- a/ai/setup/stubs.go
+++ b/ai/setup/stubs.go
@@ -19,7 +19,7 @@ func init() {
 		// Default AI Provider
 		//
 		// This option controls the default AI provider that will be used.
-		"default": "",
+		"default": config.Env("AI_PROVIDER"),
 
 		// AI Providers
 		//

--- a/log/writer.go
+++ b/log/writer.go
@@ -183,6 +183,13 @@ func (r *Writer) WithTrace() log.Writer {
 }
 
 func (r *Writer) log(level log.Level, msg string) {
+	if !r.logger.Enabled(r.ctx, slog.Level(level)) {
+		if r.entry != nil {
+			releaseEntry(r.entry)
+		}
+		return
+	}
+
 	entry := r.entry
 	if entry == nil {
 		// For direct log calls without fluent methods, acquire a fresh entry

--- a/log/writer_test.go
+++ b/log/writer_test.go
@@ -438,6 +438,41 @@ func TestWriter_LevelNotMatch(t *testing.T) {
 	assert.False(t, file.Contains(dailyLog, "test.debug: No Debug Goravel"))
 }
 
+func TestWriter_SingleChannelLevelNotMatch(t *testing.T) {
+
+	// This test verifies that with a single channel (no FanoutHandler wrapping),
+	// the Enabled() check in Writer.log() correctly filters log levels.
+	// This covers the exact scenario from issue #977: LOG_LEVEL=error but
+	// info logs still appear when the stack has only one channel.
+
+	mockConfig := mocksconfig.NewConfig(t)
+	mockConfig.EXPECT().GetString("logging.channels.daily.driver").Return("daily").Once()
+	mockConfig.EXPECT().GetString("logging.channels.daily.path").Return(singleLog).Once()
+	mockConfig.EXPECT().GetInt("logging.channels.daily.days").Return(7).Once()
+	mockConfig.EXPECT().GetBool("logging.channels.daily.print").Return(false).Once()
+	mockConfig.EXPECT().GetString("logging.channels.daily.level").Return("error").Once()
+	mockConfig.EXPECT().GetString("logging.channels.daily.formatter", "text").Return("text").Once()
+	// app.env is only called when Error is actually logged
+	mockConfig.EXPECT().GetString("app.env").Return("test").Once()
+
+	log, err := NewApplication(context.Background(), []string{"daily"}, mockConfig, json.New(), nil)
+	assert.Nil(t, err)
+
+	// Debug should be filtered out (level error > debug)
+	log.Debug("No Debug Goravel")
+	assert.False(t, file.Contains(dailyLog, "test.debug: No Debug Goravel"))
+
+	// Info should be filtered out (level error > info)
+	log.Info("No Info Goravel")
+	assert.False(t, file.Contains(dailyLog, "test.info: No Info Goravel"))
+
+	// Error should pass through (level error == error)
+	log.Error("Error Goravel")
+	assert.True(t, file.Contains(dailyLog, "test.error: Error Goravel"))
+
+	_ = file.Remove("storage")
+}
+
 func TestWriter_DailyLogWithDifferentDays(t *testing.T) {
 
 	mockConfig := initMockConfig(t)


### PR DESCRIPTION
## Summary
- Respect `LOG_LEVEL` configuration when writing log entries
- Logs below the configured level are now correctly filtered out

Closes https://github.com/goravel/goravel/issues/977

## Why
`Writer.log()` was calling `slog.Handler.Handle()` directly, bypassing the `Enabled()` level check entirely. When `slogmulti.Fanout` has a single handler (the default config with `stack` containing only `["daily"]`), it returns the handler unwrapped — so `FanoutHandler.Handle()`'s per-handler `Enabled()` checks never run. Setting `LOG_LEVEL=error` had no effect: info and debug messages were still written.

The fix adds `r.logger.Enabled()` at the top of `Writer.log()` so the configured log level is always consulted before writing any entry.

```go
// Before: LOG_LEVEL=error still logged info messages
facades.Log().Info("Example") // still logged despite LOG_LEVEL=error

// After: LOG_LEVEL is correctly respected
facades.Log().Info("Example") // filtered out when LOG_LEVEL=error
facades.Log().Error("Something went wrong") // still logged
```
