### PR TITLE
fix: prevent Orm.Connection() cached path from poisoning dbConfig

### DIFF
--- a/database/orm/orm.go
+++ b/database/orm/orm.go
@@ -17,12 +17,40 @@ import (
 	"github.com/goravel/framework/database/gorm"
 )
 
+// QueriesCache is the shared, concurrency-safe registry of connections built
+// from the same database config. Every Orm instance created from the same
+// connection pool shares one QueriesCache, so concurrent Connection(name) calls
+// from different instances (e.g. lazily building the same non-default
+// connection from multiple goroutines) are serialized by the internal mutex.
+type QueriesCache struct {
+	mu          sync.RWMutex
+	connections map[string]cachedConnection
+}
+
+// cachedConnection holds a built connection: the Query handle and the database
+// config it was built from.
+type cachedConnection struct {
+	query    contractsorm.Query
+	dbConfig database.Config
+}
+
+// NewQueriesCache creates a QueriesCache from per-connection queries and
+// configs. queries and dbConfigs must be keyed identically by connection name.
+func NewQueriesCache(queries map[string]contractsorm.Query, dbConfigs map[string]database.Config) *QueriesCache {
+	cache := &QueriesCache{connections: make(map[string]cachedConnection, len(queries))}
+	for name, query := range queries {
+		cache.connections[name] = cachedConnection{query: query, dbConfig: dbConfigs[name]}
+	}
+
+	return cache
+}
+
 type Orm struct {
 	ctx             context.Context
 	config          config.Config
 	log             log.Log
 	query           contractsorm.Query
-	queries         map[string]contractsorm.Query
+	queries         *QueriesCache
 	fresh           func(key ...any)
 	connection      string
 	modelToObserver []contractsorm.ModelToObserver
@@ -30,13 +58,18 @@ type Orm struct {
 	mutex           sync.Mutex
 }
 
+// NewOrm creates a new Orm instance for the given connection.
+//
+// queries is the shared, concurrency-safe registry of built connections and
+// must be non-nil (construct it via NewQueriesCache). It should contain an
+// entry for the connection (extended lazily by Connection()).
 func NewOrm(
 	ctx context.Context,
 	config config.Config,
 	connection string,
 	dbConfig database.Config,
 	query contractsorm.Query,
-	queries map[string]contractsorm.Query,
+	queries *QueriesCache,
 	log log.Log,
 	modelToObserver []contractsorm.ModelToObserver,
 	fresh func(key ...any),
@@ -57,14 +90,10 @@ func NewOrm(
 func BuildOrm(ctx context.Context, config config.Config, connection string, log log.Log, fresh func(key ...any)) (*Orm, error) {
 	query, dbConfig, err := gorm.BuildQuery(ctx, config, connection, log, nil)
 	if err != nil {
-		return NewOrm(ctx, config, connection, dbConfig, nil, nil, log, nil, fresh), err
+		return NewOrm(ctx, config, connection, dbConfig, nil, NewQueriesCache(nil, nil), log, nil, fresh), err
 	}
 
-	queries := map[string]contractsorm.Query{
-		connection: query,
-	}
-
-	return NewOrm(ctx, config, connection, dbConfig, query, queries, log, nil, fresh), nil
+	return NewOrm(ctx, config, connection, dbConfig, query, NewQueriesCache(map[string]contractsorm.Query{connection: query}, map[string]database.Config{connection: dbConfig}), log, nil, fresh), nil
 }
 
 func (r *Orm) Config() database.Config {
@@ -75,8 +104,12 @@ func (r *Orm) Connection(name string) contractsorm.Orm {
 	if name == "" {
 		name = r.config.GetString("database.default")
 	}
-	if instance, exist := r.queries[name]; exist {
-		return NewOrm(r.ctx, r.config, name, r.dbConfig, instance, r.queries, r.log, r.modelToObserver, r.fresh)
+
+	r.queries.mu.RLock()
+	instance, exist := r.queries.connections[name]
+	r.queries.mu.RUnlock()
+	if exist {
+		return NewOrm(r.ctx, r.config, name, instance.dbConfig, instance.query, r.queries, r.log, r.modelToObserver, r.fresh)
 	}
 
 	query, dbConfig, err := gorm.BuildQuery(r.ctx, r.config, name, r.log, r.modelToObserver)
@@ -86,7 +119,14 @@ func (r *Orm) Connection(name string) contractsorm.Orm {
 		return NewOrm(r.ctx, r.config, name, dbConfig, nil, r.queries, r.log, r.modelToObserver, r.fresh)
 	}
 
-	r.queries[name] = query
+	r.queries.mu.Lock()
+	defer r.queries.mu.Unlock()
+	// Double-check: another goroutine may have built this connection first.
+	if instance, exist := r.queries.connections[name]; exist {
+		return NewOrm(r.ctx, r.config, name, instance.dbConfig, instance.query, r.queries, r.log, r.modelToObserver, r.fresh)
+	}
+
+	r.queries.connections[name] = cachedConnection{query: query, dbConfig: dbConfig}
 
 	return NewOrm(r.ctx, r.config, name, dbConfig, query, r.queries, r.log, r.modelToObserver, r.fresh)
 }
@@ -104,7 +144,7 @@ func (r *Orm) DatabaseName() string {
 }
 
 func (r *Orm) Name() string {
-	return r.dbConfig.Connection
+	return r.connection
 }
 
 func (r *Orm) Observe(model any, observer contractsorm.Observer) {
@@ -116,7 +156,14 @@ func (r *Orm) Observe(model any, observer contractsorm.Observer) {
 		Observer: observer,
 	})
 
-	for _, query := range r.queries {
+	r.queries.mu.RLock()
+	queries := make([]contractsorm.Query, 0, len(r.queries.connections))
+	for _, connection := range r.queries.connections {
+		queries = append(queries, connection.query)
+	}
+	r.queries.mu.RUnlock()
+
+	for _, query := range queries {
 		if queryWithObserver, ok := query.(contractsorm.QueryWithObserver); ok {
 			queryWithObserver.Observe(model, observer)
 		}

--- a/database/orm/orm_test.go
+++ b/database/orm/orm_test.go
@@ -1,0 +1,73 @@
+package orm_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/goravel/framework/contracts/database"
+	contractsorm "github.com/goravel/framework/contracts/database/orm"
+	"github.com/goravel/framework/database/orm"
+	mocksorm "github.com/goravel/framework/mocks/database/orm"
+)
+
+func TestOrmConnectionResolvesPerConnectionConfig(t *testing.T) {
+	o := newTestOrm(t)
+
+	got := o.Connection("sqlite")
+	require.Equal(t, "sqlite", got.Name())
+	require.Equal(t, "sqlite_db", got.DatabaseName())
+	require.Equal(t, "sqlite", got.Config().Connection)
+}
+
+func TestOrmConnectionWarmPathConcurrentReads(t *testing.T) {
+	o := newTestOrm(t)
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	var mu sync.Mutex
+	results := make([]connResult, 0, n)
+
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			got := o.Connection("sqlite")
+			mu.Lock()
+			results = append(results, connResult{name: got.Name(), databaseName: got.DatabaseName()})
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+
+	require.Len(t, results, n)
+	for _, result := range results {
+		require.Equal(t, "sqlite", result.name)
+		require.Equal(t, "sqlite_db", result.databaseName)
+	}
+}
+
+type connResult struct {
+	name         string
+	databaseName string
+}
+
+func newTestOrm(t *testing.T) *orm.Orm {
+	t.Helper()
+
+	defaultCfg := database.Config{Connection: "postgres", Database: "default_db"}
+	sqliteCfg := database.Config{Connection: "sqlite", Database: "sqlite_db"}
+	defaultQuery := mocksorm.NewQuery(t)
+	sqliteQuery := mocksorm.NewQuery(t)
+
+	cache := orm.NewQueriesCache(
+		map[string]contractsorm.Query{"postgres": defaultQuery, "sqlite": sqliteQuery},
+		map[string]database.Config{"postgres": defaultCfg, "sqlite": sqliteCfg},
+	)
+
+	return orm.NewOrm(context.Background(), nil, "postgres", defaultCfg, defaultQuery, cache, nil, nil, nil)
+}

--- a/tests/migrator_test.go
+++ b/tests/migrator_test.go
@@ -163,6 +163,52 @@ func TestDefaultMigratorWithSqlserverSchema(t *testing.T) {
 	assert.False(t, schema.HasTable("goravel.users"))
 }
 
+func TestMigratorWithNonDefaultConnection(t *testing.T) {
+	postgresTestQuery := NewTestQueryBuilder().Postgres("", false)
+	sqliteTestQuery := NewTestQueryBuilder().Sqlite("", false)
+
+	docker, err := sqliteTestQuery.Driver().Docker()
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, docker.Shutdown())
+	}()
+
+	sqliteConfig := sqliteTestQuery.Driver().Pool().Writers[0]
+	sqliteConnection := sqliteConfig.Connection
+	postgresConnection := postgresTestQuery.Driver().Pool().Writers[0].Connection
+
+	// Register the sqlite connection on the default (postgres) config so it can be
+	// lazily resolved when a migration requests it via Connection().
+	mockDatabaseConfig(postgresTestQuery.MockConfig(), sqliteConfig)
+
+	// Only the default connection is pre-cached; sqlite is loaded lazily (cold path).
+	schema := newSchema(postgresTestQuery, map[string]*TestQuery{
+		postgresConnection: postgresTestQuery,
+	})
+
+	schema.Register([]contractsschema.Migration{
+		NewTestConnectionMigration(schema, sqliteConnection, "20260826160940_create_users_table", "users"),
+		NewTestConnectionMigration(schema, sqliteConnection, "20260826161140_create_user_tokens_table", "user_tokens"),
+	})
+
+	migrator := migration.NewMigrator(nil, schema, "migrations")
+
+	// Fails on current code: the 2nd ledger row is written to sqlite (no migrations table).
+	assert.NoError(t, migrator.Run())
+
+	// Both tables were created on the non-default (sqlite) connection.
+	assert.True(t, schema.Connection(sqliteConnection).HasTable("users"))
+	assert.True(t, schema.Connection(sqliteConnection).HasTable("user_tokens"))
+
+	// Both ledger rows were written to the default (postgres) connection.
+	status, err := migrator.Status()
+	assert.NoError(t, err)
+	assert.Len(t, status, 2)
+	for _, s := range status {
+		assert.True(t, s.Ran)
+	}
+}
+
 type TestMigration struct {
 	schema contractsschema.Schema
 }
@@ -205,4 +251,33 @@ func (r *TestMigrationWithSqlserverSchema) Up() error {
 
 func (r *TestMigrationWithSqlserverSchema) Down() error {
 	return r.schema.DropIfExists("goravel.users")
+}
+
+type TestConnectionMigration struct {
+	schema     contractsschema.Schema
+	connection string
+	signature  string
+	table      string
+}
+
+func NewTestConnectionMigration(schema contractsschema.Schema, connection, signature, table string) *TestConnectionMigration {
+	return &TestConnectionMigration{schema: schema, connection: connection, signature: signature, table: table}
+}
+
+func (r *TestConnectionMigration) Signature() string {
+	return r.signature
+}
+
+func (r *TestConnectionMigration) Connection() string {
+	return r.connection
+}
+
+func (r *TestConnectionMigration) Up() error {
+	return r.schema.Create(r.table, func(table contractsschema.Blueprint) {
+		table.String("name")
+	})
+}
+
+func (r *TestConnectionMigration) Down() error {
+	return r.schema.DropIfExists(r.table)
 }

--- a/tests/orm_test.go
+++ b/tests/orm_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goravel/framework/contracts/database"
 	contractsorm "github.com/goravel/framework/contracts/database/orm"
 	databasedb "github.com/goravel/framework/database/db"
 	"github.com/goravel/framework/database/orm"
@@ -36,14 +39,16 @@ func (s *OrmSuite) SetupSuite() {
 
 func (s *OrmSuite) SetupTest() {
 	queries := make(map[string]contractsorm.Query)
+	dbConfigs := make(map[string]database.Config)
 
 	for driver, query := range s.queries {
 		query.CreateTable(TestTableRoles)
 		queries[driver] = query.Query()
+		dbConfigs[driver] = query.Driver().Pool().Writers[0]
 	}
 
 	dbConfig := s.queries[s.defaultConnection].Driver().Pool().Writers[0]
-	s.orm = orm.NewOrm(context.Background(), nil, dbConfig.Connection, dbConfig, queries[s.defaultConnection], queries, nil, nil, nil)
+	s.orm = orm.NewOrm(context.Background(), nil, dbConfig.Connection, dbConfig, queries[s.defaultConnection], orm.NewQueriesCache(queries, dbConfigs), nil, nil, nil)
 }
 
 func (s *OrmSuite) TearDownSuite() {
@@ -56,7 +61,60 @@ func (s *OrmSuite) TearDownSuite() {
 
 func (s *OrmSuite) TestConnection() {
 	for connection := range s.queries {
-		s.NotNil(s.orm.Connection(connection))
+		orm := s.orm.Connection(connection)
+		s.NotNil(orm)
+		s.Equal(connection, orm.Name())
+		s.Equal(s.queries[connection].Driver().Pool().Writers[0].Database, orm.DatabaseName())
+	}
+}
+
+func TestOrmConnectionConcurrentSafe(t *testing.T) {
+	postgresTestQuery := NewTestQueryBuilder().Postgres("", false)
+	sqliteTestQuery := NewTestQueryBuilder().Sqlite("", false)
+
+	docker, err := sqliteTestQuery.Driver().Docker()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, docker.Shutdown())
+	}()
+
+	sqliteConfig := sqliteTestQuery.Driver().Pool().Writers[0]
+	sqliteConnection := sqliteConfig.Connection
+	postgresConnection := postgresTestQuery.Driver().Pool().Writers[0].Connection
+
+	mockDatabaseConfig(postgresTestQuery.MockConfig(), sqliteConfig)
+
+	schema := newSchema(postgresTestQuery, map[string]*TestQuery{
+		postgresConnection: postgresTestQuery,
+	})
+
+	n := 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	var mu sync.Mutex
+	results := make([]contractsorm.Orm, 0, n)
+
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func() {
+			<-start
+			defer wg.Done()
+			orm := schema.Orm().Connection(sqliteConnection)
+			mu.Lock()
+			results = append(results, orm)
+			mu.Unlock()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	require.Len(t, results, n)
+	for _, orm := range results {
+		require.NotNil(t, orm)
+		require.Equal(t, sqliteConnection, orm.Name())
+		require.Equal(t, sqliteConfig.Database, orm.DatabaseName())
 	}
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 
+	contractsdatabase "github.com/goravel/framework/contracts/database"
 	contractsorm "github.com/goravel/framework/contracts/database/orm"
 	databaseorm "github.com/goravel/framework/database/orm"
 	"github.com/goravel/framework/database/schema"
@@ -18,13 +19,15 @@ const (
 
 func newSchema(testQuery *TestQuery, connectionToTestQuery map[string]*TestQuery) *schema.Schema {
 	queries := make(map[string]contractsorm.Query)
+	dbConfigs := make(map[string]contractsdatabase.Config)
 	for connection, testQuery := range connectionToTestQuery {
 		queries[connection] = testQuery.Query()
+		dbConfigs[connection] = testQuery.Driver().Pool().Writers[0]
 	}
 
 	log := utils.NewTestLog()
 	dbConfig := testQuery.Driver().Pool().Writers[0]
-	orm := databaseorm.NewOrm(context.Background(), testQuery.Config(), dbConfig.Connection, dbConfig, testQuery.Query(), queries, log, nil, nil)
+	orm := databaseorm.NewOrm(context.Background(), testQuery.Config(), dbConfig.Connection, dbConfig, testQuery.Query(), databaseorm.NewQueriesCache(queries, dbConfigs), log, nil, nil)
 
 	schema, err := schema.NewSchema(testQuery.Config(), log, orm, testQuery.Driver(), nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `Orm.Connection()` now resolves each connection's own database config from a shared, concurrency-safe `QueriesCache`, so `Name()`/`DatabaseName()` and connection-scoped behavior (like where the migration ledger row is written) reflect the requested connection instead of the default's.
- Concurrent `Connection()` calls that lazily build the same connection are now serialized by double-checked locking, eliminating the data race on the connection cache — `TestOrmConnectionConcurrentSafe` passes under `-race` and fails on the unlocked version.
- The exported `database/orm/NewOrm` constructor now takes a `*QueriesCache` built via the new `NewQueriesCache(queries, dbConfigs)` — breaking only for direct callers of the concrete constructor; `contractsorm.Orm` is unchanged, so no mock regeneration is needed.

Closes https://github.com/goravel/goravel/issues/987

## Why
This is a backport of https://github.com/goravel/framework/pull/1540 to the `v1.17.x` release branch (original issue: https://github.com/goravel/goravel/issues/987). `Orm.Connection()` had a cached fast path that ignored the requested connection and reused the receiver's `dbConfig`. Once a non-default connection had been resolved, every later `Connection()` call for it returned an `Orm` whose `Name()`/`DatabaseName()` — and therefore derived behavior like where the migration ledger row gets written — still pointed at the default connection. Running two migrations on the same non-default `Connection()` wrote the second ledger row to the wrong database.

```go
// app/database/migrations — two consecutive migrations on the same non-default connection
func (r *M20260826160940CreateUsersTable) Connection() string {
	return "sqlite"
}

func (r *M20260826161140CreateUserTokensTable) Connection() string {
	return "sqlite"
}
```

Before the fix, the second migration's ledger row was written to the sqlite connection, where no `migrations` table exists, failing the run. After the fix, both migrations run on their declared `sqlite` connection while both ledger rows are recorded on the default connection, matching Laravel's behavior.

The same fix hardens the connection cache for concurrent use. Lazy connection builds now flow through a shared `QueriesCache` guarded by an `RWMutex` with double-checked locking, so concurrent cold-path calls from different goroutines no longer race on the shared maps; `Observe()` snapshots the cache under a read lock before invoking user code. As a cleanup, the ambiguous internal cache field was renamed from `m` to `connections`.

```go
// Concurrent resolution of the same lazily-built connection from multiple goroutines
var wg sync.WaitGroup
for range 10 {
	wg.Add(1)
	go func() {
		defer wg.Done()
		orm := facades.Orm().Connection("sqlite")
		// ...
	}()
}
wg.Wait()
```

Before the fix, these concurrent cold-path calls raced on the shared connection maps (a `DATA RACE` under `-race`). After the fix, double-checked locking serializes the build and every caller gets an `Orm` bound to the requested connection.
