### PR TITLE
feat(config): add typed getters and config inspection helpers

### DIFF
--- a/config/application.go
+++ b/config/application.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"reflect"
 	"time"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -132,14 +133,133 @@ func (app *Application) GetDuration(path string, defaultValue ...time.Duration) 
 // GetStringSlice get []string type config from application.
 func (app *Application) GetStringSlice(path string, defaultValue ...[]string) []string {
 	if !app.vip.IsSet(path) {
-		for _, value := range defaultValue {
-			if value != nil {
-				return value
+		return sliceOrDefault(defaultValue)
+	}
+	value := app.vip.GetStringSlice(path)
+	if value == nil {
+		return sliceOrDefault(defaultValue)
+	}
+	return value
+}
+
+// GetIntSlice get []int type config from application.
+func (app *Application) GetIntSlice(path string, defaultValue ...[]int) []int {
+	if !app.vip.IsSet(path) {
+		return sliceOrDefault(defaultValue)
+	}
+	value := app.vip.GetIntSlice(path)
+	if value == nil {
+		return sliceOrDefault(defaultValue)
+	}
+	return value
+}
+
+// GetStringMap get map[string]any type config from application.
+func (app *Application) GetStringMap(path string, defaultValue ...map[string]any) map[string]any {
+	if !app.vip.IsSet(path) {
+		return mapOrDefault(defaultValue)
+	}
+	value := app.vip.GetStringMap(path)
+	if value == nil {
+		return mapOrDefault(defaultValue)
+	}
+	return value
+}
+
+// GetStringMapString get map[string]string type config from application.
+func (app *Application) GetStringMapString(path string, defaultValue ...map[string]string) map[string]string {
+	if !app.vip.IsSet(path) {
+		return mapOrDefault(defaultValue)
+	}
+	value := app.vip.GetStringMapString(path)
+	if value == nil {
+		return mapOrDefault(defaultValue)
+	}
+	return value
+}
+
+// Has reports whether the given path exists in the configuration.
+func (app *Application) Has(path string) bool {
+	return app.vip.IsSet(path)
+}
+
+// Forget removes the given path from the configuration.
+func (app *Application) Forget(path string) {
+	app.vip.Set(path, nil)
+}
+
+// All returns a copy of the entire configuration as a map[string]any.
+func (app *Application) All() map[string]any {
+	return app.vip.AllSettings()
+}
+
+// GetInt64 get int64 type config from application.
+func (app *Application) GetInt64(path string, defaultValue ...int64) int64 {
+	if !app.vip.IsSet(path) {
+		return convert.Default(defaultValue...)
+	}
+	return app.vip.GetInt64(path)
+}
+
+// GetFloat64 get float64 type config from application.
+func (app *Application) GetFloat64(path string, defaultValue ...float64) float64 {
+	if !app.vip.IsSet(path) {
+		return convert.Default(defaultValue...)
+	}
+	return app.vip.GetFloat64(path)
+}
+
+// GetTime get time.Time type config from application.
+func (app *Application) GetTime(path string, defaultValue ...time.Time) time.Time {
+	if !app.vip.IsSet(path) {
+		return convert.Default(defaultValue...)
+	}
+	value := app.vip.Get(path)
+	if t, ok := value.(time.Time); ok {
+		return t
+	}
+	if str, ok := value.(string); ok {
+		if layouts := []string{time.RFC3339, time.RFC3339Nano, "2006-01-02 15:04:05", "2006-01-02"}; true {
+			for _, layout := range layouts {
+				if t, err := time.Parse(layout, str); err == nil {
+					return t
+				}
 			}
 		}
-		return nil
 	}
-	return app.vip.GetStringSlice(path)
+	return convert.Default(defaultValue...)
+}
+
+func sliceOrDefault[T any](values []T) T {
+	for _, v := range values {
+		if !isZeroValue(v) {
+			return v
+		}
+	}
+	var zero T
+	return zero
+}
+
+func mapOrDefault[T any](values []T) T {
+	for _, v := range values {
+		if !isZeroValue(v) {
+			return v
+		}
+	}
+	var zero T
+	return zero
+}
+
+func isZeroValue(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Map, reflect.Array, reflect.Chan, reflect.Pointer, reflect.Interface:
+		return rv.IsNil()
+	}
+	return false
 }
 
 // UnmarshalKey unmarshal a specific key from config into a struct.

--- a/config/application_test.go
+++ b/config/application_test.go
@@ -296,3 +296,100 @@ func TestOsVariables(t *testing.T) {
 	assert.Equal(t, 3306, config.GetInt("APP_PORT"))
 	assert.True(t, config.GetBool("APP_DEBUG"))
 }
+
+func (s *ApplicationTestSuite) TestGetInt64() {
+	s.config.Add("BIG_PORT", "9000000000")
+	s.Equal(int64(9000000000), s.config.GetInt64("BIG_PORT"))
+
+	s.Equal(int64(0), s.config.GetInt64("NOT_EXIST_INT64"))
+	s.Equal(int64(42), s.config.GetInt64("NOT_EXIST_INT64", 42))
+}
+
+func (s *ApplicationTestSuite) TestGetFloat64() {
+	s.Equal(3.14, s.config.GetFloat64("FLOAT_VALUE"))
+	s.Equal(0.0, s.config.GetFloat64("NOT_EXIST_FLOAT"))
+	s.Equal(1.25, s.config.GetFloat64("NOT_EXIST_FLOAT", 1.25))
+}
+
+func (s *ApplicationTestSuite) TestGetTime() {
+	s.config.Add("BIRTHDAY", "2023-08-15T10:30:00Z")
+	expected, err := time.Parse(time.RFC3339, "2023-08-15T10:30:00Z")
+	s.NoError(err)
+	s.True(expected.Equal(s.config.GetTime("BIRTHDAY")))
+
+	s.config.Add("SHORT_DATE", "2024-01-02")
+	expected2, err := time.Parse("2006-01-02", "2024-01-02")
+	s.NoError(err)
+	s.True(expected2.Equal(s.config.GetTime("SHORT_DATE")))
+
+	fallback := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	s.Equal(time.Time{}, s.config.GetTime("NOT_EXIST_TIME"))
+	s.True(fallback.Equal(s.config.GetTime("NOT_EXIST_TIME", fallback)))
+
+	s.config.Add("INVALID_TIME", "not-a-time")
+	s.Equal(time.Time{}, s.config.GetTime("INVALID_TIME"))
+	s.True(fallback.Equal(s.config.GetTime("INVALID_TIME", fallback)))
+}
+
+func (s *ApplicationTestSuite) TestGetIntSlice() {
+	s.config.Add("PORTS", []int{80, 443, 8080})
+	s.Equal([]int{80, 443, 8080}, s.config.GetIntSlice("PORTS"))
+
+	s.config.Add("EMPTY_PORTS", []int{})
+	s.Equal([]int{}, s.config.GetIntSlice("EMPTY_PORTS"))
+
+	s.Nil(s.config.GetIntSlice("NOT_EXIST_INT_SLICE"))
+	s.Equal([]int{1, 2, 3}, s.config.GetIntSlice("NOT_EXIST_INT_SLICE", []int{1, 2, 3}))
+}
+
+func (s *ApplicationTestSuite) TestGetStringMap() {
+	s.config.Add("FEATURES", map[string]any{
+		"login":  true,
+		"signup": true,
+	})
+	got := s.config.GetStringMap("FEATURES")
+	s.Equal(true, got["login"])
+	s.Equal(true, got["signup"])
+
+	s.Nil(s.config.GetStringMap("NOT_EXIST_MAP"))
+	s.Equal(map[string]any{"a": "b"}, s.config.GetStringMap("NOT_EXIST_MAP", map[string]any{"a": "b"}))
+}
+
+func (s *ApplicationTestSuite) TestGetStringMapString() {
+	s.config.Add("HEADERS", map[string]string{
+		"X-Foo": "bar",
+		"X-Baz": "qux",
+	})
+	s.Equal(map[string]string{"X-Foo": "bar", "X-Baz": "qux"}, s.config.GetStringMapString("HEADERS"))
+
+	s.Nil(s.config.GetStringMapString("NOT_EXIST_MAP_STRING"))
+	s.Equal(map[string]string{"k": "v"}, s.config.GetStringMapString("NOT_EXIST_MAP_STRING", map[string]string{"k": "v"}))
+}
+
+func (s *ApplicationTestSuite) TestHas() {
+	s.True(s.config.Has("APP_KEY"))
+	s.True(s.config.Has("APP_DEBUG"))
+	s.False(s.config.Has("DEFINITELY_NOT_SET_12345"))
+}
+
+func (s *ApplicationTestSuite) TestForget() {
+	s.config.Add("TEMP_VALUE", "hello")
+	s.True(s.config.Has("TEMP_VALUE"))
+	s.Equal("hello", s.config.GetString("TEMP_VALUE"))
+
+	s.config.Forget("TEMP_VALUE")
+	s.False(s.config.Has("TEMP_VALUE"))
+	s.Equal("", s.config.GetString("TEMP_VALUE"))
+}
+
+func (s *ApplicationTestSuite) TestAll() {
+	s.config.Add("ALL_TEST_KEY", "value")
+	s.config.Add("ALL_TEST_BOOL", true)
+	s.config.Add("ALL_TEST_INT", 42)
+
+	all := s.config.All()
+	s.NotNil(all)
+	s.Equal("value", all["all_test_key"])
+	s.Equal(true, all["all_test_bool"])
+	s.Equal(42, all["all_test_int"])
+}

--- a/contracts/config/config.go
+++ b/contracts/config/config.go
@@ -1,6 +1,8 @@
 package config
 
-import "time"
+import (
+	"time"
+)
 
 type Config interface {
 	// Env get config from env.
@@ -17,12 +19,30 @@ type Config interface {
 	GetString(path string, defaultValue ...string) string
 	// GetInt get int type config from application.
 	GetInt(path string, defaultValue ...int) int
+	// GetInt64 get int64 type config from application.
+	GetInt64(path string, defaultValue ...int64) int64
+	// GetFloat64 get float64 type config from application.
+	GetFloat64(path string, defaultValue ...float64) float64
 	// GetBool get bool type config from application.
 	GetBool(path string, defaultValue ...bool) bool
 	// GetDuration get duration type config from application
 	GetDuration(path string, defaultValue ...time.Duration) time.Duration
+	// GetTime get time.Time type config from application.
+	GetTime(path string, defaultValue ...time.Time) time.Time
 	// GetStringSlice get []string type config from application.
 	GetStringSlice(path string, defaultValue ...[]string) []string
+	// GetIntSlice get []int type config from application.
+	GetIntSlice(path string, defaultValue ...[]int) []int
+	// GetStringMap get map[string]any type config from application.
+	GetStringMap(path string, defaultValue ...map[string]any) map[string]any
+	// GetStringMapString get map[string]string type config from application.
+	GetStringMapString(path string, defaultValue ...map[string]string) map[string]string
+	// Has reports whether the given path exists in the configuration.
+	Has(path string) bool
+	// Forget removes the given path from the configuration.
+	Forget(path string)
+	// All returns a copy of the entire configuration as a map.
+	All() map[string]any
 	// UnmarshalKey unmarshal a specific key from config into a struct.
 	UnmarshalKey(key string, rawVal any) error
 }

--- a/mocks/config/Config.go
+++ b/mocks/config/Config.go
@@ -55,6 +55,53 @@ func (_c *Config_Add_Call) RunAndReturn(run func(string, interface{})) *Config_A
 	return _c
 }
 
+// All provides a mock function with no fields
+func (_m *Config) All() map[string]interface{} {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for All")
+	}
+
+	var r0 map[string]interface{}
+	if rf, ok := ret.Get(0).(func() map[string]interface{}); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]interface{})
+		}
+	}
+
+	return r0
+}
+
+// Config_All_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'All'
+type Config_All_Call struct {
+	*mock.Call
+}
+
+// All is a helper method to define mock.On call
+func (_e *Config_Expecter) All() *Config_All_Call {
+	return &Config_All_Call{Call: _e.mock.On("All")}
+}
+
+func (_c *Config_All_Call) Run(run func()) *Config_All_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Config_All_Call) Return(_a0 map[string]interface{}) *Config_All_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_All_Call) RunAndReturn(run func() map[string]interface{}) *Config_All_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Env provides a mock function with given fields: envName, defaultValue
 func (_m *Config) Env(envName string, defaultValue ...interface{}) interface{} {
 	var _ca []interface{}
@@ -233,6 +280,39 @@ func (_c *Config_EnvString_Call) Return(_a0 string) *Config_EnvString_Call {
 
 func (_c *Config_EnvString_Call) RunAndReturn(run func(string, ...string) string) *Config_EnvString_Call {
 	_c.Call.Return(run)
+	return _c
+}
+
+// Forget provides a mock function with given fields: path
+func (_m *Config) Forget(path string) {
+	_m.Called(path)
+}
+
+// Config_Forget_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Forget'
+type Config_Forget_Call struct {
+	*mock.Call
+}
+
+// Forget is a helper method to define mock.On call
+//   - path string
+func (_e *Config_Expecter) Forget(path interface{}) *Config_Forget_Call {
+	return &Config_Forget_Call{Call: _e.mock.On("Forget", path)}
+}
+
+func (_c *Config_Forget_Call) Run(run func(path string)) *Config_Forget_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Config_Forget_Call) Return() *Config_Forget_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *Config_Forget_Call) RunAndReturn(run func(string)) *Config_Forget_Call {
+	_c.Run(run)
 	return _c
 }
 
