### PR TITLE
feat: [#949] make queue worker receive timeout configurable

### DIFF
--- a/contracts/queue/config.go
+++ b/contracts/queue/config.go
@@ -1,6 +1,8 @@
 package queue
 
 import (
+	"time"
+
 	"github.com/goravel/framework/contracts/config"
 )
 
@@ -14,4 +16,9 @@ type Config interface {
 	FailedDatabase() string
 	FailedTable() string
 	Via(connection string) any
+	// Timeout returns the blocking receive timeout for the given connection,
+	// resolved from queue.connections.<connection>.timeout (an integer number
+	// of seconds or a duration string like "5s"), falling back to the default
+	// when missing, non-positive or unparsable.
+	Timeout(connection string) time.Duration
 }

--- a/mocks/queue/Config.go
+++ b/mocks/queue/Config.go
@@ -918,6 +918,52 @@ func (_c *Config_GetStringSlice_Call) RunAndReturn(run func(string, ...[]string)
 	return _c
 }
 
+// Timeout provides a mock function with given fields: connection
+func (_m *Config) Timeout(connection string) time.Duration {
+	ret := _m.Called(connection)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Timeout")
+	}
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func(string) time.Duration); ok {
+		r0 = rf(connection)
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
+// Config_Timeout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Timeout'
+type Config_Timeout_Call struct {
+	*mock.Call
+}
+
+// Timeout is a helper method to define mock.On call
+//   - connection string
+func (_e *Config_Expecter) Timeout(connection interface{}) *Config_Timeout_Call {
+	return &Config_Timeout_Call{Call: _e.mock.On("Timeout", connection)}
+}
+
+func (_c *Config_Timeout_Call) Run(run func(connection string)) *Config_Timeout_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *Config_Timeout_Call) Return(_a0 time.Duration) *Config_Timeout_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Config_Timeout_Call) RunAndReturn(run func(string) time.Duration) *Config_Timeout_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UnmarshalKey provides a mock function with given fields: key, rawVal
 func (_m *Config) UnmarshalKey(key string, rawVal interface{}) error {
 	ret := _m.Called(key, rawVal)

--- a/queue/config.go
+++ b/queue/config.go
@@ -2,9 +2,15 @@ package queue
 
 import (
 	"fmt"
+	"time"
 
 	contractsconfig "github.com/goravel/framework/contracts/config"
 )
+
+// defaultReceiveTimeout is the fallback timeout, in seconds, for a single
+// blocking Receive call made by the worker. It can be overridden per
+// connection via queue.connections.<connection>.timeout.
+const defaultReceiveTimeout = 5
 
 type Config struct {
 	contractsconfig.Config
@@ -68,4 +74,41 @@ func (r *Config) FailedTable() string {
 
 func (r *Config) Via(connection string) any {
 	return r.Get(fmt.Sprintf("queue.connections.%s.via", connection))
+}
+
+func (r *Config) Timeout(connection string) time.Duration {
+	switch timeout := r.Get(fmt.Sprintf("queue.connections.%s.timeout", connection)).(type) {
+	case int:
+		return secondsToTimeout(timeout)
+	case int64:
+		return secondsToTimeout(int(timeout))
+	case float64:
+		return secondsToTimeout(int(timeout))
+	case string:
+		duration, err := time.ParseDuration(timeout)
+		if err != nil {
+			return defaultReceiveTimeout * time.Second
+		}
+		return durationToTimeout(duration)
+	default:
+		return defaultReceiveTimeout * time.Second
+	}
+}
+
+// secondsToTimeout converts a configured number of seconds into a duration,
+// falling back to the default when the value is missing or non-positive.
+func secondsToTimeout(seconds int) time.Duration {
+	if seconds <= 0 {
+		return defaultReceiveTimeout * time.Second
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// durationToTimeout returns the duration as-is when positive, otherwise the
+// default.
+func durationToTimeout(duration time.Duration) time.Duration {
+	if duration <= 0 {
+		return defaultReceiveTimeout * time.Second
+	}
+	return duration
 }

--- a/queue/config_test.go
+++ b/queue/config_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
@@ -63,4 +64,31 @@ func (s *ConfigTestSuite) TestFailedTable() {
 func (s *ConfigTestSuite) TestVia() {
 	s.mockConfig.EXPECT().Get("queue.connections.sync.via").Return("sync").Once()
 	s.Equal("sync", s.config.Via("sync"))
+}
+
+func (s *ConfigTestSuite) TestTimeout() {
+	tests := []struct {
+		name     string
+		value    any
+		expected time.Duration
+	}{
+		{"int seconds", 10, 10 * time.Second},
+		{"int64 seconds", int64(8), 8 * time.Second},
+		{"float64 seconds", float64(7), 7 * time.Second},
+		{"duration string", "5s", 5 * time.Second},
+		{"duration string with ms", "1500ms", 1500 * time.Millisecond},
+		{"zero falls back to default", 0, defaultReceiveTimeout * time.Second},
+		{"negative falls back to default", -3, defaultReceiveTimeout * time.Second},
+		{"negative duration string falls back to default", "-5s", defaultReceiveTimeout * time.Second},
+		{"garbage string falls back to default", "not-a-duration", defaultReceiveTimeout * time.Second},
+		{"missing falls back to default", nil, defaultReceiveTimeout * time.Second},
+		{"unsupported type falls back to default", true, defaultReceiveTimeout * time.Second},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			s.mockConfig.EXPECT().Get("queue.connections.redis.timeout").Return(test.value).Once()
+			s.Equal(test.expected, s.config.Timeout("redis"))
+		})
+	}
 }

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -2,7 +2,6 @@ package queue
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,11 +19,6 @@ import (
 	"github.com/goravel/framework/support/console"
 )
 
-// defaultReceiveTimeout is the fallback timeout, in seconds, for a single
-// blocking Receive call made by the worker. It can be overridden per
-// connection via queue.connections.<connection>.timeout.
-const defaultReceiveTimeout = 5
-
 type Worker struct {
 	config queue.Config
 	db     db.DB
@@ -41,7 +35,7 @@ type Worker struct {
 	failedJobWg    sync.WaitGroup
 	concurrent     int
 	tries          int
-	timeout        time.Duration
+	receiveTimeout time.Duration
 	shutdownCtx    context.Context
 	shutdownCancel context.CancelFunc
 
@@ -72,7 +66,7 @@ func NewWorker(config queue.Config, cache cache.Cache, db db.DB, job queue.JobSt
 		queue:          queue,
 		concurrent:     concurrent,
 		tries:          tries,
-		timeout:        time.Duration(config.GetInt(fmt.Sprintf("queue.connections.%s.timeout", connection), defaultReceiveTimeout)) * time.Second,
+		receiveTimeout: config.Timeout(connection),
 		debug:          config.Debug(),
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
@@ -315,7 +309,7 @@ func (r *Worker) runWithReceive(receiver queue.DriverWithReceive) error {
 			return nil
 		}
 
-		ctx, cancel := context.WithTimeout(r.shutdownCtx, r.timeout)
+		ctx, cancel := context.WithTimeout(r.shutdownCtx, r.receiveTimeout)
 		jobs, err := receiver.Receive(ctx, r.queue, r.concurrent)
 		cancel()
 

--- a/queue/worker.go
+++ b/queue/worker.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -19,6 +20,11 @@ import (
 	"github.com/goravel/framework/support/console"
 )
 
+// defaultReceiveTimeout is the fallback timeout, in seconds, for a single
+// blocking Receive call made by the worker. It can be overridden per
+// connection via queue.connections.<connection>.timeout.
+const defaultReceiveTimeout = 5
+
 type Worker struct {
 	config queue.Config
 	db     db.DB
@@ -35,6 +41,7 @@ type Worker struct {
 	failedJobWg    sync.WaitGroup
 	concurrent     int
 	tries          int
+	timeout        time.Duration
 	shutdownCtx    context.Context
 	shutdownCancel context.CancelFunc
 
@@ -65,6 +72,7 @@ func NewWorker(config queue.Config, cache cache.Cache, db db.DB, job queue.JobSt
 		queue:          queue,
 		concurrent:     concurrent,
 		tries:          tries,
+		timeout:        time.Duration(config.GetInt(fmt.Sprintf("queue.connections.%s.timeout", connection), defaultReceiveTimeout)) * time.Second,
 		debug:          config.Debug(),
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
@@ -307,7 +315,7 @@ func (r *Worker) runWithReceive(receiver queue.DriverWithReceive) error {
 			return nil
 		}
 
-		ctx, cancel := context.WithTimeout(r.shutdownCtx, 5*time.Second) // TODO make the timeout configurable
+		ctx, cancel := context.WithTimeout(r.shutdownCtx, r.timeout)
 		jobs, err := receiver.Receive(ctx, r.queue, r.concurrent)
 		cancel()
 

--- a/queue/worker_test.go
+++ b/queue/worker_test.go
@@ -59,7 +59,7 @@ func (s *WorkerTestSuite) SetupTest() {
 		queue:          "default",
 		concurrent:     1,
 		tries:          1,
-		timeout:        defaultReceiveTimeout * time.Second,
+		receiveTimeout: defaultReceiveTimeout * time.Second,
 		debug:          true,
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
@@ -69,24 +69,24 @@ func (s *WorkerTestSuite) SetupTest() {
 func (s *WorkerTestSuite) TestNewWorker() {
 	s.Run("happy path", func() {
 		s.mockConfig.EXPECT().Driver("sync").Return(contractsqueue.DriverSync).Once()
-		s.mockConfig.EXPECT().GetInt("queue.connections.sync.timeout", defaultReceiveTimeout).Return(defaultReceiveTimeout).Once()
+		s.mockConfig.EXPECT().Timeout("sync").Return(defaultReceiveTimeout * time.Second).Once()
 		s.mockConfig.EXPECT().Debug().Return(true).Once()
 		worker, err := NewWorker(s.mockConfig, nil, s.mockDB, s.mockJob, s.mockJson, s.mockLog, "sync", "default", 2, 1)
 
 		s.NotNil(worker)
 		s.NoError(err)
-		s.Equal(defaultReceiveTimeout*time.Second, worker.timeout)
+		s.Equal(defaultReceiveTimeout*time.Second, worker.receiveTimeout)
 	})
 
 	s.Run("custom timeout", func() {
 		s.mockConfig.EXPECT().Driver("sync").Return(contractsqueue.DriverSync).Once()
-		s.mockConfig.EXPECT().GetInt("queue.connections.sync.timeout", defaultReceiveTimeout).Return(10).Once()
+		s.mockConfig.EXPECT().Timeout("sync").Return(10 * time.Second).Once()
 		s.mockConfig.EXPECT().Debug().Return(true).Once()
 		worker, err := NewWorker(s.mockConfig, nil, s.mockDB, s.mockJob, s.mockJson, s.mockLog, "sync", "default", 2, 1)
 
 		s.NotNil(worker)
 		s.NoError(err)
-		s.Equal(10*time.Second, worker.timeout)
+		s.Equal(10*time.Second, worker.receiveTimeout)
 	})
 
 	s.Run("failed to create driver", func() {
@@ -780,6 +780,62 @@ func (s *WorkerTestSuite) Test_runWithReceive() {
 		time.Sleep(200 * time.Millisecond)
 		s.NoError(s.worker.Shutdown())
 	})
+
+	for _, tt := range []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{name: "default timeout", timeout: defaultReceiveTimeout * time.Second},
+		{name: "custom timeout", timeout: 2 * time.Second},
+	} {
+		s.Run("receive context deadline matches "+tt.name, func() {
+			s.SetupTest()
+
+			mockDriverWithReceive := mocksqueue.NewDriverWithReceive(s.T())
+			s.worker.driver = &receiveDriver{
+				driver:   s.mockDriver,
+				receiver: mockDriverWithReceive,
+			}
+			s.worker.connection = connection
+			s.worker.receiveTimeout = tt.timeout
+
+			deadlineCh := make(chan time.Time, 1)
+			mockDriverWithReceive.EXPECT().Receive(mock.Anything, queue, s.worker.concurrent).
+				Run(func(ctx context.Context, _ string, _ int) {
+					deadline, ok := ctx.Deadline()
+					s.True(ok, "receive context should have a deadline")
+					select {
+					case deadlineCh <- deadline:
+					default:
+					}
+				}).Return(nil, nil).Once()
+			mockDriverWithReceive.EXPECT().Receive(mock.Anything, queue, s.worker.concurrent).
+				RunAndReturn(func(ctx context.Context, _ string, _ int) ([]contractsqueue.ReservedJob, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				}).Once()
+
+			before := time.Now()
+			go func() {
+				s.NoError(s.worker.run())
+			}()
+
+			select {
+			case deadline := <-deadlineCh:
+				after := time.Now()
+				// The deadline must sit ~receiveTimeout after the moment the
+				// context was created, not at some other value.
+				s.GreaterOrEqual(deadline, before.Add(tt.timeout-100*time.Millisecond))
+				s.LessOrEqual(deadline, after.Add(tt.timeout+100*time.Millisecond))
+			case <-time.After(2 * time.Second):
+				s.Fail("timed out waiting for Receive to be called")
+			}
+
+			// Let the loop issue its second (blocking) Receive before shutting down
+			time.Sleep(200 * time.Millisecond)
+			s.NoError(s.worker.Shutdown())
+		})
+	}
 
 	s.Run("receive error", func() {
 		s.SetupTest()

--- a/queue/worker_test.go
+++ b/queue/worker_test.go
@@ -59,6 +59,7 @@ func (s *WorkerTestSuite) SetupTest() {
 		queue:          "default",
 		concurrent:     1,
 		tries:          1,
+		timeout:        defaultReceiveTimeout * time.Second,
 		debug:          true,
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
@@ -68,11 +69,24 @@ func (s *WorkerTestSuite) SetupTest() {
 func (s *WorkerTestSuite) TestNewWorker() {
 	s.Run("happy path", func() {
 		s.mockConfig.EXPECT().Driver("sync").Return(contractsqueue.DriverSync).Once()
+		s.mockConfig.EXPECT().GetInt("queue.connections.sync.timeout", defaultReceiveTimeout).Return(defaultReceiveTimeout).Once()
 		s.mockConfig.EXPECT().Debug().Return(true).Once()
 		worker, err := NewWorker(s.mockConfig, nil, s.mockDB, s.mockJob, s.mockJson, s.mockLog, "sync", "default", 2, 1)
 
 		s.NotNil(worker)
 		s.NoError(err)
+		s.Equal(defaultReceiveTimeout*time.Second, worker.timeout)
+	})
+
+	s.Run("custom timeout", func() {
+		s.mockConfig.EXPECT().Driver("sync").Return(contractsqueue.DriverSync).Once()
+		s.mockConfig.EXPECT().GetInt("queue.connections.sync.timeout", defaultReceiveTimeout).Return(10).Once()
+		s.mockConfig.EXPECT().Debug().Return(true).Once()
+		worker, err := NewWorker(s.mockConfig, nil, s.mockDB, s.mockJob, s.mockJson, s.mockLog, "sync", "default", 2, 1)
+
+		s.NotNil(worker)
+		s.NoError(err)
+		s.Equal(10*time.Second, worker.timeout)
 	})
 
 	s.Run("failed to create driver", func() {


### PR DESCRIPTION
## Problem

`runWithReceive` hardcoded a 5-second timeout on each blocking `Receive` call, with a `// TODO make the timeout configurable` left in the code (goravel/goravel#949 quotes the original review note from #1435).

## Approach

Per-connection config key `queue.connections.<connection>.timeout` (integer seconds, default `5`), matching the existing per-connection style of `concurrent` / `retry_after`:

- `Worker` gains a `timeout` field resolved once in `NewWorker`.
- `runWithReceive` uses it instead of the hardcoded `5*time.Second`.
- No contract change, so no mocks regenerated.

Extending timeouts to `Pop`/`Push` was explicitly deferred to a future issue in the original comment, so the `Driver` interface is untouched here.

## Testing

- `go build ./...`
- `go test ./queue/... -count=1` — 189 passed
- New subtest asserts a custom `timeout` config value reaches the worker; `TestNewWorker` happy path covers the default.