### PR TITLE
perf: [#999] stop rebuilding the row decoder and buffer the cursor channel

### DIFF
--- a/database/db/query.go
+++ b/database/db/query.go
@@ -49,6 +49,9 @@ func NewQuery(ctx context.Context, readBuilder db.CommonBuilder, writeBuilder db
 	}
 }
 
+// cursorBufferSize is the number of rows Cursor keeps in flight.
+const cursorBufferSize = 64
+
 func (r *Query) Chunk(size uint64, callback func(rows []db.Row) error) error {
 	offset := uint64(0)
 
@@ -116,7 +119,9 @@ func (r *Query) CrossJoin(query string, args ...any) db.Query {
 }
 
 func (r *Query) Cursor() chan db.Row {
-	ch := make(chan db.Row)
+	// Buffered so the producing goroutine can stay ahead of the consumer. An
+	// unbuffered channel costs a goroutine handoff on every single row.
+	ch := make(chan db.Row, cursorBufferSize)
 	go func() {
 		var (
 			args  []any

--- a/database/db/row.go
+++ b/database/db/row.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -26,20 +27,61 @@ func (r *Row) Err() error {
 	return r.err
 }
 
+// decodeHooks is built once. Composing it per row rebuilt the same six hooks on
+// every row of every result set.
+var decodeHooks = mapstructure.ComposeDecodeHookFunc(
+	ToStringHookFunc(), ToTimeHookFunc(), ToDeletedAtHookFunc(), ToScannerHookFunc(), ToSliceHookFunc(), ToMapHookFunc(),
+)
+
+// mapstructure calls MatchName for every column and field pair, so the case
+// conversions ran O(columns x fields) times per row. Column names and struct
+// field names come from the schema and from the code, so the set is small and
+// fixed for the life of the process.
+var (
+	studlyNames sync.Map
+	snakeNames  sync.Map
+)
+
+func studlyName(name string) string {
+	if cached, ok := studlyNames.Load(name); ok {
+		return cached.(string)
+	}
+
+	converted := str.Of(name).Studly().String()
+	studlyNames.Store(name, converted)
+
+	return converted
+}
+
+func snakeName(name string) string {
+	if cached, ok := snakeNames.Load(name); ok {
+		return cached.(string)
+	}
+
+	converted := str.Of(name).Snake().String()
+	snakeNames.Store(name, converted)
+
+	return converted
+}
+
+// matchName keeps the three original conditions, with the one that needs no
+// conversion first.
+func matchName(mapKey, fieldName string) bool {
+	return strings.EqualFold(mapKey, fieldName) ||
+		studlyName(mapKey) == fieldName ||
+		mapKey == snakeName(fieldName)
+}
+
 func (r *Row) Scan(value any) error {
 	if r.err != nil {
 		return r.err
 	}
 
 	msConfig := &mapstructure.DecoderConfig{
-		DecodeHook: mapstructure.ComposeDecodeHookFunc(
-			ToStringHookFunc(), ToTimeHookFunc(), ToDeletedAtHookFunc(), ToScannerHookFunc(), ToSliceHookFunc(), ToMapHookFunc(),
-		),
-		Squash: true,
-		Result: value,
-		MatchName: func(mapKey, fieldName string) bool {
-			return str.Of(mapKey).Studly().String() == fieldName || mapKey == str.Of(fieldName).Snake().String() || strings.EqualFold(mapKey, fieldName)
-		},
+		DecodeHook: decodeHooks,
+		Squash:     true,
+		Result:     value,
+		MatchName:  matchName,
 	}
 
 	decoder, err := mapstructure.NewDecoder(msConfig)
@@ -50,11 +92,19 @@ func (r *Row) Scan(value any) error {
 	return decoder.Decode(r.row)
 }
 
+var (
+	stringType    = reflect.TypeOf("")
+	timeType      = reflect.TypeOf(time.Time{})
+	deletedAtType = reflect.TypeOf(gorm.DeletedAt{})
+	byteSliceType = reflect.TypeOf([]byte(nil))
+	scannerType   = reflect.TypeOf((*interface{ Scan(any) error })(nil)).Elem()
+)
+
 // ToStringHookFunc is a hook function that converts []uint8 to string.
 // Mysql returns []uint8 for String type when scanning the rows.
 func ToStringHookFunc() mapstructure.DecodeHookFunc {
 	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
-		if t != reflect.TypeOf("") {
+		if t != stringType {
 			return data, nil
 		}
 
@@ -69,7 +119,7 @@ func ToStringHookFunc() mapstructure.DecodeHookFunc {
 
 func ToTimeHookFunc() mapstructure.DecodeHookFunc {
 	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
-		if t != reflect.TypeOf(time.Time{}) {
+		if t != timeType {
 			return data, nil
 		}
 
@@ -88,11 +138,11 @@ func ToTimeHookFunc() mapstructure.DecodeHookFunc {
 
 func ToDeletedAtHookFunc() mapstructure.DecodeHookFunc {
 	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
-		if t != reflect.TypeOf(gorm.DeletedAt{}) {
+		if t != deletedAtType {
 			return data, nil
 		}
 
-		if f == reflect.TypeOf(time.Time{}) {
+		if f == timeType {
 			return gorm.DeletedAt{Time: data.(time.Time), Valid: true}, nil
 		}
 
@@ -109,7 +159,7 @@ func ToDeletedAtHookFunc() mapstructure.DecodeHookFunc {
 func ToScannerHookFunc() mapstructure.DecodeHookFunc {
 	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
 		// Skip types that are handled by other specific hooks
-		if t == reflect.TypeOf(time.Time{}) || t == reflect.TypeOf(gorm.DeletedAt{}) {
+		if t == timeType || t == deletedAtType {
 			return data, nil
 		}
 
@@ -119,12 +169,9 @@ func ToScannerHookFunc() mapstructure.DecodeHookFunc {
 		}
 
 		// Only process database types (string, []byte, []uint8, time.Time)
-		if f.Kind() != reflect.String && f != reflect.TypeOf([]byte(nil)) && f != reflect.TypeOf([]uint8(nil)) && f != reflect.TypeOf(time.Time{}) {
+		if f.Kind() != reflect.String && f != byteSliceType && f != timeType {
 			return data, nil
 		}
-
-		// Check if the target type implements a Scan method
-		scannerType := reflect.TypeOf((*interface{ Scan(any) error })(nil)).Elem()
 
 		// Create a pointer to the target type to check for Scan method
 		targetPtr := reflect.PointerTo(t)

--- a/database/gorm/query.go
+++ b/database/gorm/query.go
@@ -33,6 +33,9 @@ import (
 
 const Associations = clause.Associations
 
+// cursorBufferSize is the number of rows Cursor keeps in flight.
+const cursorBufferSize = 64
+
 type Query struct {
 	config            config.Config
 	ctx               context.Context
@@ -164,7 +167,9 @@ func (r *Query) Cursor() chan contractsdb.Row {
 	query := r.addGlobalScopes().buildConditions()
 	r.conditions.with = with
 
-	cursorChan := make(chan contractsdb.Row)
+	// Buffered so the producing goroutine can stay ahead of the consumer. An
+	// unbuffered channel costs a goroutine handoff on every single row.
+	cursorChan := make(chan contractsdb.Row, cursorBufferSize)
 	go func() {
 		var (
 			err  error


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/999

The cursor path repeated per row what can be done once.

`Row.Scan` (`database/db/row.go:29`) composed the six decode hooks and built a
`mapstructure` decoder for every row. mapstructure then called `MatchName` for
every column and field pair, and each of those calls ran `Studly` on the column
name and `Snake` on the field name, constructing an `x/text` caser both times.
Column names come from the schema and field names from the code, so the same
small set of conversions was redone on every row. The `reflect.TypeOf` values
the hooks compare against were rebuilt on every hook call too.

Both `Cursor` implementations handed rows over an unbuffered channel, which
costs a goroutine handoff per row.

This path is reached by `db.Query().Cursor()`, by `db.Query().Chunk()`, which
calls `Cursor` internally, and by `orm.Query().Cursor()`, whose `Row.Scan`
delegates to the `db` one (`database/gorm/row.go:18`).

### What changed

The hooks are built once, the two name conversions are memoised, and the
`reflect.TypeOf` values moved to package level. Both cursor channels now keep
64 rows in flight.

`matchName` keeps all three original conditions and only reorders them so the
one that needs no conversion is checked first. They are joined with `||`, so the
result is unchanged.

One small cleanup came with it: `ToScannerHookFunc` compared against both
`reflect.TypeOf([]byte(nil))` and `reflect.TypeOf([]uint8(nil))`. `byte` is an
alias for `uint8`, so those are the same `reflect.Type` and the check was
duplicated. One remains.

### Numbers

Measured with a driver that returns synthetic rows immediately, so only
framework work is timed. The harness is in the issue, no database needed.

```
go test ./database/db/ -bench='Cursor100$|Cursor1000$' -benchmem -run=^$
```

before:
```
BenchmarkCursor100-8     544    2138637 ns/op    2256388 B/op    32065 allocs/op
BenchmarkCursor1000-8     56   20847660 ns/op   22131739 B/op   320277 allocs/op
```

after:
```
BenchmarkCursor100-8    2739     435314 ns/op     409895 B/op     6912 allocs/op
BenchmarkCursor1000-8    282    4261419 ns/op    3862573 B/op    68886 allocs/op
```

go1.27.0, darwin/arm64, Apple M3.

About 20.8us per row before, 4.26us after. A thousand rows carried 21ms of
framework overhead, 16ms of which goes away.

### Scope

* `database/db/row.go`: hooks built once, conversions memoised, types lifted
* `database/db/query.go`: buffered cursor channel
* `database/gorm/query.go`: buffered cursor channel

No public API changed, no behaviour changed.

## ✅ Checks

- [ ] Added test cases for my code

No new tests. This changes how existing work is done, not what it produces, so
the existing `database` suites cover it, and they pass along with `-race` on
`db` and `gorm`.

The benchmark harness from the issue is not included here to keep the diff
small. Happy to add it as a permanent benchmark if you would like the cursor
path measurable without a database.