@@ -417,6 +497,67 @@ func (_c *Config_GetDuration_Call) RunAndReturn(run func(string, ...time.Duratio
 	return _c
 }
 
+// GetFloat64 provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetFloat64(path string, defaultValue ...float64) float64 {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFloat64")
+	}
+
+	var r0 float64
+	if rf, ok := ret.Get(0).(func(string, ...float64) float64); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	return r0
+}
+
+// Config_GetFloat64_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFloat64'
+type Config_GetFloat64_Call struct {
+	*mock.Call
+}
+
+// GetFloat64 is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...float64
+func (_e *Config_Expecter) GetFloat64(path interface{}, defaultValue ...interface{}) *Config_GetFloat64_Call {
+	return &Config_GetFloat64_Call{Call: _e.mock.On("GetFloat64",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetFloat64_Call) Run(run func(path string, defaultValue ...float64)) *Config_GetFloat64_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]float64, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(float64)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetFloat64_Call) Return(_a0 float64) *Config_GetFloat64_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetFloat64_Call) RunAndReturn(run func(string, ...float64) float64) *Config_GetFloat64_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetInt provides a mock function with given fields: path, defaultValue
 func (_m *Config) GetInt(path string, defaultValue ...int) int {
 	_va := make([]interface{}, len(defaultValue))
@@ -474,6 +615,130 @@ func (_c *Config_GetInt_Call) Return(_a0 int) *Config_GetInt_Call {
 }
 
 func (_c *Config_GetInt_Call) RunAndReturn(run func(string, ...int) int) *Config_GetInt_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetInt64 provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetInt64(path string, defaultValue ...int64) int64 {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetInt64")
+	}
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(string, ...int64) int64); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	return r0
+}
+
+// Config_GetInt64_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInt64'
+type Config_GetInt64_Call struct {
+	*mock.Call
+}
+
+// GetInt64 is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...int64
+func (_e *Config_Expecter) GetInt64(path interface{}, defaultValue ...interface{}) *Config_GetInt64_Call {
+	return &Config_GetInt64_Call{Call: _e.mock.On("GetInt64",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetInt64_Call) Run(run func(path string, defaultValue ...int64)) *Config_GetInt64_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]int64, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(int64)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetInt64_Call) Return(_a0 int64) *Config_GetInt64_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetInt64_Call) RunAndReturn(run func(string, ...int64) int64) *Config_GetInt64_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetIntSlice provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetIntSlice(path string, defaultValue ...[]int) []int {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIntSlice")
+	}
+
+	var r0 []int
+	if rf, ok := ret.Get(0).(func(string, ...[]int) []int); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int)
+		}
+	}
+
+	return r0
+}
+
+// Config_GetIntSlice_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIntSlice'
+type Config_GetIntSlice_Call struct {
+	*mock.Call
+}
+
+// GetIntSlice is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...[]int
+func (_e *Config_Expecter) GetIntSlice(path interface{}, defaultValue ...interface{}) *Config_GetIntSlice_Call {
+	return &Config_GetIntSlice_Call{Call: _e.mock.On("GetIntSlice",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetIntSlice_Call) Run(run func(path string, defaultValue ...[]int)) *Config_GetIntSlice_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([][]int, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.([]int)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetIntSlice_Call) Return(_a0 []int) *Config_GetIntSlice_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetIntSlice_Call) RunAndReturn(run func(string, ...[]int) []int) *Config_GetIntSlice_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -539,6 +804,132 @@ func (_c *Config_GetString_Call) RunAndReturn(run func(string, ...string) string
 	return _c
 }
 
+// GetStringMap provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetStringMap(path string, defaultValue ...map[string]interface{}) map[string]interface{} {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetStringMap")
+	}
+
+	var r0 map[string]interface{}
+	if rf, ok := ret.Get(0).(func(string, ...map[string]interface{}) map[string]interface{}); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]interface{})
+		}
+	}
+
+	return r0
+}
+
+// Config_GetStringMap_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStringMap'
+type Config_GetStringMap_Call struct {
+	*mock.Call
+}
+
+// GetStringMap is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...map[string]interface{}
+func (_e *Config_Expecter) GetStringMap(path interface{}, defaultValue ...interface{}) *Config_GetStringMap_Call {
+	return &Config_GetStringMap_Call{Call: _e.mock.On("GetStringMap",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetStringMap_Call) Run(run func(path string, defaultValue ...map[string]interface{})) *Config_GetStringMap_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]map[string]interface{}, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(map[string]interface{})
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetStringMap_Call) Return(_a0 map[string]interface{}) *Config_GetStringMap_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetStringMap_Call) RunAndReturn(run func(string, ...map[string]interface{}) map[string]interface{}) *Config_GetStringMap_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetStringMapString provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetStringMapString(path string, defaultValue ...map[string]string) map[string]string {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetStringMapString")
+	}
+
+	var r0 map[string]string
+	if rf, ok := ret.Get(0).(func(string, ...map[string]string) map[string]string); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+
+	return r0
+}
+
+// Config_GetStringMapString_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStringMapString'
+type Config_GetStringMapString_Call struct {
+	*mock.Call
+}
+
+// GetStringMapString is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...map[string]string
+func (_e *Config_Expecter) GetStringMapString(path interface{}, defaultValue ...interface{}) *Config_GetStringMapString_Call {
+	return &Config_GetStringMapString_Call{Call: _e.mock.On("GetStringMapString",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetStringMapString_Call) Run(run func(path string, defaultValue ...map[string]string)) *Config_GetStringMapString_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]map[string]string, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(map[string]string)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetStringMapString_Call) Return(_a0 map[string]string) *Config_GetStringMapString_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetStringMapString_Call) RunAndReturn(run func(string, ...map[string]string) map[string]string) *Config_GetStringMapString_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetStringSlice provides a mock function with given fields: path, defaultValue
 func (_m *Config) GetStringSlice(path string, defaultValue ...[]string) []string {
 	_va := make([]interface{}, len(defaultValue))
@@ -598,6 +989,113 @@ func (_c *Config_GetStringSlice_Call) Return(_a0 []string) *Config_GetStringSlic
 }
 
 func (_c *Config_GetStringSlice_Call) RunAndReturn(run func(string, ...[]string) []string) *Config_GetStringSlice_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTime provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetTime(path string, defaultValue ...time.Time) time.Time {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTime")
+	}
+
+	var r0 time.Time
+	if rf, ok := ret.Get(0).(func(string, ...time.Time) time.Time); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		r0 = ret.Get(0).(time.Time)
+	}
+
+	return r0
+}
+
+// Config_GetTime_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTime'
+type Config_GetTime_Call struct {
+	*mock.Call
+}
+
+// GetTime is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...time.Time
+func (_e *Config_Expecter) GetTime(path interface{}, defaultValue ...interface{}) *Config_GetTime_Call {
+	return &Config_GetTime_Call{Call: _e.mock.On("GetTime",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetTime_Call) Run(run func(path string, defaultValue ...time.Time)) *Config_GetTime_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]time.Time, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(time.Time)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetTime_Call) Return(_a0 time.Time) *Config_GetTime_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetTime_Call) RunAndReturn(run func(string, ...time.Time) time.Time) *Config_GetTime_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Has provides a mock function with given fields: path
+func (_m *Config) Has(path string) bool {
+	ret := _m.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Has")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// Config_Has_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Has'
+type Config_Has_Call struct {
+	*mock.Call
+}
+
+// Has is a helper method to define mock.On call
+//   - path string
+func (_e *Config_Expecter) Has(path interface{}) *Config_Has_Call {
+	return &Config_Has_Call{Call: _e.mock.On("Has", path)}
+}
+
+func (_c *Config_Has_Call) Run(run func(path string)) *Config_Has_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Config_Has_Call) Return(_a0 bool) *Config_Has_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_Has_Call) RunAndReturn(run func(string) bool) *Config_Has_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/queue/Config.go
+++ b/mocks/queue/Config.go
@@ -55,6 +55,53 @@ func (_c *Config_Add_Call) RunAndReturn(run func(string, interface{})) *Config_A
 	return _c
 }
 
