### PR TITLE
fix: [#996] guard the translation loaded map against concurrent access

### DIFF
--- a/translation/translator.go
+++ b/translation/translator.go
@@ -24,16 +24,23 @@ type Translator struct {
 	selector   *MessageSelector
 	locale     string
 	fallback   string
-	mu         sync.Mutex
 }
 
-// loaded is a map structure used to store loaded translation data.
-// It is organized as follows:
-//   - First map (map[string]): Maps from locale to...
-//   - Second map (map[string]): Maps from folder(group) to...
-//   - Third map (map[string]): Maps from key to...
-//   - Value (any): The translation line corresponding to the key in the specified locale, folder(group), and key hierarchy.
-var loaded = make(map[string]map[string]map[string]any)
+// loaded stores the translation data that has been read from a loader. The key
+// is the locale and the folder(group) it came from, the value is the map from
+// translation key to line.
+//
+// The state is package level because the Lang binding is registered with
+// BindWith: every facades.Lang() call builds a new Translator, so per-instance
+// state would guard nothing.
+//
+// loaded is a sync.Map because the access pattern is the one it is built for, a
+// cache that only grows where every entry is written once and read many times.
+// loadMu serializes the cold path only, so a group is still loaded exactly once.
+var (
+	loaded sync.Map
+	loadMu sync.Mutex
+)
 
 // contextKey is an unexported type for keys defined in this package.
 type contextKey string
@@ -156,7 +163,7 @@ func (t *Translator) SetLocale(locale string) context.Context {
 }
 
 func (t *Translator) getLine(locale string, group string, key string, options ...translationcontract.Option) string {
-	err := t.load(locale, group)
+	translations, err := t.load(locale, group)
 	if err != nil {
 		if errors.Is(err, errors.LangFileNotExist) {
 			return ""
@@ -168,7 +175,7 @@ func (t *Translator) getLine(locale string, group string, key string, options ..
 		return ""
 	}
 
-	keyValue := getValue(loaded[locale][group], key)
+	keyValue := getValue(translations, key)
 	// If the key doesn't exist, return empty string.
 	if keyValue == nil {
 		return ""
@@ -185,17 +192,22 @@ func (t *Translator) getLine(locale string, group string, key string, options ..
 	return line
 }
 
-func (t *Translator) load(locale string, group string) error {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+func (t *Translator) load(locale string, group string) (map[string]any, error) {
+	if translations, ok := lookupLoaded(locale, group); ok {
+		return translations, nil
+	}
 
-	if t.isLoaded(locale, group) {
-		return nil
+	loadMu.Lock()
+	defer loadMu.Unlock()
+
+	// Another goroutine may have loaded the group while this one waited.
+	if translations, ok := lookupLoaded(locale, group); ok {
+		return translations, nil
 	}
 
 	// Check if no loaders are available
 	if t.fileLoader == nil && t.fsLoader == nil {
-		return errors.LangNoLoaderAvailable
+		return nil, errors.LangNoLoaderAvailable
 	}
 
 	var (
@@ -210,26 +222,30 @@ func (t *Translator) load(locale string, group string) error {
 		translations, err = t.fsLoader.Load(locale, group)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if loaded[locale] == nil {
-		loaded[locale] = make(map[string]map[string]any)
+	loaded.Store(loadedKey(locale, group), translations)
+	return translations, nil
+}
+
+func loadedKey(locale string, group string) string {
+	return locale + "\x00" + group
+}
+
+func lookupLoaded(locale string, group string) (map[string]any, bool) {
+	value, ok := loaded.Load(loadedKey(locale, group))
+	if !ok {
+		return nil, false
 	}
-	loaded[locale][group] = translations
-	return nil
+
+	translations, ok := value.(map[string]any)
+	return translations, ok
 }
 
 func (t *Translator) isLoaded(locale string, group string) bool {
-	if _, ok := loaded[locale]; !ok {
-		return false
-	}
-
-	if _, ok := loaded[locale][group]; !ok {
-		return false
-	}
-
-	return true
+	_, ok := lookupLoaded(locale, group)
+	return ok
 }
 
 func makeReplacements(line string, replace map[string]string) string {

--- a/translation/translator_test.go
+++ b/translation/translator_test.go
@@ -2,6 +2,8 @@ package translation
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"testing/fstest"
 
@@ -31,7 +33,7 @@ func (s *TranslatorTestSuite) SetupTest() {
 	s.mockLoader = mockloader.NewLoader(s.T())
 	s.ctx = context.Background()
 	s.mockLog = mocklog.NewLog(s.T())
-	loaded = make(map[string]map[string]map[string]any)
+	loaded.Clear()
 }
 
 func (s *TranslatorTestSuite) TestChoice() {
@@ -362,13 +364,9 @@ func (s *TranslatorTestSuite) TestLoad() {
 			fsLoader:   fsLoader,
 			fileLoader: s.mockLoader,
 			setup: func() {
-				loaded = map[string]map[string]map[string]any{
-					"en": {
-						"test": {
-							"foo": "bar",
-						},
-					},
-				}
+				loaded.Store(loadedKey("en", "test"), map[string]any{
+					"foo": "bar",
+				})
 			},
 			locale: "en",
 			group:  "test",
@@ -491,20 +489,21 @@ func (s *TranslatorTestSuite) TestLoad() {
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			loaded = make(map[string]map[string]map[string]any)
+			loaded.Clear()
 
 			tt.setup()
 
 			translator := NewTranslator(s.ctx, tt.fsLoader, tt.fileLoader, "en", "en", s.mockLog)
 
-			err := translator.load(tt.locale, tt.group)
+			_, err := translator.load(tt.locale, tt.group)
 
 			if tt.expectError != nil {
 				s.Equal(tt.expectError.Error(), err.Error())
 			} else {
 				s.NoError(err)
 				if tt.expected != nil {
-					s.Equal(tt.expected, loaded[tt.locale][tt.group])
+					actual, _ := lookupLoaded(tt.locale, tt.group)
+					s.Equal(tt.expected, actual)
 				}
 			}
 		})
@@ -516,7 +515,7 @@ func (s *TranslatorTestSuite) TestIsLoaded() {
 	s.mockLoader.On("Load", "en", "bar").Once().Return(map[string]any{
 		"foo": "one",
 	}, nil)
-	err := translator.load("en", "bar")
+	_, err := translator.load("en", "bar")
 	s.NoError(err)
 
 	// Case: Folder and locale are not loaded
@@ -527,6 +526,35 @@ func (s *TranslatorTestSuite) TestIsLoaded() {
 
 	// Case: Both folder and locale are loaded
 	s.True(translator.isLoaded("en", "bar"))
+}
+
+// concurrentLoader stands in for a real loader, the mock is not meant to be
+// driven from several goroutines at once.
+type concurrentLoader struct{}
+
+func (concurrentLoader) Load(locale, group string) (map[string]any, error) {
+	return map[string]any{"foo": "bar"}, nil
+}
+
+// TestConcurrentGet guards the package level loaded map. The Lang binding is
+// registered with BindWith, so every facades.Lang() call builds a new Translator
+// and a per instance mutex would guard nothing. Before the fix this crashed the
+// process with "concurrent map read and map write".
+func (s *TranslatorTestSuite) TestConcurrentGet() {
+	loaded.Clear()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			translator := NewTranslator(context.Background(), nil, concurrentLoader{}, "en", "en", s.mockLog)
+			translator.SetLocale(fmt.Sprintf("locale%d", i%8))
+			s.Equal("bar", translator.Get("foo"))
+		}(i)
+	}
+	wg.Wait()
 }
 
 func TestMakeReplacements(t *testing.T) {


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/996

Translating from more than one goroutine crashes the process. `loaded` is a
package level map (`translation/translator.go:36`) but `mu` is a field on
`Translator` (`:27`). The Lang binding is registered with `BindWith`, so
`facades.Lang(ctx)` builds a new `Translator` on every call, each with its own
mutex, while they all read and write the same package level map. The mutex
guarded nothing.

`getLine` made it worse by reading `loaded[locale][group]` (`:171`) outside any
lock at all, so a package level mutex on its own would not have been enough
either.

Reproduced without the race detector, 41 fatal errors in 60 runs:

```
fatal error: concurrent map read and map write
  translation/translator.go:224   isLoaded
  translation/translator.go:192   load
  translation/translator.go:159   getLine
  translation/translator.go:97    Get
```

Present in `master`, `v1.18.0` and `v1.17.x`.

### What changed

`loaded` is now a `sync.Map`. Its access pattern is the one `sync.Map`
documents itself for: a cache that only grows, where every entry is written
once and read many times. A plain mutex still serializes the cold path and
re-checks the cache after taking it, so a group is loaded exactly once, same as
before.

`load` returns the group it resolved, so `getLine` no longer reaches into the
map a second time. `isLoaded` keeps its signature and goes through the same
lookup helper. The per instance `mu` field is gone, it had no job left.

### Verification

| | before | after |
|---|---|---|
| fatal errors in 60 runs, no `-race` | 41 | 0 |
| `go test ./translation/ -race -count=3` | DATA RACE | clean |
| added regression test, 10 runs under `-race` | fails 10/10 | passes |

Full framework suite passes.

Taking the read lock instead of the full mutex, and dropping the second map
lookup, also shows up in the numbers:

```
go test ./translation/ -bench='Get' -benchmem -run=^$
```

before:
```
BenchmarkGetSequential-8   129.7 ns/op   48 B/op   3 allocs/op
BenchmarkGetParallel-8     226.6 ns/op   48 B/op   3 allocs/op
```

after:
```
BenchmarkGetSequential-8    49.75 ns/op   16 B/op   1 allocs/op
BenchmarkGetParallel-8      13.19 ns/op   16 B/op   1 allocs/op
```

The shape matters more than the absolute numbers. Parallel lookups used to be
2.1x slower per operation than sequential ones, which is what a mutex taken on
every lookup looks like. They are now 3.8x faster, which is what scaling across
cores looks like.

I also measured a `RWMutex` over the existing nested map. It fixes the crash
just as well, but it does not scale: 39.07 ns sequential and 81.82 ns parallel,
degrading further as cores are added, because every reader writes to the shared
reader count. Happy to switch to that if you would rather keep the map shape.

### Scope

* `translation/translator.go`: the fix
* `translation/translator_test.go`: regression test, and two call sites updated
  for the new `load` signature

No public API changed. `load` and `isLoaded` are unexported.

## ✅ Checks

- [x] Added test cases for my code

`TestConcurrentGet` builds translators the way `facades.Lang()` does and
resolves from 200 goroutines. It fails 10 out of 10 runs under `-race` without
the fix.
