### PR TITLE
fix: [#997] stop Memory.Flush from replacing the sync.Map it shares with readers

### DIFF
--- a/cache/memory.go
+++ b/cache/memory.go
@@ -82,7 +82,7 @@ func (r *Memory) Forget(key string) bool {
 
 // Flush Remove all items from the cache.
 func (r *Memory) Flush() bool {
-	r.instance = sync.Map{}
+	r.instance.Clear()
 	return true
 }
 

--- a/cache/memory_test.go
+++ b/cache/memory_test.go
@@ -111,6 +111,36 @@ func (s *MemoryTestSuite) TestFlush() {
 	s.False(s.memory.Has("test-flush"))
 }
 
+// TestFlushWhileReading guards against replacing the sync.Map itself. Assigning
+// a fresh sync.Map over it swaps out the mutex the readers inside Load are
+// holding, and the runtime kills the process with "sync: unlock of unlocked
+// mutex". Before the fix this crashed 13 out of 20 runs, without the race
+// detector.
+func (s *MemoryTestSuite) TestFlushWhileReading() {
+	s.Nil(s.memory.Put("test-flush-while-reading", "goravel", NoExpiration))
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 500 {
+				s.memory.Get("test-flush-while-reading")
+			}
+		}()
+	}
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 200 {
+				s.memory.Flush()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func (s *MemoryTestSuite) TestGet() {
 	s.Nil(s.memory.Put("name", "Goravel", 1*time.Second))
 	s.Equal("Goravel", s.memory.Get("name", "").(string))


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/997

`Memory.Flush()` assigned a fresh `sync.Map` over `r.instance`:

```go
func (r *Memory) Flush() bool {
	r.instance = sync.Map{}
	return true
}
```

`sync.Map` carries its own mutex, so that assignment swaps the mutex out from
under a goroutine sitting inside `Load`. The reader reaches its unlock, finds a
mutex that is no longer locked, and the runtime kills the process:

```
fatal error: sync: unlock of unlocked mutex
```

Not a race detector warning, a check built into the runtime. The added test
crashed 20 of 20 runs without `-race`. Under `-race` it also reports a write at
`memory.go:85` against concurrent readers.

`Flush` is public API, reachable as `facades.Cache().Flush()`, so one request
clearing the cache while others read from it is enough to hit this.

Present in `master`, `v1.18.0` and `v1.17.x`.

### What changed

`sync.Map.Clear` drops every entry without replacing the value, so the mutex the
readers hold stays intact. It has been available since Go 1.23 and `go.mod` asks
for 1.26.

### Verification

| | before | after |
|---|---|---|
| `TestFlushWhileReading`, 10 runs, no `-race` | 10 fatal errors | 0 |
| `TestFlushWhileReading` under `-race` | DATA RACE at `memory.go:85` | clean |
| `go test ./cache/` | | pass |

`go test ./cache/ -race` for the whole package still fails on master because of
`TestIncrementWithConcurrent` and `TestDecrementWithConcurrent`, which share one
`err` variable across goroutines. That is unrelated to this change.

The existing `cache` suite and the full framework suite pass.

### Scope

* `cache/memory.go`: one line, plus a comment on why
* `cache/memory_test.go`: regression test

No public API changed.

## ✅ Checks

- [x] Added test cases for my code

`TestFlushWhileReading` reads one key from 50 goroutines while 10 others call
`Flush`. It crashes every run against the old code, without the race detector.
