### PR TITLE
fix: respect LOG_LEVEL in Writer.log()

### DIFF
--- a/log/writer.go
+++ b/log/writer.go
@@ -183,6 +183,13 @@ func (r *Writer) WithTrace() log.Writer {
 }
 
 func (r *Writer) log(level log.Level, msg string) {
+	if !r.logger.Enabled(r.ctx, slog.Level(level)) {
+		if r.entry != nil {
+			releaseEntry(r.entry)
+		}
+		return
+	}
+
 	entry := r.entry
 	if entry == nil {
 		// For direct log calls without fluent methods, acquire a fresh entry

--- a/log/writer_test.go
+++ b/log/writer_test.go
@@ -435,6 +435,42 @@ func TestWriter_LevelNotMatch(t *testing.T) {
 	assert.False(t, file.Contains(dailyLog, "test.debug: No Debug Goravel"))
 }
 
+func TestWriter_SingleChannelLevelNotMatch(t *testing.T) {
+
+	// This test verifies that with a single channel (no FanoutHandler wrapping),
+	// the Enabled() check in Writer.log() correctly filters log levels.
+	// This covers the exact scenario from issue #977: LOG_LEVEL=error but
+	// info logs still appear when the stack has only one channel.
+	clearChannelCache()
+
+	mockConfig := mocksconfig.NewConfig(t)
+	mockConfig.EXPECT().GetString("logging.channels.daily.driver").Return("daily").Once()
+	mockConfig.EXPECT().GetString("logging.channels.daily.path").Return(singleLog).Once()
+	mockConfig.EXPECT().GetInt("logging.channels.daily.days").Return(7).Once()
+	mockConfig.EXPECT().GetBool("logging.channels.daily.print").Return(false).Once()
+	mockConfig.EXPECT().GetString("logging.channels.daily.level").Return("error").Once()
+	mockConfig.EXPECT().GetString("logging.channels.daily.formatter", "text").Return("text").Once()
+	// app.env is only called when Error is actually logged
+	mockConfig.EXPECT().GetString("app.env").Return("test").Once()
+
+	log, err := NewApplication(context.Background(), []string{"daily"}, mockConfig, json.New())
+	assert.Nil(t, err)
+
+	// Debug should be filtered out (level error > debug)
+	log.Debug("No Debug Goravel")
+	assert.False(t, file.Contains(dailyLog, "test.debug: No Debug Goravel"))
+
+	// Info should be filtered out (level error > info)
+	log.Info("No Info Goravel")
+	assert.False(t, file.Contains(dailyLog, "test.info: No Info Goravel"))
+
+	// Error should pass through (level error == error)
+	log.Error("Error Goravel")
+	assert.True(t, file.Contains(dailyLog, "test.error: Error Goravel"))
+
+	_ = file.Remove("storage")
+}
+
 func TestWriter_DailyLogWithDifferentDays(t *testing.T) {
 	// Clear handler cache
 	clearChannelCache()


### PR DESCRIPTION
## Summary
- Respect `LOG_LEVEL` configuration when writing log entries
- Logs below the configured level are now correctly filtered out

Closes https://github.com/goravel/goravel/issues/977

## Why
`Writer.log()` was calling `slog.Handler.Handle()` directly, bypassing the `Enabled()` level check entirely. When `slogmulti.Fanout` has a single handler (the default config with `stack` containing only `["daily"]`), it returns the handler unwrapped — so `FanoutHandler.Handle()`'s per-handler `Enabled()` checks never run. Setting `LOG_LEVEL=error` had no effect: info and debug messages were still written.

The fix adds `r.logger.Enabled()` at the top of `Writer.log()` so the configured log level is always consulted before writing any entry.

```go
// Before: LOG_LEVEL=error still logged info messages
facades.Log().Info("Example") // still logged despite LOG_LEVEL=error

// After: LOG_LEVEL is correctly respected
facades.Log().Info("Example") // filtered out when LOG_LEVEL=error
facades.Log().Error("Something went wrong") // still logged
```