### PR TITLE
fix(notification): register notification manager as a singleton

### DIFF
--- a/notification/service_provider.go
+++ b/notification/service_provider.go
@@ -24,7 +24,7 @@ func (r *ServiceProvider) Relationship() binding.Relationship {
 }
 
 func (r *ServiceProvider) Register(app foundation.Application) {
-	app.Bind(binding.Notification, func(app foundation.Application) (any, error) {
+	app.Singleton(binding.Notification, func(app foundation.Application) (any, error) {
 		logger := app.MakeLog()
 		if logger == nil {
 			return nil, errors.LogFacadeNotSet.SetModule(errors.ModuleNotification)

--- a/notification/service_provider_test.go
+++ b/notification/service_provider_test.go
@@ -32,7 +32,7 @@ func TestServiceProviderRegister(t *testing.T) {
 
 	t.Run("log facade not set", func(t *testing.T) {
 		app := mocksfoundation.NewApplication(t)
-		app.EXPECT().Bind(binding.Notification, mock.AnythingOfType("func(foundation.Application) (interface {}, error)")).Run(func(_ any, callback func(contractsfoundation.Application) (any, error)) {
+		app.EXPECT().Singleton(binding.Notification, mock.AnythingOfType("func(foundation.Application) (interface {}, error)")).Run(func(_ any, callback func(contractsfoundation.Application) (any, error)) {
 			callbackApp := mocksfoundation.NewApplication(t)
 			callbackApp.EXPECT().MakeLog().Return(nil).Once()
 
@@ -48,7 +48,7 @@ func TestServiceProviderRegister(t *testing.T) {
 
 	t.Run("mail facade not set", func(t *testing.T) {
 		app := mocksfoundation.NewApplication(t)
-		app.EXPECT().Bind(binding.Notification, mock.AnythingOfType("func(foundation.Application) (interface {}, error)")).Run(func(_ any, callback func(contractsfoundation.Application) (any, error)) {
+		app.EXPECT().Singleton(binding.Notification, mock.AnythingOfType("func(foundation.Application) (interface {}, error)")).Run(func(_ any, callback func(contractsfoundation.Application) (any, error)) {
 			callbackApp := mocksfoundation.NewApplication(t)
 			logger := mockslog.NewLog(t)
 			callbackApp.EXPECT().MakeLog().Return(logger).Once()
@@ -66,7 +66,7 @@ func TestServiceProviderRegister(t *testing.T) {
 
 	t.Run("orm facade not set", func(t *testing.T) {
 		app := mocksfoundation.NewApplication(t)
-		app.EXPECT().Bind(binding.Notification, mock.AnythingOfType("func(foundation.Application) (interface {}, error)")).Run(func(_ any, callback func(contractsfoundation.Application) (any, error)) {
+		app.EXPECT().Singleton(binding.Notification, mock.AnythingOfType("func(foundation.Application) (interface {}, error)")).Run(func(_ any, callback func(contractsfoundation.Application) (any, error)) {
 			callbackApp := mocksfoundation.NewApplication(t)
 			logger := mockslog.NewLog(t)
 			mailer := mocksmail.NewMail(t)
@@ -86,7 +86,7 @@ func TestServiceProviderRegister(t *testing.T) {
 
 	t.Run("queue facade not set", func(t *testing.T) {
 		app := mocksfoundation.NewApplication(t)
-		app.EXPECT().Bind(binding.Notification, mock.AnythingOfType("func(foundation.Application) (interface {}, error)")).Run(func(_ any, callback func(contractsfoundation.Application) (any, error)) {
+		app.EXPECT().Singleton(binding.Notification, mock.AnythingOfType("func(foundation.Application) (interface {}, error)")).Run(func(_ any, callback func(contractsfoundation.Application) (any, error)) {
 			callbackApp := mocksfoundation.NewApplication(t)
 			logger := mockslog.NewLog(t)
 			mailer := mocksmail.NewMail(t)
@@ -108,7 +108,7 @@ func TestServiceProviderRegister(t *testing.T) {
 
 	t.Run("register notification manager", func(t *testing.T) {
 		app := mocksfoundation.NewApplication(t)
-		app.EXPECT().Bind(binding.Notification, mock.AnythingOfType("func(foundation.Application) (interface {}, error)")).Run(func(_ any, callback func(contractsfoundation.Application) (any, error)) {
+		app.EXPECT().Singleton(binding.Notification, mock.AnythingOfType("func(foundation.Application) (interface {}, error)")).Run(func(_ any, callback func(contractsfoundation.Application) (any, error)) {
 			callbackApp := mocksfoundation.NewApplication(t)
 			logger := mockslog.NewLog(t)
 			mailer := mocksmail.NewMail(t)


### PR DESCRIPTION
## Description

The notification service provider was the only provider in the framework still using a transient `app.Bind(...)` instead of `app.Singleton(...)`. Every other provider registers its facade as a singleton.

With a transient binding, each resolution builds a fresh manager, so:
- Channels extended during `Register` are lost between resolutions.
- The manager handed to the dispatched job (via `registerJobs` → `*Manager` cast) can diverge from the one exposed through `facades.Notification()`.

## Changes

- Register the notification manager with `app.Singleton(...)` so a single shared instance is resolved consistently across facade access and job dispatch.
- Updated the corresponding service provider unit tests.

## Tests

- [x] `go test ./notification/...` passes.