### PR TITLE
fix: [#960] make cache lock optional for the database queue driver

### DIFF
--- a/queue/driver_creator_test.go
+++ b/queue/driver_creator_test.go
@@ -76,6 +76,7 @@ func (s *DriverCreatorTestSuite) TestCreate() {
 			setup: func() {
 				s.mockConfig.EXPECT().Driver("database").Return(contractsqueue.DriverDatabase).Once()
 				s.mockConfig.EXPECT().GetString("queue.connections.database.connection").Return("mysql").Once()
+				s.mockConfig.EXPECT().GetBool("queue.connections.database.use_cache_lock").Return(false).Once()
 				s.mockConfig.EXPECT().GetString("queue.connections.database.table", "jobs").Return("jobs").Once()
 				s.mockConfig.EXPECT().GetInt("queue.connections.database.retry_after", 60).Return(60).Once()
 				s.mockDB.EXPECT().Connection("mysql").Return(s.mockDB).Once()

--- a/queue/driver_database.go
+++ b/queue/driver_database.go
@@ -24,8 +24,9 @@ type Database struct {
 	jobStorer contractsqueue.JobStorer
 	json      contractsfoundation.Json
 
-	jobsTable  string
-	retryAfter int
+	jobsTable    string
+	retryAfter   int
+	useCacheLock bool
 }
 
 func NewDatabase(
@@ -35,13 +36,18 @@ func NewDatabase(
 	jobStorer contractsqueue.JobStorer,
 	json contractsfoundation.Json,
 	connection string) (*Database, error) {
-	if cache == nil {
-		return nil, errors.CacheFacadeNotSet.SetModule(errors.ModuleQueue)
-	}
-
 	dbConnection := config.GetString(fmt.Sprintf("queue.connections.%s.connection", connection))
 	if dbConnection == "" {
 		return nil, errors.QueueInvalidDatabaseConnection.Args(connection)
+	}
+
+	// The cache lock is opt-in: the SELECT ... FOR UPDATE inside the
+	// transaction already serializes job reservation on the database
+	// (same contract as Laravel's database queue driver), so a cache
+	// backend is not required unless explicitly enabled.
+	useCacheLock := config.GetBool(fmt.Sprintf("queue.connections.%s.use_cache_lock", connection))
+	if useCacheLock && cache == nil {
+		return nil, errors.CacheFacadeNotSet.SetModule(errors.ModuleQueue)
 	}
 
 	return &Database{
@@ -50,8 +56,9 @@ func NewDatabase(
 		jobStorer: jobStorer,
 		json:      json,
 
-		jobsTable:  config.GetString(fmt.Sprintf("queue.connections.%s.table", connection), "jobs"),
-		retryAfter: config.GetInt(fmt.Sprintf("queue.connections.%s.retry_after", connection), 60),
+		jobsTable:    config.GetString(fmt.Sprintf("queue.connections.%s.table", connection), "jobs"),
+		retryAfter:   config.GetInt(fmt.Sprintf("queue.connections.%s.retry_after", connection), 60),
+		useCacheLock: useCacheLock,
 	}, nil
 }
 
@@ -62,13 +69,15 @@ func (r *Database) Driver() string {
 func (r *Database) Pop(queue string) (contractsqueue.ReservedJob, error) {
 	var job models.Job
 
-	cacheLock := fmt.Sprintf("goravel:queue-database-%s:lock", queue)
-	lock := r.cache.Lock(cacheLock, 1*time.Minute)
-	if !lock.Block(1 * time.Minute) {
-		return nil, errors.QueuePopIsLocked.Args(queue, cacheLock)
-	}
+	if r.useCacheLock {
+		cacheLock := fmt.Sprintf("goravel:queue-database-%s:lock", queue)
+		lock := r.cache.Lock(cacheLock, 1*time.Minute)
+		if !lock.Block(1 * time.Minute) {
+			return nil, errors.QueuePopIsLocked.Args(queue, cacheLock)
+		}
 
-	defer lock.Release()
+		defer lock.Release()
+	}
 
 	if err := r.db.Transaction(func(tx contractsdb.Tx) error {
 		if err := tx.Table(r.jobsTable).LockForUpdate().Where("queue", queue).Where(func(q contractsdb.Query) contractsdb.Query {

--- a/queue/driver_database_test.go
+++ b/queue/driver_database_test.go
@@ -59,16 +59,18 @@ func (s *DatabaseTestSuite) TestNewDatabase() {
 	var mockConfig *mocksqueue.Config
 
 	tests := []struct {
-		name          string
-		cache         contractscache.Cache
-		setup         func()
-		expectedError error
+		name             string
+		cache            contractscache.Cache
+		setup            func()
+		wantUseCacheLock bool
+		expectedError    error
 	}{
 		{
-			name:  "successful creation",
-			cache: mockscache.NewCache(s.T()),
+			name:  "successful creation without cache",
+			cache: nil,
 			setup: func() {
 				mockConfig.EXPECT().GetString("queue.connections.default.connection").Return("mysql").Once()
+				mockConfig.EXPECT().GetBool("queue.connections.default.use_cache_lock").Return(false).Once()
 				mockConfig.EXPECT().GetString("queue.connections.default.table", "jobs").Return("jobs").Once()
 				mockConfig.EXPECT().GetInt("queue.connections.default.retry_after", 60).Return(60).Once()
 				s.mockDB.EXPECT().Connection("mysql").Return(s.mockDB).Once()
@@ -76,8 +78,25 @@ func (s *DatabaseTestSuite) TestNewDatabase() {
 			expectedError: nil,
 		},
 		{
-			name:          "invalid cache",
-			setup:         func() {},
+			name:  "successful creation with cache lock",
+			cache: mockscache.NewCache(s.T()),
+			setup: func() {
+				mockConfig.EXPECT().GetString("queue.connections.default.connection").Return("mysql").Once()
+				mockConfig.EXPECT().GetBool("queue.connections.default.use_cache_lock").Return(true).Once()
+				mockConfig.EXPECT().GetString("queue.connections.default.table", "jobs").Return("jobs").Once()
+				mockConfig.EXPECT().GetInt("queue.connections.default.retry_after", 60).Return(60).Once()
+				s.mockDB.EXPECT().Connection("mysql").Return(s.mockDB).Once()
+			},
+			wantUseCacheLock: true,
+			expectedError:    nil,
+		},
+		{
+			name:  "cache lock requested but cache not set",
+			cache: nil,
+			setup: func() {
+				mockConfig.EXPECT().GetString("queue.connections.default.connection").Return("mysql").Once()
+				mockConfig.EXPECT().GetBool("queue.connections.default.use_cache_lock").Return(true).Once()
+			},
 			expectedError: errors.CacheFacadeNotSet.SetModule(errors.ModuleQueue),
 		},
 		{
@@ -109,6 +128,7 @@ func (s *DatabaseTestSuite) TestNewDatabase() {
 				s.Equal(s.mockJson, database.json)
 				s.Equal(s.jobsTable, database.jobsTable)
 				s.Equal(s.retryAfter, database.retryAfter)
+				s.Equal(test.wantUseCacheLock, database.useCacheLock)
 			}
 		})
 	}
@@ -128,12 +148,80 @@ func (s *DatabaseTestSuite) TestPop() {
 
 	tests := []struct {
 		name            string
+		useCacheLock    bool
 		setup           func()
 		wantReservedJob contractsqueue.ReservedJob
 		wantError       error
 	}{
 		{
 			name: "happy path",
+			setup: func() {
+				mockTx := mocksdb.NewTx(s.T())
+				mockQuery := mocksdb.NewQuery(s.T())
+
+				s.mockDB.EXPECT().Transaction(mock.Anything).Run(func(txFunc func(tx contractsdb.Tx) error) {
+					s.NoError(txFunc(mockTx))
+				}).Return(nil).Once()
+
+				mockTx.EXPECT().Table(s.jobsTable).Return(mockQuery).Once()
+				mockQuery.EXPECT().LockForUpdate().Return(mockQuery).Once()
+				mockQuery.EXPECT().Where("queue", queue).Return(mockQuery).Once()
+				mockQuery.EXPECT().Where(mock.Anything).Return(mockQuery).Once()
+				mockQuery.EXPECT().OrderBy("id").Return(mockQuery).Once()
+
+				var job models.Job
+				wantJob := models.Job{
+					ID:       1,
+					Queue:    queue,
+					Payload:  payload,
+					Attempts: 0,
+				}
+				mockQuery.EXPECT().First(&job).
+					Run(func(dest any) {
+						*dest.(*models.Job) = wantJob
+					}).Return(nil).Once()
+
+				mockTx.EXPECT().Table(s.jobsTable).Return(mockQuery).Once()
+				mockQuery.EXPECT().Where("id", uint(1)).Return(mockQuery).Once()
+				mockQuery.EXPECT().Update(map[string]any{
+					"attempts":    1,
+					"reserved_at": carbon.NewDateTime(carbon.Now()),
+				}).Return(nil, nil).Once()
+
+				var task utils.Task
+				s.mockJson.EXPECT().UnmarshalString(payload, &task).
+					Run(func(_ string, taskPtr any) {
+						*taskPtr.(*utils.Task) = utils.Task{
+							UUID: "test",
+							Job: utils.Job{
+								Signature: testJobOne.Signature(),
+							},
+						}
+					}).Return(nil).Once()
+				s.mockJobStorer.EXPECT().Get(testJobOne.Signature()).Return(testJobOne, nil).Once()
+			},
+			wantReservedJob: &DatabaseReservedJob{
+				db: s.mockDB,
+				job: &models.Job{
+					ID:         1,
+					Queue:      queue,
+					Payload:    payload,
+					Attempts:   1,
+					ReservedAt: carbon.NewDateTime(carbon.Now()),
+				},
+				jobsTable: s.jobsTable,
+				task: contractsqueue.Task{
+					UUID: "test",
+					ChainJob: contractsqueue.ChainJob{
+						Job: testJobOne,
+					},
+				},
+			},
+			wantError: nil,
+		},
+		{
+			name:         "happy path with cache lock",
+			useCacheLock: true,
 			setup: func() {
 				mockCacheLock := mockscache.NewLock(s.T())
 				s.mockCache.EXPECT().Lock("goravel:queue-database-default:lock", 1*time.Minute).Return(mockCacheLock).Once()
@@ -204,12 +292,18 @@ func (s *DatabaseTestSuite) TestPop() {
 			wantError: nil,
 		},
 		{
-			name: "no job found",
+			name:         "failed to acquire cache lock",
+			useCacheLock: true,
 			setup: func() {
 				mockCacheLock := mockscache.NewLock(s.T())
 				s.mockCache.EXPECT().Lock("goravel:queue-database-default:lock", 1*time.Minute).Return(mockCacheLock).Once()
-				mockCacheLock.EXPECT().Block(1 * time.Minute).Return(true).Once()
-				mockCacheLock.EXPECT().Release().Return(true).Once()
+				mockCacheLock.EXPECT().Block(1 * time.Minute).Return(false).Once()
+			},
+			wantError: errors.QueuePopIsLocked.Args(queue, "goravel:queue-database-default:lock"),
+		},
+		{
+			name: "no job found",
+			setup: func() {
 				s.mockDB.EXPECT().Transaction(mock.Anything).Return(errors.QueueDriverNoJobFound.Args(queue)).Once()
 			},
 			wantError: errors.QueueDriverNoJobFound.Args(queue),
@@ -218,6 +312,7 @@ func (s *DatabaseTestSuite) TestPop() {
 
 	for _, test := range tests {
 		s.Run(test.name, func() {
+			s.database.useCacheLock = test.useCacheLock
 			test.setup()
 
 			job, err := s.database.Pop(queue)

--- a/queue/setup/stubs.go
+++ b/queue/setup/stubs.go
@@ -32,6 +32,10 @@ func init() {
 				"connection": config.Env("DB_CONNECTION"),
 				"queue":      "default",
 				"concurrent": 1,
+				// Optionally guard Pop() with a cache lock on top of the
+				// database row lock. Requires a cache driver to be
+				// configured; defaults to false.
+				"use_cache_lock": false,
 			},
 		},
 


### PR DESCRIPTION
## Problem

The database queue driver hard-required a cache backend: `NewDatabase` returned `CacheFacadeNotSet` whenever `cache == nil`, so a DB-queue-only app could not even construct the driver without configuring a cache. On top of that, `Pop()` took a cache lock around a transaction that already serializes reservation with `SELECT ... FOR UPDATE` — two cache round-trips per poll for no correctness gain.

Fixes goravel/goravel#960.

## Approach

Followed option 2 from the issue: the cache lock becomes **opt-in** via `queue.connections.<name>.use_cache_lock` (default `false`).

- The constructor no longer rejects a nil cache; it only errors with `CacheFacadeNotSet` when the user explicitly enables the cache lock without a cache configured.
- `Pop()` wraps the cache lock in `if r.useCacheLock`, relying on `FOR UPDATE` alone otherwise — the same contract as Laravel's database queue driver.
- `use_cache_lock: false` documented in the generated queue config stub.

## Testing

- `go build ./...`
- `go test ./queue/... -count=1` — 191 passed
- New cases: nil cache constructs OK, opt-in lock works, opt-in without cache errors; `Pop` default path takes no cache lock, with-lock path unchanged.

## Notes

- Silent default change: apps that relied on the cache lock as a belt-and-braces guard now get `FOR UPDATE`-only semantics by default. The issue argues this is correct (Laravel parity); worth a changelog mention.
- I left `Cache` in the Queue binding's `Dependencies` (`contracts/binding/binding.go`) untouched — removing it changes `artisan package:install` prompts and boot ordering; happy to drop it in a follow-up if maintainers want full consistency.