+// All provides a mock function with no fields
+func (_m *Config) All() map[string]interface{} {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for All")
+	}
+
+	var r0 map[string]interface{}
+	if rf, ok := ret.Get(0).(func() map[string]interface{}); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]interface{})
+		}
+	}
+
+	return r0
+}
+
+// Config_All_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'All'
+type Config_All_Call struct {
+	*mock.Call
+}
+
+// All is a helper method to define mock.On call
+func (_e *Config_Expecter) All() *Config_All_Call {
+	return &Config_All_Call{Call: _e.mock.On("All")}
+}
+
+func (_c *Config_All_Call) Run(run func()) *Config_All_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Config_All_Call) Return(_a0 map[string]interface{}) *Config_All_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_All_Call) RunAndReturn(run func() map[string]interface{}) *Config_All_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Debug provides a mock function with no fields
 func (_m *Config) Debug() bool {
 	ret := _m.Called()
@@ -552,6 +599,39 @@ func (_c *Config_FailedTable_Call) RunAndReturn(run func() string) *Config_Faile
 	return _c
 }
 
+// Forget provides a mock function with given fields: path
+func (_m *Config) Forget(path string) {
+	_m.Called(path)
+}
+
+// Config_Forget_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Forget'
+type Config_Forget_Call struct {
+	*mock.Call
+}
+
+// Forget is a helper method to define mock.On call
+//   - path string
+func (_e *Config_Expecter) Forget(path interface{}) *Config_Forget_Call {
+	return &Config_Forget_Call{Call: _e.mock.On("Forget", path)}
+}
+
+func (_c *Config_Forget_Call) Run(run func(path string)) *Config_Forget_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Config_Forget_Call) Return() *Config_Forget_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *Config_Forget_Call) RunAndReturn(run func(string)) *Config_Forget_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Get provides a mock function with given fields: path, defaultValue
 func (_m *Config) Get(path string, defaultValue ...interface{}) interface{} {
 	var _ca []interface{}
@@ -733,6 +813,67 @@ func (_c *Config_GetDuration_Call) RunAndReturn(run func(string, ...time.Duratio
 	return _c
 }
 
+// GetFloat64 provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetFloat64(path string, defaultValue ...float64) float64 {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFloat64")
+	}
+
+	var r0 float64
+	if rf, ok := ret.Get(0).(func(string, ...float64) float64); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	return r0
+}
+
+// Config_GetFloat64_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFloat64'
+type Config_GetFloat64_Call struct {
+	*mock.Call
+}
+
+// GetFloat64 is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...float64
+func (_e *Config_Expecter) GetFloat64(path interface{}, defaultValue ...interface{}) *Config_GetFloat64_Call {
+	return &Config_GetFloat64_Call{Call: _e.mock.On("GetFloat64",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetFloat64_Call) Run(run func(path string, defaultValue ...float64)) *Config_GetFloat64_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]float64, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(float64)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetFloat64_Call) Return(_a0 float64) *Config_GetFloat64_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetFloat64_Call) RunAndReturn(run func(string, ...float64) float64) *Config_GetFloat64_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetInt provides a mock function with given fields: path, defaultValue
 func (_m *Config) GetInt(path string, defaultValue ...int) int {
 	_va := make([]interface{}, len(defaultValue))
@@ -790,6 +931,130 @@ func (_c *Config_GetInt_Call) Return(_a0 int) *Config_GetInt_Call {
 }
 
 func (_c *Config_GetInt_Call) RunAndReturn(run func(string, ...int) int) *Config_GetInt_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetInt64 provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetInt64(path string, defaultValue ...int64) int64 {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetInt64")
+	}
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(string, ...int64) int64); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	return r0
+}
+
+// Config_GetInt64_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetInt64'
+type Config_GetInt64_Call struct {
+	*mock.Call
+}
+
+// GetInt64 is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...int64
+func (_e *Config_Expecter) GetInt64(path interface{}, defaultValue ...interface{}) *Config_GetInt64_Call {
+	return &Config_GetInt64_Call{Call: _e.mock.On("GetInt64",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetInt64_Call) Run(run func(path string, defaultValue ...int64)) *Config_GetInt64_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]int64, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(int64)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetInt64_Call) Return(_a0 int64) *Config_GetInt64_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetInt64_Call) RunAndReturn(run func(string, ...int64) int64) *Config_GetInt64_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetIntSlice provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetIntSlice(path string, defaultValue ...[]int) []int {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetIntSlice")
+	}
+
+	var r0 []int
+	if rf, ok := ret.Get(0).(func(string, ...[]int) []int); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]int)
+		}
+	}
+
+	return r0
+}
+
+// Config_GetIntSlice_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetIntSlice'
+type Config_GetIntSlice_Call struct {
+	*mock.Call
+}
+
+// GetIntSlice is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...[]int
+func (_e *Config_Expecter) GetIntSlice(path interface{}, defaultValue ...interface{}) *Config_GetIntSlice_Call {
+	return &Config_GetIntSlice_Call{Call: _e.mock.On("GetIntSlice",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetIntSlice_Call) Run(run func(path string, defaultValue ...[]int)) *Config_GetIntSlice_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([][]int, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.([]int)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetIntSlice_Call) Return(_a0 []int) *Config_GetIntSlice_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetIntSlice_Call) RunAndReturn(run func(string, ...[]int) []int) *Config_GetIntSlice_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -855,6 +1120,132 @@ func (_c *Config_GetString_Call) RunAndReturn(run func(string, ...string) string
 	return _c
 }
 
+// GetStringMap provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetStringMap(path string, defaultValue ...map[string]interface{}) map[string]interface{} {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetStringMap")
+	}
+
+	var r0 map[string]interface{}
+	if rf, ok := ret.Get(0).(func(string, ...map[string]interface{}) map[string]interface{}); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]interface{})
+		}
+	}
+
+	return r0
+}
+
+// Config_GetStringMap_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStringMap'
+type Config_GetStringMap_Call struct {
+	*mock.Call
+}
+
+// GetStringMap is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...map[string]interface{}
+func (_e *Config_Expecter) GetStringMap(path interface{}, defaultValue ...interface{}) *Config_GetStringMap_Call {
+	return &Config_GetStringMap_Call{Call: _e.mock.On("GetStringMap",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetStringMap_Call) Run(run func(path string, defaultValue ...map[string]interface{})) *Config_GetStringMap_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]map[string]interface{}, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(map[string]interface{})
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetStringMap_Call) Return(_a0 map[string]interface{}) *Config_GetStringMap_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetStringMap_Call) RunAndReturn(run func(string, ...map[string]interface{}) map[string]interface{}) *Config_GetStringMap_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetStringMapString provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetStringMapString(path string, defaultValue ...map[string]string) map[string]string {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetStringMapString")
+	}
+
+	var r0 map[string]string
+	if rf, ok := ret.Get(0).(func(string, ...map[string]string) map[string]string); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+
+	return r0
+}
+
+// Config_GetStringMapString_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStringMapString'
+type Config_GetStringMapString_Call struct {
+	*mock.Call
+}
+
+// GetStringMapString is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...map[string]string
+func (_e *Config_Expecter) GetStringMapString(path interface{}, defaultValue ...interface{}) *Config_GetStringMapString_Call {
+	return &Config_GetStringMapString_Call{Call: _e.mock.On("GetStringMapString",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetStringMapString_Call) Run(run func(path string, defaultValue ...map[string]string)) *Config_GetStringMapString_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]map[string]string, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(map[string]string)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetStringMapString_Call) Return(_a0 map[string]string) *Config_GetStringMapString_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetStringMapString_Call) RunAndReturn(run func(string, ...map[string]string) map[string]string) *Config_GetStringMapString_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetStringSlice provides a mock function with given fields: path, defaultValue
 func (_m *Config) GetStringSlice(path string, defaultValue ...[]string) []string {
 	_va := make([]interface{}, len(defaultValue))
@@ -914,6 +1305,113 @@ func (_c *Config_GetStringSlice_Call) Return(_a0 []string) *Config_GetStringSlic
 }
 
 func (_c *Config_GetStringSlice_Call) RunAndReturn(run func(string, ...[]string) []string) *Config_GetStringSlice_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTime provides a mock function with given fields: path, defaultValue
