### PR TITLE
perf: [#998] compile validation patterns once instead of on every field

### DIFF
--- a/validation/benchmark_test.go
+++ b/validation/benchmark_test.go
@@ -10,6 +10,28 @@ import (
 
 // --- End-to-end validation benchmarks ---
 
+func BenchmarkValidation_RegexRule(b *testing.B) {
+	v := NewValidation()
+	ctx := context.Background()
+	data := map[string]any{
+		"name": "John",
+		"code": "AB-1234",
+	}
+	rules := map[string]any{
+		"name": "required|string",
+		"code": `required|regex:^[A-Z]{2}-\d{4}$`,
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		validator, err := v.Make(ctx, data, rules)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = validator.Fails()
+	}
+}
+
 func BenchmarkValidation_Simple(b *testing.B) {
 	v := NewValidation()
 	ctx := context.Background()

--- a/validation/rules.go
+++ b/validation/rules.go
@@ -1096,7 +1096,7 @@ func ruleRegex(ctx *RuleContext) bool {
 		return false
 	}
 	pattern := ctx.Parameters[0]
-	re, err := regexp.Compile(pattern)
+	re, err := compilePattern(pattern)
 	if err != nil {
 		return false
 	}
@@ -1109,7 +1109,7 @@ func ruleNotRegex(ctx *RuleContext) bool {
 		return false
 	}
 	pattern := ctx.Parameters[0]
-	re, err := regexp.Compile(pattern)
+	re, err := compilePattern(pattern)
 	if err != nil {
 		return false
 	}

--- a/validation/utils.go
+++ b/validation/utils.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -15,6 +16,31 @@ import (
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/spf13/cast"
 )
+
+// compiledPatterns caches compiled patterns. The patterns come from rule
+// definitions, which are written in application code, so the set of distinct
+// patterns a program uses is bounded by the rules it declares. Failed compiles
+// are deliberately not cached, so an invalid pattern cannot grow the map.
+var compiledPatterns sync.Map
+
+// compilePattern compiles a pattern once and reuses it afterwards. Compiling is
+// what a regular expression costs, matching against an already compiled one is
+// cheap, and the rules that use this compiled the same pattern on every field of
+// every request.
+func compilePattern(pattern string) (*regexp.Regexp, error) {
+	if cached, ok := compiledPatterns.Load(pattern); ok {
+		return cached.(*regexp.Regexp), nil
+	}
+
+	compiled, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	compiledPatterns.Store(pattern, compiled)
+
+	return compiled, nil
+}
 
 // isValueEmpty checks if a value is considered "empty" for validation purposes.
 func isValueEmpty(val any) bool {
@@ -466,7 +492,7 @@ func expandWildcardFields[T any](fields map[string]T, dataKeys []string, keepUnm
 
 		pattern := "^" + regexp.QuoteMeta(field) + "$"
 		pattern = strings.ReplaceAll(pattern, `\*`, `[^.]+`)
-		re, err := regexp.Compile(pattern)
+		re, err := compilePattern(pattern)
 		if err != nil {
 			expanded[field] = value
 			continue

--- a/validation/utils_test.go
+++ b/validation/utils_test.go
@@ -11,6 +11,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCompilePattern(t *testing.T) {
+	t.Run("compiles and matches", func(t *testing.T) {
+		re, err := compilePattern(`^[A-Z]{2}-\d{4}$`)
+		assert.NoError(t, err)
+		assert.True(t, re.MatchString("AB-1234"))
+		assert.False(t, re.MatchString("ab-1234"))
+	})
+
+	t.Run("the same pattern is compiled once", func(t *testing.T) {
+		first, err := compilePattern(`^cached-[0-9]+$`)
+		assert.NoError(t, err)
+
+		second, err := compilePattern(`^cached-[0-9]+$`)
+		assert.NoError(t, err)
+		assert.Same(t, first, second)
+	})
+
+	t.Run("an invalid pattern errors and is not cached", func(t *testing.T) {
+		const invalid = `^[a-z`
+
+		re, err := compilePattern(invalid)
+		assert.Error(t, err)
+		assert.Nil(t, re)
+
+		_, cached := compiledPatterns.Load(invalid)
+		assert.False(t, cached)
+	})
+}
+
 func TestIsValueEmpty(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/998

`ruleRegex` (`validation/rules.go:1099`), `ruleNotRegex` (`:1112`) and
`expandWildcardFields` (`validation/utils.go:469`) called `regexp.Compile` on
every invocation. The patterns come from rule definitions written in application
code, so the same handful was rebuilt on every field of every request.
Compiling is what a regular expression costs, matching an already compiled one
is cheap.

The rest of the package already keeps its patterns in package level variables
(`macRegex`, `uuidRegex`, `ulidRegex`, `hexColorRegex`, `htmlTagRegex`), so this
brings the last three call sites in line with that.

### What changed

`compilePattern` looks the pattern up in a `sync.Map` before compiling it and
stores it with `LoadOrStore`, so concurrent callers share one compiled value.
`trackDistinct` (`validation/engine.go`), which went through `regexp.MatchString`
on every `distinct` check, uses it as well.

Failed compiles are not cached. Valid patterns are bounded by the rules a
program declares, invalid ones are not, so caching failures would let a rule set
built from untrusted input grow the map. It also leaves the behaviour of an
invalid pattern exactly as it was.

For the same reason the cache has a soft cap of 1024 entries. Past it, new
patterns are compiled on every call, which is the behaviour before this PR, so
rules built from untrusted input cannot grow the map without bound either.

### Numbers

```
go test ./validation/ -bench='Validation_RegexRule|ExpandWildcardFields|Validation_Wildcards' -benchmem
```

`BenchmarkValidation_RegexRule` and `BenchmarkValidation_WildcardsDistinct` are
added by this PR, the other two already existed.

before:
```
BenchmarkValidation_RegexRule-8      339045    3532 ns/op    6896 B/op    90 allocs/op
BenchmarkExpandWildcardFields-8       60337   20386 ns/op   27520 B/op   227 allocs/op
BenchmarkValidation_Wildcards-8       17259   69022 ns/op   55953 B/op   775 allocs/op
BenchmarkValidation_WildcardsDistinct-8  11895  100517 ns/op  147404 B/op  2083 allocs/op
```

after:
```
BenchmarkValidation_RegexRule-8      747267    1604 ns/op    2154 B/op    33 allocs/op
BenchmarkExpandWildcardFields-8       96663   12323 ns/op   10901 B/op    20 allocs/op
BenchmarkValidation_Wildcards-8       19732   60339 ns/op   39332 B/op   568 allocs/op
BenchmarkValidation_WildcardsDistinct-8  27159   44134 ns/op   28687 B/op   489 allocs/op
```

go1.27.0, darwin/arm64, Apple M3.

The interesting number is the marginal one. Two fields with `required|string`
and no regex rule cost 1406 ns. Adding one `regex:` rule used to cost another
2101 ns, more than the rest of the validation put together. It now costs 190 ns.

Validation that uses no regex rule is unchanged: 1406 ns before, 1390 ns after,
same allocations.

### Scope

* `validation/utils.go`: `compilePattern` and the wildcard call site
* `validation/rules.go`: two call sites
* `validation/engine.go`: `trackDistinct`
* `validation/utils_test.go`: tests for the cache
* `validation/benchmark_test.go`: `BenchmarkValidation_RegexRule`, `BenchmarkValidation_WildcardsDistinct`

No public API changed.

## ✅ Checks

- [x] Added test cases for my code

`TestCompilePattern` covers that a pattern compiles and matches, that the same
pattern returns the identical compiled value rather than a new one, that concurrent
callers get the same value, that an invalid pattern still errors and does not
end up in the map, and that patterns past the cap still compile but are not
stored.

