### PR TITLE
fix: [#995] upgrade dromara/carbon to v2.6.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/charmbracelet/huh/spinner v0.0.0-20260223110133-9dc45e34a40b
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/dave/dst v0.27.4
-	github.com/dromara/carbon/v2 v2.6.11
+	github.com/dromara/carbon/v2 v2.6.17
 	github.com/gabriel-vasile/mimetype v1.4.15
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/goforj/godump v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dromara/carbon/v2 v2.6.11 h1:wnAWZ+sbza1uXw3r05hExNSCaBPFaarWfUvYAX86png=
-github.com/dromara/carbon/v2 v2.6.11/go.mod h1:7GXqCUplwN1s1b4whGk2zX4+g4CMCoDIZzmjlyt0vLY=
+github.com/dromara/carbon/v2 v2.6.17 h1:QL1LVcp5A/NQtIPbc1vrL9qIXxPNWnaDOBaFlmP1iDg=
+github.com/dromara/carbon/v2 v2.6.17/go.mod h1:NGo3reeV5vhWCYWcSqbJRZm46MEwyfYI5EJRdVFoLJo=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=

--- a/support/carbon/carbon_test.go
+++ b/support/carbon/carbon_test.go
@@ -267,7 +267,7 @@ func TestFromPersian(t *testing.T) {
 }
 
 func TestFromHebrew(t *testing.T) {
-	assert.Equal(t, "2023-12-17", FromHebrew(5784, 10, 20).ToDateString())
-	assert.Equal(t, "2024-07-21", FromHebrew(5784, 5, 1).ToDateString())
-	assert.Equal(t, "2025-09-18", FromHebrew(5786, 7, 10).ToDateString())
+	assert.Equal(t, "2024-01-01", FromHebrew(5784, 10, 20).ToDateString())
+	assert.Equal(t, "2024-08-05", FromHebrew(5784, 5, 1).ToDateString())
+	assert.Equal(t, "2025-10-02", FromHebrew(5786, 7, 10).ToDateString())
 }


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/995

Bumps `github.com/dromara/carbon/v2` from `v2.6.11` (2025-07-18) to `v2.6.17`
(2026-08-09). No framework source changes, only `go.mod`, `go.sum` and three
corrected test expectations.

carbon is listed in `ignoreDeps` in `renovate.json`, added in `b99b8c93` during
the discussion in goravel/goravel#645, when `v2.6.x` was still a breaking change
for goravel v1.15. That migration has since happened and we are on `v2.6.11`,
but the Renovate exclusion stayed, so six patch releases inside `v2.6.x` never
reached us. `master`, `v1.18.x` and `v1.17.x` all pin `v2.6.11`.

### 1. Timezone resolution is no longer repeated on every call

`time.LoadLocation` caches only `""`, `"UTC"` and `"Local"`. Every other IANA
name is re-read and re-parsed from tzdata on each call. carbon v2.6.11 calls it
unconditionally in `parseTimezone`, which sits on the path of `NewCarbon()`, so
the cost applies to every Carbon construction and not just `Now()`. `v2.6.12`
added a `sync.Map` that caches successful lookups.

We call `carbon.Now()` from 50 non-test sites, including
`gorm.Config.NowFunc` (`database/driver/gorm.go:60`), so every GORM
create/update timestamp, and 10 sites in `database/db/query.go`.

Benchmark used on both versions:

```go
package carbon_test

import (
	"testing"

	"github.com/goravel/framework/support/carbon"
)

func BenchmarkNowNonUTC(b *testing.B) {
	carbon.SetTimezone("America/New_York")
	b.ReportAllocs()
	for b.Loop() {
		_ = carbon.Now()
	}
}

func BenchmarkNowNonUTCParallel(b *testing.B) {
	carbon.SetTimezone("America/New_York")
	b.ReportAllocs()
	b.RunParallel(func(pb *testing.PB) {
		for pb.Next() {
			_ = carbon.Now()
		}
	})
}
```

```
go test ./support/carbon/ -bench='NowNonUTC' -benchmem -run=^$
```

before, `v2.6.11`:

```
BenchmarkNowNonUTC-8           	   61053	     17823 ns/op	   12366 B/op	      43 allocs/op
BenchmarkNowNonUTCParallel-8   	  146809	      8226 ns/op	   12439 B/op	      43 allocs/op
```

after, `v2.6.17`:

```
BenchmarkNowNonUTC-8           	 1968549	       597.7 ns/op	    1600 B/op	      13 allocs/op
BenchmarkNowNonUTCParallel-8   	 3046171	       399.6 ns/op	    1600 B/op	      13 allocs/op
```

About 30x faster sequential, 21x parallel, 7.7x less garbage.
go1.27.0, darwin/arm64, Apple M3.

With `app.timezone = UTC` there is no measurable difference, since the stdlib
short-circuits. The benchmark sets a real timezone for that reason.

### 2. Hebrew date conversion was broken and is now fixed

`TestFromHebrew` needed updating. The old expectations were wrong, this is not
a test bent to fit a new dependency.

`Gregorian -> Hebrew -> Gregorian` should return the original date. Over 3000
consecutive dates from 2020-01-01:

| version | broken round-trips |
|---|---|
| v2.6.11 | 3000 / 3000 (100%) |
| v2.6.17 | 0 / 3000 |

The forward direction was already correct in v2.6.11. Only `CreateFromHebrew`
was wrong, which is why `TestFromHebrew` is the only affected test. It is the
one place we exercise the reverse direction.

Cross-checked against a separate implementation following Dershowitz &
Reingold's *Calendrical Calculations*, validated against published dates for
Yom Kippur 5786, Rosh Hashanah 5786, Tisha B'Av 5784, Asara B'Tevet 5784,
Pesach 5785 and Hanukkah 5785. All matched.

| input | old expectation | new expectation | independent reference |
|---|---|---|---|
| `FromHebrew(5784, 10, 20)` | 2023-12-17 | 2024-01-01 | 2024-01-01 |
| `FromHebrew(5784, 5, 1)` | 2024-07-21 | 2024-08-05 | 2024-08-05 |
| `FromHebrew(5786, 7, 10)` | 2025-09-18 | 2025-10-02 | 2025-10-02 |

Upstream replaced the floating-point conversion with exact integer Rata Die
arithmetic, corrected their own expectations, and now covers both directions
against an authoritative dataset.

### Scope

* `go.mod` / `go.sum`: carbon `v2.6.11` to `v2.6.17`
* `support/carbon/carbon_test.go`: three corrected expectations

## ✅ Checks

- [ ] Added test cases for my code

No new tests. This PR changes a dependency version and corrects three
expectations that were asserting an upstream bug, so there is no new code to
cover. `support/carbon.FromHebrew` is a one-line delegate to
`carbon.CreateFromHebrew`, and both conversion directions are covered by
carbon's own suite in `calendar/hebrew`. Happy to add a round-trip regression
test here instead if you would rather guard the boundary on our side.

Verified locally:

```
go build ./...   ok
go test ./...    ok, full suite
go vet ./...     one pre-existing warning in generated mocks, also present on master
```