+func (_m *Config) GetTime(path string, defaultValue ...time.Time) time.Time {
+	_va := make([]interface{}, len(defaultValue))
+	for _i := range defaultValue {
+		_va[_i] = defaultValue[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, path)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTime")
+	}
+
+	var r0 time.Time
+	if rf, ok := ret.Get(0).(func(string, ...time.Time) time.Time); ok {
+		r0 = rf(path, defaultValue...)
+	} else {
+		r0 = ret.Get(0).(time.Time)
+	}
+
+	return r0
+}
+
+// Config_GetTime_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTime'
+type Config_GetTime_Call struct {
+	*mock.Call
+}
+
+// GetTime is a helper method to define mock.On call
+//   - path string
+//   - defaultValue ...time.Time
+func (_e *Config_Expecter) GetTime(path interface{}, defaultValue ...interface{}) *Config_GetTime_Call {
+	return &Config_GetTime_Call{Call: _e.mock.On("GetTime",
+		append([]interface{}{path}, defaultValue...)...)}
+}
+
+func (_c *Config_GetTime_Call) Run(run func(path string, defaultValue ...time.Time)) *Config_GetTime_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]time.Time, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(time.Time)
+			}
+		}
+		run(args[0].(string), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Config_GetTime_Call) Return(_a0 time.Time) *Config_GetTime_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_GetTime_Call) RunAndReturn(run func(string, ...time.Time) time.Time) *Config_GetTime_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// Has provides a mock function with given fields: path
+func (_m *Config) Has(path string) bool {
+	ret := _m.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Has")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// Config_Has_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Has'
+type Config_Has_Call struct {
+	*mock.Call
+}
+
+// Has is a helper method to define mock.On call
+//   - path string
+func (_e *Config_Expecter) Has(path interface{}) *Config_Has_Call {
+	return &Config_Has_Call{Call: _e.mock.On("Has", path)}
+}
+
+func (_c *Config_Has_Call) Run(run func(path string)) *Config_Has_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Config_Has_Call) Return(_a0 bool) *Config_Has_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_Has_Call) RunAndReturn(run func(string) bool) *Config_Has_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary

