### PR TITLE
fix: resolve http telemetry middleware lazily

### DIFF
--- a/telemetry/instrumentation/http/middleware.go
+++ b/telemetry/instrumentation/http/middleware.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/codes"
@@ -28,7 +29,7 @@ const (
 
 type disabledTelemetry struct{}
 
-func (d *disabledTelemetry) Signature() string { return "goravel:telemetry" }
+func (d *disabledTelemetry) Signature() string       { return "goravel:telemetry" }
 func (d *disabledTelemetry) Handle(ctx http.Context) { ctx.Request().Next() }
 
 // Telemetry creates HTTP server telemetry middleware that instruments incoming
@@ -38,7 +39,31 @@ func (d *disabledTelemetry) Handle(ctx http.Context) { ctx.Request().Next() }
 // context, records spans and metrics when telemetry is enabled, and otherwise
 // transparently passes requests through when telemetry is disabled or not
 // initialized.
+//
+// The underlying handler is resolved lazily on the first request. The
+// application configures middleware before booting providers, so the telemetry
+// facade is not yet available when Telemetry is called; resolving eagerly would
+// permanently capture a disabled handler.
 func Telemetry(opts ...Option) http.Middleware {
+	return &lazyMiddleware{opts: opts}
+}
+
+type lazyMiddleware struct {
+	opts    []Option
+	once    sync.Once
+	handler http.Middleware
+}
+
+func (m *lazyMiddleware) Signature() string { return "goravel:telemetry" }
+
+func (m *lazyMiddleware) Handle(ctx http.Context) {
+	m.once.Do(func() {
+		m.handler = newTelemetry(m.opts...)
+	})
+	m.handler.Handle(ctx)
+}
+
+func newTelemetry(opts ...Option) http.Middleware {
 	if telemetry.ConfigFacade == nil || telemetry.Facade == nil {
 		return &disabledTelemetry{}
 	}


### PR DESCRIPTION
## Problem

RelatedTo https://github.com/goravel/goravel/issues/976

The HTTP server telemetry middleware silently emits no spans or metrics. `telemetryhttp.Telemetry()` resolves the telemetry facade at construction time and returns a no-op when the facade is nil:

```go
func Telemetry(opts ...Option) http.Middleware {
    if telemetry.ConfigFacade == nil || telemetry.Facade == nil {
        return &disabledTelemetry{}
    }
    ...
}
```

Middleware is configured before providers boot (`configureMiddleware()` runs before `providerRepository.Boot()`, see #1508), and the telemetry facade is set in the provider's `Boot()`. So `Telemetry()` always observes a nil facade and permanently installs the disabled handler. The framework's route-named spans (`GET /telemetry`) disappear; only otelhttp's generic `HTTP GET` remains.

## What is changing

`Telemetry()` now returns a small wrapper that builds the real handler lazily, on the first request, by which point the facade is available. The decision about whether telemetry is enabled is made once, at first use, instead of at construction.

```go
func Telemetry(opts ...Option) http.Middleware {
    return &lazyMiddleware{opts: opts}
}

func (m *lazyMiddleware) Handle(ctx http.Context) {
    m.once.Do(func() { m.handler = newTelemetry(m.opts...) })
    m.handler.Handle(ctx)
}
```

`newTelemetry` is the previous construction logic verbatim, so the enabled / disabled / config-error paths are unchanged. `Signature()` stays `"goravel:telemetry"`, so `WithoutMiddleware` comparison is unaffected.

## Verification

- `go test ./telemetry/...` passes.
- Against the goravel/example telemetry suite (goravel/example#130): `TestTraces` was failing on master (HTTP spans missing); with this change it passes in ~6s, with `GET /telemetry`, `GET /grpc/user`, and the DB `SELECT users` span all present under the expected service.
