### PR TITLE
feat: fall back queued notification/broadcast retries to worker tries (Laravel parity)

### DIFF
--- a/broadcasting/application.go
+++ b/broadcasting/application.go
@@ -145,7 +145,7 @@ func (a *Application) Dispatch(ctx context.Context, event broadcasting.ShouldBro
 	}
 	// Backoff is serialized unconditionally: it applies to every retry,
 	// whether capped by the event's own BroadcastTries or the queue worker's
-	// tries config (Laravel parity).
+	// tries config.
 	if withBackoff, ok := event.(broadcasting.ShouldBroadcastWithBackoff); ok {
 		backoff := withBackoff.BroadcastBackoff()
 		if len(backoff) > 0 {

--- a/broadcasting/application.go
+++ b/broadcasting/application.go
@@ -143,16 +143,15 @@ func (a *Application) Dispatch(ctx context.Context, event broadcasting.ShouldBro
 	if withTries, ok := event.(broadcasting.ShouldBroadcastWithTries); ok && withTries.BroadcastTries() > 0 {
 		item.Tries = withTries.BroadcastTries()
 	}
-	// Backoff only takes effect when retries exist, so it is serialized only
-	// alongside a positive Tries value.
-	if item.Tries > 0 {
-		if withBackoff, ok := event.(broadcasting.ShouldBroadcastWithBackoff); ok {
-			backoff := withBackoff.BroadcastBackoff()
-			if len(backoff) > 0 {
-				item.Backoff = make([]int64, len(backoff))
-				for i, d := range backoff {
-					item.Backoff[i] = d.Milliseconds()
-				}
+	// Backoff is serialized unconditionally: it applies to every retry,
+	// whether capped by the event's own BroadcastTries or the queue worker's
+	// tries config (Laravel parity).
+	if withBackoff, ok := event.(broadcasting.ShouldBroadcastWithBackoff); ok {
+		backoff := withBackoff.BroadcastBackoff()
+		if len(backoff) > 0 {
+			item.Backoff = make([]int64, len(backoff))
+			for i, d := range backoff {
+				item.Backoff[i] = d.Milliseconds()
 			}
 		}
 	}

--- a/broadcasting/application_test.go
+++ b/broadcasting/application_test.go
@@ -408,7 +408,7 @@ func TestApplication_Dispatch(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("dispatch with backoff but no tries suppresses backoff", func(t *testing.T) {
+	t.Run("dispatch with backoff but no tries serializes backoff", func(t *testing.T) {
 		mockCf := setupMockConfig(t, "")
 		mockQ := mocksqueue.NewQueue(t)
 		mockPJ := mocksqueue.NewPendingJob(t)
@@ -423,7 +423,7 @@ func TestApplication_Dispatch(t *testing.T) {
 				if err := json.Unmarshal([]byte(args[0].Value.(string)), &item); err != nil {
 					return false
 				}
-				return item.Tries == 0 && item.Backoff == nil
+				return item.Tries == 0 && slices.Equal(item.Backoff, []int64{1000})
 			}),
 		).Return(mockPJ).Once()
 		mockPJ.EXPECT().Dispatch().Return(nil).Once()
@@ -431,8 +431,8 @@ func TestApplication_Dispatch(t *testing.T) {
 		app := NewApplication(mockCf, mockLog, mockQ, nil)
 
 		// Implements ShouldBroadcastWithBackoff with a non-empty backoff but
-		// no BroadcastTries: backoff only takes effect with retries, so the
-		// serialized payload must not carry it.
+		// no BroadcastTries: backoff applies to worker-driven retries, so the
+		// serialized payload must carry it (Laravel parity).
 		event := &mockBroadcastEvent{
 			broadcastOn:      []string{"test-channel"},
 			broadcastAs:      "test.event",

--- a/broadcasting/job.go
+++ b/broadcasting/job.go
@@ -36,11 +36,11 @@ func (j *BroadcastJob) Signature() string {
 
 // Handle executes the queued broadcast. Retries are governed by ShouldRetry
 // using the event's BroadcastTries/BroadcastBackoff captured at dispatch time.
-// Broadcasts without BroadcastTries are single-shot, regardless of the queue
-// worker's tries config. A fresh context is synthesized (the dispatch-time ctx
-// cannot cross the queue boundary); if the originating event implemented
-// ShouldBroadcastWithTimeout the worker context is bounded accordingly, which
-// the Pusher driver honours via WithContext.
+// Broadcasts without BroadcastTries defer to the queue worker's tries config.
+// A fresh context is synthesized (the dispatch-time ctx cannot cross the queue
+// boundary); if the originating event implemented ShouldBroadcastWithTimeout
+// the worker context is bounded accordingly, which the Pusher driver honours
+// via WithContext.
 func (j *BroadcastJob) Handle(args ...any) error {
 	if len(args) != 1 {
 		j.mu.Lock()
@@ -99,17 +99,24 @@ func (j *BroadcastJob) Handle(args ...any) error {
 	return nil
 }
 
-// ShouldRetry controls retries for the queued broadcast. It is authoritative
-// and replaces the worker's tries: without BroadcastTries the broadcast is
-// single-shot, regardless of the worker's tries config. With BroadcastTries it
-// retries while attempt < Tries using the configured per-attempt Backoff
-// (last value repeats).
-func (j *BroadcastJob) ShouldRetry(err error, attempt int) (retryable bool, delay time.Duration) {
+// ShouldRetry controls retries for the queued broadcast. A
+// BroadcastTries-declaring event wins; without one (Tries <= 0) the queue
+// worker's maxTries governs, mirroring Laravel's
+// Worker::markJobAsFailedIfWillExceedMaxAttempts. With a cap it retries while
+// attempt < Tries using the configured per-attempt Backoff (last value
+// repeats); backoff applies to worker-driven retries too. item == nil (cleared
+// on success/invalid payload) is the safe single-shot fallback — never the
+// worker's tries, so an interleaved concurrent task can't inherit another
+// task's policy.
+func (j *BroadcastJob) ShouldRetry(err error, attempt, maxTries int) (retryable bool, delay time.Duration) {
 	j.mu.Lock()
 	item := j.item
 	j.mu.Unlock()
 
-	if item == nil || item.Tries <= 0 {
+	// item == nil = no task policy (cleared on success/invalid payload): the
+	// safe single-shot fallback — never the worker's tries, so an interleaved
+	// concurrent task can't inherit another task's policy.
+	if item == nil {
 		return false, 0
 	}
 	if attempt < 1 {
@@ -118,7 +125,14 @@ func (j *BroadcastJob) ShouldRetry(err error, attempt int) (retryable bool, dela
 		// Returning false avoids an accidental infinite retry loop.
 		return false, 0
 	}
-	if attempt >= item.Tries {
+
+	// Laravel parity: the event's own BroadcastTries wins; without one the
+	// worker's maxTries governs (Worker::markJobAsFailedIfWillExceedMaxAttempts).
+	effectiveTries := item.Tries
+	if effectiveTries <= 0 {
+		effectiveTries = maxTries
+	}
+	if attempt >= effectiveTries {
 		return false, 0
 	}
 	if len(item.Backoff) == 0 {

--- a/broadcasting/job.go
+++ b/broadcasting/job.go
@@ -101,8 +101,7 @@ func (j *BroadcastJob) Handle(args ...any) error {
 
 // ShouldRetry controls retries for the queued broadcast. A
 // BroadcastTries-declaring event wins; without one (Tries <= 0) the queue
-// worker's maxTries governs, mirroring Laravel's
-// Worker::markJobAsFailedIfWillExceedMaxAttempts. With a cap it retries while
+// worker's maxTries governs. With a cap it retries while
 // attempt < Tries using the configured per-attempt Backoff (last value
 // repeats); backoff applies to worker-driven retries too. item == nil (cleared
 // on success/invalid payload) is the safe single-shot fallback — never the
@@ -126,8 +125,8 @@ func (j *BroadcastJob) ShouldRetry(err error, attempt, maxTries int) (retryable 
 		return false, 0
 	}
 
-	// Laravel parity: the event's own BroadcastTries wins; without one the
-	// worker's maxTries governs (Worker::markJobAsFailedIfWillExceedMaxAttempts).
+	// The event's own BroadcastTries wins; without one the worker's
+	// maxTries governs.
 	effectiveTries := item.Tries
 	if effectiveTries <= 0 {
 		effectiveTries = maxTries

--- a/broadcasting/job_test.go
+++ b/broadcasting/job_test.go
@@ -327,6 +327,10 @@ func TestBroadcastJob_ShouldRetry(t *testing.T) {
 		})
 	}
 
+	// The following cases exercise stateful behavior — establishing a stale
+	// item, then clearing or overriding it via a second Handle call — rather
+	// than the single-shot decision the table above covers. They need multiple
+	// sequential Handle calls, so they stay as separate t.Run cases.
 	t.Run("invalid payload clears stale item", func(t *testing.T) {
 		job := &BroadcastJob{}
 		err := job.Handle("not-json")

--- a/broadcasting/job_test.go
+++ b/broadcasting/job_test.go
@@ -167,83 +167,150 @@ func TestBroadcastJob_ShouldRetry(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		payload string
-		attempt int
-		err     error
-		want    bool
-		wantD   time.Duration
+		name     string
+		payload  string
+		attempt  int
+		maxTries int // the queue worker's tries (ignored when item.Tries > 0)
+		err      error
+		want     bool
+		wantD    time.Duration
 	}{
 		{
-			name:    "tries zero is single-shot",
-			payload: marshalItem(0, nil),
-			attempt: 1,
-			want:    false,
-			wantD:   0,
+			// No retry policy declared and the worker runs with Tries=1
+			// (the default): single-shot.
+			name:     "tries zero is single-shot",
+			payload:  marshalItem(0, nil),
+			attempt:  1,
+			maxTries: 1,
+			want:     false,
+			wantD:    0,
 		},
 		{
-			name:    "tries 3 first attempt retries",
-			payload: marshalItem(3, nil),
-			attempt: 1,
-			want:    true,
-			wantD:   0,
+			// No retry policy declared: the worker's Tries=3 governs.
+			name:     "tries zero defers to worker tries first attempt retries",
+			payload:  marshalItem(0, nil),
+			attempt:  1,
+			maxTries: 3,
+			want:     true,
+			wantD:    0,
 		},
 		{
-			name:    "tries 3 second attempt retries",
-			payload: marshalItem(3, nil),
-			attempt: 2,
-			want:    true,
-			wantD:   0,
+			name:     "tries zero defers to worker tries second attempt retries",
+			payload:  marshalItem(0, nil),
+			attempt:  2,
+			maxTries: 3,
+			want:     true,
+			wantD:    0,
 		},
 		{
-			name:    "tries 3 third attempt stops",
-			payload: marshalItem(3, nil),
-			attempt: 3,
-			want:    false,
-			wantD:   0,
+			name:     "tries zero defers to worker tries third attempt stops",
+			payload:  marshalItem(0, nil),
+			attempt:  3,
+			maxTries: 3,
+			want:     false,
+			wantD:    0,
 		},
 		{
-			name:    "backoff first attempt",
-			payload: marshalItem(4, []int64{1000, 2000}),
-			attempt: 1,
-			err:     errors.New("test error"), // err is ignored by ShouldRetry
-			want:    true,
-			wantD:   1 * time.Second,
+			// Worker Tries=0 keeps the existing single-shot behavior.
+			name:     "tries zero with worker tries zero is single-shot",
+			payload:  marshalItem(0, nil),
+			attempt:  1,
+			maxTries: 0,
+			want:     false,
+			wantD:    0,
 		},
 		{
-			name:    "backoff second attempt",
-			payload: marshalItem(4, []int64{1000, 2000}),
-			attempt: 2,
-			want:    true,
-			wantD:   2 * time.Second,
+			name:     "tries 3 first attempt retries",
+			payload:  marshalItem(3, nil),
+			attempt:  1,
+			maxTries: 1,
+			want:     true,
+			wantD:    0,
 		},
 		{
-			name:    "backoff last value repeats",
-			payload: marshalItem(4, []int64{1000, 2000}),
-			attempt: 3,
-			want:    true,
-			wantD:   2 * time.Second,
+			name:     "tries 3 second attempt retries",
+			payload:  marshalItem(3, nil),
+			attempt:  2,
+			maxTries: 1,
+			want:     true,
+			wantD:    0,
 		},
 		{
-			name:    "backoff with attempt 0 is single-shot fallback",
-			payload: marshalItem(4, []int64{1000, 2000}),
-			attempt: 0,
-			want:    false,
-			wantD:   0,
+			name:     "tries 3 third attempt stops",
+			payload:  marshalItem(3, nil),
+			attempt:  3,
+			maxTries: 1,
+			want:     false,
+			wantD:    0,
 		},
 		{
-			name:    "backoff stop at final attempt before index",
-			payload: marshalItem(2, []int64{1000, 2000}),
-			attempt: 2,
-			want:    false,
-			wantD:   0,
+			// A broadcast-declared Tries always wins over the worker's:
+			// with Tries=3 and worker maxTries=1, attempt 2 must retry.
+			name:     "item tries overrides worker tries",
+			payload:  marshalItem(3, nil),
+			attempt:  2,
+			maxTries: 1,
+			want:     true,
+			wantD:    0,
 		},
 		{
-			name:    "backoff last attempt stops",
-			payload: marshalItem(4, []int64{1000, 2000}),
-			attempt: 4,
-			want:    false,
-			wantD:   0,
+			name:     "backoff first attempt",
+			payload:  marshalItem(4, []int64{1000, 2000}),
+			attempt:  1,
+			maxTries: 1,
+			err:      errors.New("test error"), // err is ignored by ShouldRetry
+			want:     true,
+			wantD:    1 * time.Second,
+		},
+		{
+			name:     "backoff second attempt",
+			payload:  marshalItem(4, []int64{1000, 2000}),
+			attempt:  2,
+			maxTries: 1,
+			want:     true,
+			wantD:    2 * time.Second,
+		},
+		{
+			name:     "backoff last value repeats",
+			payload:  marshalItem(4, []int64{1000, 2000}),
+			attempt:  3,
+			maxTries: 1,
+			want:     true,
+			wantD:    2 * time.Second,
+		},
+		{
+			name:     "backoff with attempt 0 is single-shot fallback",
+			payload:  marshalItem(4, []int64{1000, 2000}),
+			attempt:  0,
+			maxTries: 1,
+			want:     false,
+			wantD:    0,
+		},
+		{
+			name:     "backoff stop at final attempt before index",
+			payload:  marshalItem(2, []int64{1000, 2000}),
+			attempt:  2,
+			maxTries: 1,
+			want:     false,
+			wantD:    0,
+		},
+		{
+			name:     "backoff last attempt stops",
+			payload:  marshalItem(4, []int64{1000, 2000}),
+			attempt:  4,
+			maxTries: 1,
+			want:     false,
+			wantD:    0,
+		},
+		{
+			// Backoff is honored during worker-driven retries too (no
+			// BroadcastTries, worker Tries=3).
+			name:     "backoff applies during worker fallback",
+			payload:  marshalItem(0, []int64{1000, 2000}),
+			attempt:  2,
+			maxTries: 3,
+			want:     true,
+			wantD:    2 * time.Second,
 		},
 	}
 
@@ -254,7 +321,7 @@ func TestBroadcastJob_ShouldRetry(t *testing.T) {
 			// retains the parsed item for ShouldRetry to read.
 			assert.Error(t, job.Handle(tt.payload))
 
-			retryable, delay := job.ShouldRetry(tt.err, tt.attempt)
+			retryable, delay := job.ShouldRetry(tt.err, tt.attempt, tt.maxTries)
 			assert.Equal(t, tt.want, retryable)
 			assert.Equal(t, tt.wantD, delay)
 		})
@@ -265,7 +332,15 @@ func TestBroadcastJob_ShouldRetry(t *testing.T) {
 		err := job.Handle("not-json")
 		assert.Error(t, err)
 
-		retryable, delay := job.ShouldRetry(nil, 1)
+		retryable, delay := job.ShouldRetry(nil, 1, 1)
+		assert.False(t, retryable)
+		assert.Equal(t, time.Duration(0), delay)
+
+		// item == nil must stay the safe single-shot fallback even when the
+		// worker's maxTries would otherwise allow a retry: with maxTries=3
+		// and attempt=1 a worker-tries fallback would return true, so this
+		// locks the "never the worker's tries" invariant.
+		retryable, delay = job.ShouldRetry(nil, 1, 3)
 		assert.False(t, retryable)
 		assert.Equal(t, time.Duration(0), delay)
 	})
@@ -275,18 +350,18 @@ func TestBroadcastJob_ShouldRetry(t *testing.T) {
 		// The failed broadcast retains the parsed item (driver-path failure),
 		// exactly the stale state a concurrent failed task would leave.
 		assert.Error(t, job.Handle(marshalItem(3, nil)))
-		retryable, _ := job.ShouldRetry(nil, 1)
+		retryable, _ := job.ShouldRetry(nil, 1, 1)
 		assert.True(t, retryable) // stale policy present (Tries=3)
 
 		assert.Error(t, job.Handle())
-		retryable, _ = job.ShouldRetry(nil, 1)
+		retryable, _ = job.ShouldRetry(nil, 1, 1)
 		assert.False(t, retryable)
 	})
 
 	t.Run("successful handle clears stale item", func(t *testing.T) {
 		job := newJob(t)
 		assert.Error(t, job.Handle(marshalItem(3, nil)))
-		retryable, _ := job.ShouldRetry(nil, 1)
+		retryable, _ := job.ShouldRetry(nil, 1, 1)
 		assert.True(t, retryable) // stale policy present (Tries=3)
 
 		// A successful task releases the payload, so any concurrent policy
@@ -302,18 +377,18 @@ func TestBroadcastJob_ShouldRetry(t *testing.T) {
 		data, _ := json.Marshal(item)
 		assert.NoError(t, job.Handle(string(data)))
 
-		retryable, _ = job.ShouldRetry(nil, 1)
+		retryable, _ = job.ShouldRetry(nil, 1, 1)
 		assert.False(t, retryable)
 	})
 
 	t.Run("non-string arg clears stale item", func(t *testing.T) {
 		job := newJob(t)
 		assert.Error(t, job.Handle(marshalItem(3, nil)))
-		retryable, _ := job.ShouldRetry(nil, 1)
+		retryable, _ := job.ShouldRetry(nil, 1, 1)
 		assert.True(t, retryable) // stale policy present (Tries=3)
 
 		assert.Error(t, job.Handle(42))
-		retryable, _ = job.ShouldRetry(nil, 1)
+		retryable, _ = job.ShouldRetry(nil, 1, 1)
 		assert.False(t, retryable)
 	})
 }

--- a/contracts/broadcasting/broadcasting.go
+++ b/contracts/broadcasting/broadcasting.go
@@ -61,8 +61,7 @@ type ShouldBroadcastWithTries interface {
 	// BroadcastTries returns the maximum number of attempts for the
 	// queued broadcast. 0 / not implementing the interface means no
 	// retry policy is declared and the queue worker's Tries config
-	// applies (Laravel parity,
-	// Worker::markJobAsFailedIfWillExceedMaxAttempts).
+	// applies.
 	BroadcastTries() int
 }
 

--- a/contracts/broadcasting/broadcasting.go
+++ b/contracts/broadcasting/broadcasting.go
@@ -59,15 +59,17 @@ type ShouldBroadcastWithTimeout interface {
 
 type ShouldBroadcastWithTries interface {
 	// BroadcastTries returns the maximum number of attempts for the
-	// queued broadcast. 0 / not implementing the interface means the
-	// broadcast is single-shot.
+	// queued broadcast. 0 / not implementing the interface means no
+	// retry policy is declared and the queue worker's Tries config
+	// applies (Laravel parity,
+	// Worker::markJobAsFailedIfWillExceedMaxAttempts).
 	BroadcastTries() int
 }
 
 type ShouldBroadcastWithBackoff interface {
 	// BroadcastBackoff returns the delay before each retry attempt, in
-	// order; the last value repeats for subsequent attempts. It only takes
-	// effect together with BroadcastTries; without it the broadcast is
-	// single-shot.
+	// order; the last value repeats for subsequent attempts. It applies
+	// to every retry, whether capped by the event's own BroadcastTries
+	// or the queue worker's Tries config; the last value repeats.
 	BroadcastBackoff() []time.Duration
 }

--- a/contracts/notification/notification.go
+++ b/contracts/notification/notification.go
@@ -43,9 +43,9 @@ type NotificationWithAfterSending interface {
 type NotificationWithTries interface {
 	Notification
 	// Tries returns the maximum number of attempts for the given
-	// channel. 0 / not implementing this interface means the
-	// notification is single-shot on that channel — no retry at all,
-	// not even once, matching ShouldBroadcastWithTries's semantics.
+	// channel. 0 / not implementing this interface means no retry policy
+	// is declared and the queue worker's Tries config applies (Laravel
+	// parity, Worker::markJobAsFailedIfWillExceedMaxAttempts).
 	Tries(channel string) int
 }
 
@@ -59,8 +59,8 @@ type NotificationWithTries interface {
 // slice's length (min(attempt-1, len(backoff)-1)), matching Laravel's
 // Worker::calculateBackoff and BroadcastJob.ShouldRetry precisely.
 //
-// Only takes effect together with NotificationWithTries; without Tries
-// the notification is single-shot regardless of Backoff.
+// Backoff applies to every retry, whether capped by the notification's own
+// Tries or the queue worker's Tries config; the last value repeats.
 type NotificationWithBackoff interface {
 	Notification
 	// Backoff returns the delay before each retry attempt on channel,

--- a/contracts/notification/notification.go
+++ b/contracts/notification/notification.go
@@ -44,8 +44,7 @@ type NotificationWithTries interface {
 	Notification
 	// Tries returns the maximum number of attempts for the given
 	// channel. 0 / not implementing this interface means no retry policy
-	// is declared and the queue worker's Tries config applies (Laravel
-	// parity, Worker::markJobAsFailedIfWillExceedMaxAttempts).
+	// is declared and the queue worker's Tries config applies.
 	Tries(channel string) int
 }
 

--- a/contracts/queue/job.go
+++ b/contracts/queue/job.go
@@ -54,5 +54,12 @@ type ChainJob struct {
 
 type JobWithShouldRetry interface {
 	// ShouldRetry determines if the job should be retried based on the error.
-	ShouldRetry(err error, attempt int) (retryable bool, delay time.Duration)
+	// maxTries is the queue worker's configured tries: queue.Args.Tries for
+	// Worker(args), or 1 for the no-argument Worker() (which hardcodes it).
+	// Note that leaving Args.Tries unset passes the zero value 0; both 0 and 1
+	// yield a single-shot fallback for jobs without their own retry policy.
+	// Implementations without their own retry policy fall back to maxTries,
+	// mirroring Laravel's Worker::markJobAsFailedIfWillExceedMaxAttempts
+	// ($job->maxTries() ?? $options->maxTries).
+	ShouldRetry(err error, attempt, maxTries int) (retryable bool, delay time.Duration)
 }

--- a/contracts/queue/job.go
+++ b/contracts/queue/job.go
@@ -58,8 +58,6 @@ type JobWithShouldRetry interface {
 	// Worker(args), or 1 for the no-argument Worker() (which hardcodes it).
 	// Note that leaving Args.Tries unset passes the zero value 0; both 0 and 1
 	// yield a single-shot fallback for jobs without their own retry policy.
-	// Implementations without their own retry policy fall back to maxTries,
-	// mirroring Laravel's Worker::markJobAsFailedIfWillExceedMaxAttempts
-	// ($job->maxTries() ?? $options->maxTries).
+	// Implementations without their own retry policy fall back to maxTries.
 	ShouldRetry(err error, attempt, maxTries int) (retryable bool, delay time.Duration)
 }

--- a/mocks/queue/JobWithShouldRetry.go
+++ b/mocks/queue/JobWithShouldRetry.go
@@ -21,9 +21,9 @@ func (_m *JobWithShouldRetry) EXPECT() *JobWithShouldRetry_Expecter {
 	return &JobWithShouldRetry_Expecter{mock: &_m.Mock}
 }
 
-// ShouldRetry provides a mock function with given fields: err, attempt
-func (_m *JobWithShouldRetry) ShouldRetry(err error, attempt int) (bool, time.Duration) {
-	ret := _m.Called(err, attempt)
+// ShouldRetry provides a mock function with given fields: err, attempt, maxTries
+func (_m *JobWithShouldRetry) ShouldRetry(err error, attempt int, maxTries int) (bool, time.Duration) {
+	ret := _m.Called(err, attempt, maxTries)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ShouldRetry")
@@ -31,17 +31,17 @@ func (_m *JobWithShouldRetry) ShouldRetry(err error, attempt int) (bool, time.Du
 
 	var r0 bool
 	var r1 time.Duration
-	if rf, ok := ret.Get(0).(func(error, int) (bool, time.Duration)); ok {
-		return rf(err, attempt)
+	if rf, ok := ret.Get(0).(func(error, int, int) (bool, time.Duration)); ok {
+		return rf(err, attempt, maxTries)
 	}
-	if rf, ok := ret.Get(0).(func(error, int) bool); ok {
-		r0 = rf(err, attempt)
+	if rf, ok := ret.Get(0).(func(error, int, int) bool); ok {
+		r0 = rf(err, attempt, maxTries)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(error, int) time.Duration); ok {
-		r1 = rf(err, attempt)
+	if rf, ok := ret.Get(1).(func(error, int, int) time.Duration); ok {
+		r1 = rf(err, attempt, maxTries)
 	} else {
 		r1 = ret.Get(1).(time.Duration)
 	}
@@ -57,13 +57,14 @@ type JobWithShouldRetry_ShouldRetry_Call struct {
 // ShouldRetry is a helper method to define mock.On call
 //   - err error
 //   - attempt int
-func (_e *JobWithShouldRetry_Expecter) ShouldRetry(err interface{}, attempt interface{}) *JobWithShouldRetry_ShouldRetry_Call {
-	return &JobWithShouldRetry_ShouldRetry_Call{Call: _e.mock.On("ShouldRetry", err, attempt)}
+//   - maxTries int
+func (_e *JobWithShouldRetry_Expecter) ShouldRetry(err interface{}, attempt interface{}, maxTries interface{}) *JobWithShouldRetry_ShouldRetry_Call {
+	return &JobWithShouldRetry_ShouldRetry_Call{Call: _e.mock.On("ShouldRetry", err, attempt, maxTries)}
 }
 
-func (_c *JobWithShouldRetry_ShouldRetry_Call) Run(run func(err error, attempt int)) *JobWithShouldRetry_ShouldRetry_Call {
+func (_c *JobWithShouldRetry_ShouldRetry_Call) Run(run func(err error, attempt int, maxTries int)) *JobWithShouldRetry_ShouldRetry_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(error), args[1].(int))
+		run(args[0].(error), args[1].(int), args[2].(int))
 	})
 	return _c
 }
@@ -73,7 +74,7 @@ func (_c *JobWithShouldRetry_ShouldRetry_Call) Return(retryable bool, delay time
 	return _c
 }
 
-func (_c *JobWithShouldRetry_ShouldRetry_Call) RunAndReturn(run func(error, int) (bool, time.Duration)) *JobWithShouldRetry_ShouldRetry_Call {
+func (_c *JobWithShouldRetry_ShouldRetry_Call) RunAndReturn(run func(error, int, int) (bool, time.Duration)) *JobWithShouldRetry_ShouldRetry_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/notification/job.go
+++ b/notification/job.go
@@ -101,8 +101,7 @@ func (j *DispatchJob) Handle(args ...any) error {
 
 // ShouldRetry controls retries for the queued notification dispatch. A
 // notification-declared Tries wins; without one (Tries <= 0) the queue
-// worker's maxTries governs, mirroring Laravel's
-// Worker::markJobAsFailedIfWillExceedMaxAttempts. Backoff applies to every
+// worker's maxTries governs. Backoff applies to every
 // retry, whoever supplied the cap, and the last value repeats. item == nil
 // (cleared on success/invalid payload) is the safe single-shot fallback —
 // never the worker's tries, so an interleaved concurrent task can't inherit
@@ -123,8 +122,8 @@ func (j *DispatchJob) ShouldRetry(err error, attempt, maxTries int) (retryable b
 		return false, 0
 	}
 
-	// Laravel parity: the notification's own Tries wins; without one the
-	// worker's maxTries governs (Worker::markJobAsFailedIfWillExceedMaxAttempts).
+	// The notification's own Tries wins; without one the worker's
+	// maxTries governs.
 	effectiveTries := item.Tries
 	if effectiveTries <= 0 {
 		effectiveTries = maxTries

--- a/notification/job.go
+++ b/notification/job.go
@@ -99,19 +99,37 @@ func (j *DispatchJob) Handle(args ...any) error {
 	return nil
 }
 
-func (j *DispatchJob) ShouldRetry(err error, attempt int) (retryable bool, delay time.Duration) {
+// ShouldRetry controls retries for the queued notification dispatch. A
+// notification-declared Tries wins; without one (Tries <= 0) the queue
+// worker's maxTries governs, mirroring Laravel's
+// Worker::markJobAsFailedIfWillExceedMaxAttempts. Backoff applies to every
+// retry, whoever supplied the cap, and the last value repeats. item == nil
+// (cleared on success/invalid payload) is the safe single-shot fallback —
+// never the worker's tries, so an interleaved concurrent task can't inherit
+// another task's policy.
+func (j *DispatchJob) ShouldRetry(err error, attempt, maxTries int) (retryable bool, delay time.Duration) {
 	j.mu.Lock()
 	item := j.item
 	j.mu.Unlock()
 
-	if item == nil || item.Tries <= 0 {
+	// item == nil = no task policy (cleared on success/invalid payload): the
+	// safe single-shot fallback — never the worker's tries, so an interleaved
+	// concurrent task can't inherit another task's policy.
+	if item == nil {
 		return false, 0
 	}
 	if attempt < 1 {
-
+		// Defensive: unreachable in practice (pop-incremented reservation).
 		return false, 0
 	}
-	if attempt >= item.Tries {
+
+	// Laravel parity: the notification's own Tries wins; without one the
+	// worker's maxTries governs (Worker::markJobAsFailedIfWillExceedMaxAttempts).
+	effectiveTries := item.Tries
+	if effectiveTries <= 0 {
+		effectiveTries = maxTries
+	}
+	if attempt >= effectiveTries {
 		return false, 0
 	}
 	if len(item.Backoff) == 0 {

--- a/notification/job_test.go
+++ b/notification/job_test.go
@@ -295,6 +295,10 @@ func TestDispatchJob_ShouldRetry(t *testing.T) {
 		})
 	}
 
+	// This case exercises stateful behavior — establishing a stale item, then
+	// clearing it via a second Handle call — rather than the single-shot
+	// decision the table above covers. It needs multiple sequential Handle
+	// calls, so it stays separate.
 	t.Run("invalid payload clears stale item", func(t *testing.T) {
 		job := newJob(t)
 		// The failed dispatch retains the parsed item (deliver-path failure),

--- a/notification/job_test.go
+++ b/notification/job_test.go
@@ -133,83 +133,150 @@ func TestDispatchJob_ShouldRetry(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		payload string
-		attempt int
-		err     error
-		want    bool
-		wantD   time.Duration
+		name     string
+		payload  string
+		attempt  int
+		maxTries int // the queue worker's tries (ignored when item.Tries > 0)
+		err      error
+		want     bool
+		wantD    time.Duration
 	}{
 		{
-			name:    "tries zero is single-shot",
-			payload: marshalItem(0, nil),
-			attempt: 1,
-			want:    false,
-			wantD:   0,
+			// No retry policy declared and the worker runs with Tries=1
+			// (the default): single-shot.
+			name:     "tries zero is single-shot",
+			payload:  marshalItem(0, nil),
+			attempt:  1,
+			maxTries: 1,
+			want:     false,
+			wantD:    0,
 		},
 		{
-			name:    "tries 3 first attempt retries",
-			payload: marshalItem(3, nil),
-			attempt: 1,
-			want:    true,
-			wantD:   0,
+			// No retry policy declared: the worker's Tries=3 governs.
+			name:     "tries zero defers to worker tries first attempt retries",
+			payload:  marshalItem(0, nil),
+			attempt:  1,
+			maxTries: 3,
+			want:     true,
+			wantD:    0,
 		},
 		{
-			name:    "tries 3 second attempt retries",
-			payload: marshalItem(3, nil),
-			attempt: 2,
-			want:    true,
-			wantD:   0,
+			name:     "tries zero defers to worker tries second attempt retries",
+			payload:  marshalItem(0, nil),
+			attempt:  2,
+			maxTries: 3,
+			want:     true,
+			wantD:    0,
 		},
 		{
-			name:    "tries 3 third attempt stops",
-			payload: marshalItem(3, nil),
-			attempt: 3,
-			want:    false,
-			wantD:   0,
+			name:     "tries zero defers to worker tries third attempt stops",
+			payload:  marshalItem(0, nil),
+			attempt:  3,
+			maxTries: 3,
+			want:     false,
+			wantD:    0,
 		},
 		{
-			name:    "backoff first attempt",
-			payload: marshalItem(4, []int64{1000, 2000}),
-			attempt: 1,
-			err:     errors.New("test error"), // err is ignored by ShouldRetry
-			want:    true,
-			wantD:   1 * time.Second,
+			// Worker Tries=0 keeps the existing single-shot behavior.
+			name:     "tries zero with worker tries zero is single-shot",
+			payload:  marshalItem(0, nil),
+			attempt:  1,
+			maxTries: 0,
+			want:     false,
+			wantD:    0,
 		},
 		{
-			name:    "backoff second attempt",
-			payload: marshalItem(4, []int64{1000, 2000}),
-			attempt: 2,
-			want:    true,
-			wantD:   2 * time.Second,
+			name:     "tries 3 first attempt retries",
+			payload:  marshalItem(3, nil),
+			attempt:  1,
+			maxTries: 1,
+			want:     true,
+			wantD:    0,
 		},
 		{
-			name:    "backoff last value repeats",
-			payload: marshalItem(4, []int64{1000, 2000}),
-			attempt: 3,
-			want:    true,
-			wantD:   2 * time.Second,
+			name:     "tries 3 second attempt retries",
+			payload:  marshalItem(3, nil),
+			attempt:  2,
+			maxTries: 1,
+			want:     true,
+			wantD:    0,
 		},
 		{
-			name:    "backoff with attempt 0 is single-shot fallback",
-			payload: marshalItem(4, []int64{1000, 2000}),
-			attempt: 0,
-			want:    false,
-			wantD:   0,
+			name:     "tries 3 third attempt stops",
+			payload:  marshalItem(3, nil),
+			attempt:  3,
+			maxTries: 1,
+			want:     false,
+			wantD:    0,
 		},
 		{
-			name:    "backoff stop at final attempt before index",
-			payload: marshalItem(2, []int64{1000, 2000}),
-			attempt: 2,
-			want:    false,
-			wantD:   0,
+			// A notification-declared Tries always wins over the worker's:
+			// with Tries=3 and worker maxTries=1, attempt 2 must retry.
+			name:     "item tries overrides worker tries",
+			payload:  marshalItem(3, nil),
+			attempt:  2,
+			maxTries: 1,
+			want:     true,
+			wantD:    0,
 		},
 		{
-			name:    "backoff last attempt stops",
-			payload: marshalItem(4, []int64{1000, 2000}),
-			attempt: 4,
-			want:    false,
-			wantD:   0,
+			name:     "backoff first attempt",
+			payload:  marshalItem(4, []int64{1000, 2000}),
+			attempt:  1,
+			maxTries: 1,
+			err:      errors.New("test error"), // err is ignored by ShouldRetry
+			want:     true,
+			wantD:    1 * time.Second,
+		},
+		{
+			name:     "backoff second attempt",
+			payload:  marshalItem(4, []int64{1000, 2000}),
+			attempt:  2,
+			maxTries: 1,
+			want:     true,
+			wantD:    2 * time.Second,
+		},
+		{
+			name:     "backoff last value repeats",
+			payload:  marshalItem(4, []int64{1000, 2000}),
+			attempt:  3,
+			maxTries: 1,
+			want:     true,
+			wantD:    2 * time.Second,
+		},
+		{
+			name:     "backoff with attempt 0 is single-shot fallback",
+			payload:  marshalItem(4, []int64{1000, 2000}),
+			attempt:  0,
+			maxTries: 1,
+			want:     false,
+			wantD:    0,
+		},
+		{
+			name:     "backoff stop at final attempt before index",
+			payload:  marshalItem(2, []int64{1000, 2000}),
+			attempt:  2,
+			maxTries: 1,
+			want:     false,
+			wantD:    0,
+		},
+		{
+			name:     "backoff last attempt stops",
+			payload:  marshalItem(4, []int64{1000, 2000}),
+			attempt:  4,
+			maxTries: 1,
+			want:     false,
+			wantD:    0,
+		},
+		{
+			// Backoff is honored during worker-driven retries too (no
+			// notification Tries, worker Tries=3).
+			name:     "backoff applies during worker fallback",
+			payload:  marshalItem(0, []int64{1000, 2000}),
+			attempt:  2,
+			maxTries: 3,
+			want:     true,
+			wantD:    2 * time.Second,
 		},
 	}
 
@@ -222,9 +289,31 @@ func TestDispatchJob_ShouldRetry(t *testing.T) {
 			// broadcasting/job_test.go's own setup.
 			assert.Error(t, job.Handle(tt.payload))
 
-			retryable, delay := job.ShouldRetry(tt.err, tt.attempt)
+			retryable, delay := job.ShouldRetry(tt.err, tt.attempt, tt.maxTries)
 			assert.Equal(t, tt.want, retryable)
 			assert.Equal(t, tt.wantD, delay)
 		})
 	}
+
+	t.Run("invalid payload clears stale item", func(t *testing.T) {
+		job := newJob(t)
+		// The failed dispatch retains the parsed item (deliver-path failure),
+		// exactly the stale state a concurrent failed task would leave.
+		assert.Error(t, job.Handle(marshalItem(3, nil)))
+		retryable, _ := job.ShouldRetry(nil, 1, 1)
+		assert.True(t, retryable) // stale policy present (Tries=3)
+
+		assert.Error(t, job.Handle("not-json"))
+		retryable, delay := job.ShouldRetry(nil, 1, 1)
+		assert.False(t, retryable)
+		assert.Equal(t, time.Duration(0), delay)
+
+		// item == nil must stay the safe single-shot fallback even when the
+		// worker's maxTries would otherwise allow a retry: with maxTries=3
+		// and attempt=1 a worker-tries fallback would return true, so this
+		// locks the "never the worker's tries" invariant.
+		retryable, delay = job.ShouldRetry(nil, 1, 3)
+		assert.False(t, retryable)
+		assert.Equal(t, time.Duration(0), delay)
+	})
 }

--- a/notification/notification.go
+++ b/notification/notification.go
@@ -148,14 +148,12 @@ func (m *Manager) dispatchQueued(
 				item.Tries = tries
 			}
 		}
-		if item.Tries > 0 {
-			if withBackoff, ok := n.(contractsnotification.NotificationWithBackoff); ok {
-				backoff := withBackoff.Backoff(name)
-				if len(backoff) > 0 {
-					item.Backoff = make([]int64, len(backoff))
-					for i, d := range backoff {
-						item.Backoff[i] = d.Milliseconds()
-					}
+		if withBackoff, ok := n.(contractsnotification.NotificationWithBackoff); ok {
+			backoff := withBackoff.Backoff(name)
+			if len(backoff) > 0 {
+				item.Backoff = make([]int64, len(backoff))
+				for i, d := range backoff {
+					item.Backoff[i] = d.Milliseconds()
 				}
 			}
 		}

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -464,12 +464,11 @@ func TestManager_Send_QueuedNotification_CapturesTriesAndBackoff(t *testing.T) {
 	assert.Equal(t, []int64{1000, 2000}, item.Backoff) // milliseconds on the wire
 }
 
-// TestManager_Send_QueuedNotification_OmitsBackoff_WhenTriesNotSet
-// confirms Backoff only takes effect alongside a positive Tries,
-// matching broadcasting's exact rule (Backoff has no effect without
-// Tries, so there's no reason to carry it across the queue boundary
-// otherwise).
-func TestManager_Send_QueuedNotification_OmitsBackoff_WhenTriesNotSet(t *testing.T) {
+// TestManager_Send_QueuedNotification_SerializesBackoff_WhenTriesNotSet
+// confirms Backoff is serialized unconditionally, even without a positive
+// Tries: it applies to worker-driven retries (Laravel parity), so it must
+// travel across the queue boundary regardless of the declared Tries.
+func TestManager_Send_QueuedNotification_SerializesBackoff_WhenTriesNotSet(t *testing.T) {
 	logger := mockslog.NewLog(t)
 	q := mocksqueue.NewQueue(t)
 	pending := mocksqueue.NewPendingJob(t)
@@ -502,7 +501,7 @@ func TestManager_Send_QueuedNotification_OmitsBackoff_WhenTriesNotSet(t *testing
 	assert.True(t, ok)
 	assert.NoError(t, json.Unmarshal([]byte(raw), &item))
 	assert.Zero(t, item.Tries)
-	assert.Empty(t, item.Backoff)
+	assert.Equal(t, []int64{5000}, item.Backoff) // milliseconds on the wire
 }
 
 // ---- Route (on-demand notifications) ----

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -127,7 +127,7 @@ func (r *Worker) call(task queue.Task, reservedJob queue.ReservedJob) (released 
 		var delay time.Duration = 0
 
 		if jobWithShouldRetry, ok := task.Job.(queue.JobWithShouldRetry); ok {
-			shouldRetry, delay = jobWithShouldRetry.ShouldRetry(callErr, attempt)
+			shouldRetry, delay = jobWithShouldRetry.ShouldRetry(callErr, attempt, r.tries)
 		} else {
 			shouldRetry = attempt < r.tries /* || r.tries == 0 */ // Currently, we do not support unlimited retries, see https://github.com/goravel/framework/pull/1123#discussion_r2194272829
 		}

--- a/queue/worker_test.go
+++ b/queue/worker_test.go
@@ -211,6 +211,29 @@ func (s *WorkerTestSuite) Test_call() {
 		s.True(released)
 		s.NoError(err)
 		s.Equal(3, retryTask.Job.(*TestJobRetry).attempt)
+		s.Equal(1, retryTask.Job.(*TestJobRetry).maxTries) // default worker tries
+	})
+
+	s.Run("worker tries reaches ShouldRetry", func() {
+		s.SetupTest()
+		s.worker.tries = 3
+
+		retryTask := contractsqueue.Task{
+			ChainJob: contractsqueue.ChainJob{
+				Job: &TestJobRetry{},
+			},
+			UUID: "test",
+		}
+
+		mockReservedJob := mocksqueue.NewReservedJob(s.T())
+		s.mockJob.EXPECT().Call(retryTask.Job.Signature(), make([]any, 0)).Return(assert.AnError).Once()
+		mockReservedJob.EXPECT().Attempts().Return(1).Once()
+		mockReservedJob.EXPECT().Release(time.Duration(0)).Return(nil).Once()
+
+		released, err := s.worker.call(retryTask, mockReservedJob)
+		s.True(released)
+		s.NoError(err)
+		s.Equal(3, retryTask.Job.(*TestJobRetry).maxTries) // worker's tries handed to ShouldRetry
 	})
 }
 
@@ -1178,7 +1201,8 @@ func matchFailedJob(uuid string) interface{} {
 }
 
 type TestJobRetry struct {
-	attempt int
+	attempt  int
+	maxTries int
 }
 
 // Signature The name and signature of the job.
@@ -1194,7 +1218,8 @@ func (r *TestJobRetry) Handle(args ...any) error {
 	return assert.AnError
 }
 
-func (r *TestJobRetry) ShouldRetry(err error, attempt int) (bool, time.Duration) {
+func (r *TestJobRetry) ShouldRetry(err error, attempt, maxTries int) (bool, time.Duration) {
 	r.attempt = attempt
+	r.maxTries = maxTries
 	return true, 0
 }


### PR DESCRIPTION
## Summary
- Queued notifications and broadcasts that declare no retry policy (`Tries == 0` / not implementing the interface) now follow the queue worker's `Tries` config instead of failing after a single attempt (Laravel `Worker::markJobAsFailedIfWillExceedMaxAttempts` parity).
- `Backoff` is serialized into the queued payload unconditionally, so per-attempt delays now apply to worker-driven retries too (last value repeats).
- A notification/broadcast-declared `Tries` still overrides the worker's, and a cleared/invalid payload remains a safe single-shot fallback.

## Why
Previously `DispatchJob`/`BroadcastJob` treated a missing retry policy (`Tries == 0`) as single-shot and dropped `Backoff` from the payload whenever no positive `Tries` was declared. That diverged from Laravel, where `$job->maxTries() ?? $options->maxTries` lets the queue worker's tries config govern when the notification or broadcast declares none. `JobWithShouldRetry.ShouldRetry` now receives the worker's `maxTries`, and the notification/broadcast jobs fall back to it when they declare no policy of their own — so a worker configured with `Tries = 3` now retries queued notifications/broadcasts that don't opt into their own policy, honoring their backoff on every retry.

```go
package notifications

import (
	"time"

	"github.com/goravel/framework/contracts/notification"
)

// OrderFailed declares a backoff but no Tries: delivery retries are now
// governed by the queue worker's Tries config, and the backoff applies to
// every retry (Laravel parity).
type OrderFailed struct {
	OrderID string
}

func NewOrderFailed(orderID string) *OrderFailed {
	return &OrderFailed{OrderID: orderID}
}

func (r *OrderFailed) Via(notifiable notification.Notifiable) []string {
	return []string{notification.ChannelDatabase}
}

func (r *OrderFailed) ToDatabase(notifiable notification.Notifiable) map[string]any {
	return map[string]any{"order_id": r.OrderID, "status": "failed"}
}

func (r *OrderFailed) OnQueue() string      { return "" }
func (r *OrderFailed) OnConnection() string { return "" }

// Backoff applies to every retry — capped by Tries when declared, or by the
// queue worker's Tries config otherwise (last value repeats).
func (r *OrderFailed) Backoff(channel string) []time.Duration {
	return []time.Duration{time.Second, 2 * time.Second}
}
```