Extends the `config` package's `Config` contract with commonly needed typedgetters and small inspection helpers, bringing the API closer to parity with
Laravel-style config usage.

## New methods on `contracts/config.Config`

Typed getters:
- `GetInt64(path string, defaultValue ...int64) int64`
- `GetFloat64(path string, defaultValue ...float64) float64`
- `GetTime(path string, defaultValue ...time.Time) time.Time`
- `GetIntSlice(path string, defaultValue ...[]int) []int`
- `GetStringMap(path string, defaultValue ...map[string]any) map[string]any`
- `GetStringMapString(path string, defaultValue ...map[string]string) map[string]string`

Inspection / mutation:
- `Has(path string) bool` — reports whether a path exists without forcing a default
- `Forget(path string)` — removes a runtime-added key
- `All() map[string]any` — returns the full config (useful for `/debug/config` routes, dumps, tests)

## Implementation notes

- Slice and map getters correctly fall back to the supplied default when the
  underlying viper value is `nil` (viper returns a nil slice/map for unset keys
  even when the key technically exists), matching the existing behavior of
  `GetStringSlice`.
- `GetTime` accepts `time.Time`, RFC3339 / RFC3339Nano, `2006-01-02 15:04:05`,
  and `2006-01-02` formats.
- `Forget` uses viper's `Set(path, nil)`, consistent with how viper represents
  missing values.

## Tests

- Added focused test cases for each new method in `config/application_test.go`,
  covering: defaults, missing keys, nil slices/maps, invalid time strings, and
  the lookup/mutation helpers.
- Mocks regenerated via `go tool mockery` (affects `mocks/config/Config.go` and
  `mocks/queue/Config.go`, which embeds `contracts/config.Config`).

## Verification

- `go build ./...`
- `go test ./config/...`
- `golangci-lint run ./config/... ./contracts/config/...` — 0 issues

## Backwards compatibility

This is a purely additive change to the `Config` interface. Existingimplementations and consumers are unaffected.