### PR TITLE
feat: [#991] support listening for database query events

### DIFF
--- a/contracts/database/db/db.go
+++ b/contracts/database/db/db.go
@@ -13,6 +13,10 @@ type DB interface {
 	BeginTransaction() (Tx, error)
 	// Connection gets an Orm instance from the connection pool.
 	Connection(name string) DB
+	// Listen registers a listener that is called for every SQL query executed
+	// by the database, mirroring Laravel's DB::listen. The registry is global,
+	// so a listener sees queries from every connection.
+	Listen(listener func(event *QueryExecuted) error)
 	// Transaction runs a callback wrapped in a database transaction.
 	Transaction(txFunc func(tx Tx) error) error
 	// WithContext sets the context to be used by the Orm.

--- a/contracts/database/db/events.go
+++ b/contracts/database/db/events.go
@@ -1,0 +1,24 @@
+package db
+
+import (
+	"time"
+)
+
+// QueryExecuted is the event fired after every SQL query executed by the
+// database, mirroring Laravel's Illuminate\Database\Events\QueryExecuted.
+// Listeners are registered through Listen on the DB facade or the package
+// level, and receive one event per executed query.
+type QueryExecuted struct {
+	// Connection is the name of the connection the query was executed on.
+	Connection string
+	// Sql is the SQL query with placeholders.
+	Sql string
+	// Bindings are the values bound to the placeholders.
+	Bindings []any
+	// RawSql is the SQL query with the bindings interpolated.
+	RawSql string
+	// Time is how long the query took to execute.
+	Time time.Duration
+	// Error is the error returned by the query, nil when the query succeeded.
+	Error error
+}

--- a/database/db/db.go
+++ b/database/db/db.go
@@ -17,6 +17,7 @@ import (
 	"github.com/goravel/framework/contracts/log"
 	contractstelemetry "github.com/goravel/framework/contracts/telemetry"
 	databasedriver "github.com/goravel/framework/database/driver"
+	"github.com/goravel/framework/database/utils"
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support/carbon"
 	instrumentationdatabase "github.com/goravel/framework/telemetry/instrumentation/database"
@@ -65,7 +66,7 @@ func BuildDB(ctx context.Context, config config.Config, log log.Log, connection 
 	}
 
 	pool := driver.Pool()
-	logger := NewLogger(config, log)
+	logger := NewLogger(config, log).WithConnection(connection)
 	gorm, instrument, err := databasedriver.BuildGorm(config, logger.ToGorm(), pool, connection, telemetryResolver)
 	if err != nil {
 		return nil, err
@@ -234,13 +235,19 @@ func (r *Tx) Select(dest any, sql string, args ...any) error {
 	}
 
 	realSql = builder.Explain(sql, args...)
+	// Carry the placeholders and bindings on the context so the logger can
+	// report them in QueryExecuted events.
+	traceCtx := r.ctx
+	if utils.HasQueryListeners() {
+		traceCtx = utils.WithQueryBindings(traceCtx, sql, args)
+	}
 
 	destValue := reflect.Indirect(reflect.ValueOf(dest))
 
 	rowsAffected := int64(1)
 	if destValue.Kind() == reflect.Slice {
 		if err = builder.SelectContext(r.ctx, dest, sql, args...); err != nil {
-			r.logger.Trace(r.ctx, carbon.Now(), realSql, -1, err)
+			r.logger.Trace(traceCtx, carbon.Now(), realSql, -1, err)
 
 			return err
 		}
@@ -248,13 +255,13 @@ func (r *Tx) Select(dest any, sql string, args ...any) error {
 		rowsAffected = int64(destValue.Len())
 	} else {
 		if err = builder.GetContext(r.ctx, dest, sql, args...); err != nil {
-			r.logger.Trace(r.ctx, carbon.Now(), realSql, -1, err)
+			r.logger.Trace(traceCtx, carbon.Now(), realSql, -1, err)
 
 			return err
 		}
 	}
 
-	r.logger.Trace(r.ctx, carbon.Now(), realSql, rowsAffected, nil)
+	r.logger.Trace(traceCtx, carbon.Now(), realSql, rowsAffected, nil)
 
 	return nil
 }
@@ -309,19 +316,26 @@ func (r *Tx) exec(sql string, args ...any) (*contractsdb.Result, error) {
 	}
 
 	realSql = builder.Explain(sql, args...)
+	// Carry the placeholders and bindings on the context so the logger can
+	// report them in QueryExecuted events.
+	traceCtx := r.ctx
+	if utils.HasQueryListeners() {
+		traceCtx = utils.WithQueryBindings(traceCtx, sql, args)
+	}
+
 	result, err = builder.ExecContext(r.ctx, sql, args...)
 	if err != nil {
-		r.logger.Trace(r.ctx, carbon.Now(), realSql, -1, err)
+		r.logger.Trace(traceCtx, carbon.Now(), realSql, -1, err)
 		return nil, err
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		r.logger.Trace(r.ctx, carbon.Now(), realSql, -1, err)
+		r.logger.Trace(traceCtx, carbon.Now(), realSql, -1, err)
 		return nil, err
 	}
 
-	r.logger.Trace(r.ctx, carbon.Now(), realSql, rowsAffected, nil)
+	r.logger.Trace(traceCtx, carbon.Now(), realSql, rowsAffected, nil)
 
 	return &contractsdb.Result{RowsAffected: rowsAffected}, nil
 }

--- a/database/db/listen.go
+++ b/database/db/listen.go
@@ -1,0 +1,18 @@
+package db
+
+import (
+	contractsdb "github.com/goravel/framework/contracts/database/db"
+	"github.com/goravel/framework/database/utils"
+)
+
+// Listen registers a listener that is called for every SQL query executed by
+// the database, mirroring Laravel's DB::listen. The registry is global, so a
+// listener sees queries from every connection.
+func Listen(listener func(event *contractsdb.QueryExecuted) error) {
+	utils.ListenQuery(listener)
+}
+
+// Listen implements contractsdb.DB.
+func (r *DB) Listen(listener func(event *contractsdb.QueryExecuted) error) {
+	Listen(listener)
+}

--- a/database/db/listen_test.go
+++ b/database/db/listen_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 	gormtests "gorm.io/gorm/utils/tests"
@@ -15,6 +16,7 @@ import (
 	contractsdb "github.com/goravel/framework/contracts/database/db"
 	"github.com/goravel/framework/contracts/database/logger"
 	"github.com/goravel/framework/database/utils"
+	mocksdb "github.com/goravel/framework/mocks/database/db"
 	"github.com/goravel/framework/support/carbon"
 )
 
@@ -157,4 +159,190 @@ func TestDBListenRegistersGlobally(t *testing.T) {
 	logger.Trace(context.Background(), carbon.Now(), "SELECT 1", 1, nil)
 
 	assert.Len(t, events(), 1)
+}
+
+func TestLoggerWithConnection(t *testing.T) {
+	events := collectEvents(t, "listen-connection")
+
+	r := &Logger{}
+	assert.Same(t, r, r.WithConnection("listen-connection"))
+	assert.Equal(t, "listen-connection", r.connection)
+
+	// The connection set through WithConnection is reported in events.
+	r.Trace(context.Background(), carbon.Now(), "SELECT 1", 1, nil)
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "listen-connection", got[0].Connection)
+}
+
+func TestTxSelectWithListenersCarriesBindings(t *testing.T) {
+	events := collectEvents(t, "listen-tx-select")
+
+	ctx := context.Background()
+	parameterizedSQL := "SELECT * FROM users WHERE name = ?"
+	explainedSQL := `SELECT * FROM users WHERE name = "John"`
+
+	mockBuilder := mocksdb.NewTxBuilder(t)
+	mockBuilder.EXPECT().Explain(parameterizedSQL, "John").Return(explainedSQL).Once()
+	mockBuilder.EXPECT().SelectContext(ctx, mock.Anything, parameterizedSQL, "John").Return(nil).Once()
+
+	tx := &Tx{ctx: ctx, logger: &Logger{connection: "listen-tx-select", level: logger.Silent}, txBuilder: mockBuilder}
+
+	var users []TestUser
+	require.NoError(t, tx.Select(&users, parameterizedSQL, "John"))
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, parameterizedSQL, got[0].Sql)
+	assert.Equal(t, []any{"John"}, got[0].Bindings)
+	assert.Equal(t, explainedSQL, got[0].RawSql)
+	assert.Nil(t, got[0].Error)
+}
+
+func TestTxSelectWithListenersErrorCarried(t *testing.T) {
+	events := collectEvents(t, "listen-tx-select-err")
+
+	ctx := context.Background()
+	queryErr := errors.New("select failed")
+
+	mockBuilder := mocksdb.NewTxBuilder(t)
+	mockBuilder.EXPECT().Explain("SELECT 1").Return("SELECT 1").Once()
+	mockBuilder.EXPECT().GetContext(ctx, mock.Anything, "SELECT 1").Return(queryErr).Once()
+
+	tx := &Tx{ctx: ctx, logger: &Logger{connection: "listen-tx-select-err", level: logger.Silent}, txBuilder: mockBuilder}
+
+	var user TestUser
+	assert.ErrorIs(t, tx.Select(&user, "SELECT 1"), queryErr)
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.ErrorIs(t, got[0].Error, queryErr)
+}
+
+func TestTxSelectSliceErrorCarried(t *testing.T) {
+	events := collectEvents(t, "listen-tx-select-slice-err")
+
+	ctx := context.Background()
+	queryErr := errors.New("select slice failed")
+
+	mockBuilder := mocksdb.NewTxBuilder(t)
+	mockBuilder.EXPECT().Explain("SELECT * FROM users WHERE id = ?", 1).Return("SELECT * FROM users WHERE id = 1").Once()
+	mockBuilder.EXPECT().SelectContext(ctx, mock.Anything, "SELECT * FROM users WHERE id = ?", 1).Return(queryErr).Once()
+
+	tx := &Tx{ctx: ctx, logger: &Logger{connection: "listen-tx-select-slice-err", level: logger.Silent}, txBuilder: mockBuilder}
+
+	var users []TestUser
+	assert.ErrorIs(t, tx.Select(&users, "SELECT * FROM users WHERE id = ?", 1), queryErr)
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.ErrorIs(t, got[0].Error, queryErr)
+	assert.Equal(t, "SELECT * FROM users WHERE id = ?", got[0].Sql)
+	assert.Equal(t, []any{1}, got[0].Bindings)
+}
+
+func TestTxExecWithListenersCarriesBindings(t *testing.T) {
+	events := collectEvents(t, "listen-tx-exec")
+
+	ctx := context.Background()
+	sqlStr := "INSERT INTO users (name) VALUES (?)"
+	explainedSQL := `INSERT INTO users (name) VALUES ("John")`
+
+	mockResult := &MockResult{}
+	mockResult.On("RowsAffected").Return(int64(1), nil).Once()
+
+	mockBuilder := mocksdb.NewTxBuilder(t)
+	mockBuilder.EXPECT().Explain(sqlStr, "John").Return(explainedSQL).Once()
+	mockBuilder.EXPECT().ExecContext(ctx, sqlStr, "John").Return(mockResult, nil).Once()
+
+	tx := &Tx{ctx: ctx, logger: &Logger{connection: "listen-tx-exec", level: logger.Silent}, txBuilder: mockBuilder}
+
+	result, err := tx.Insert(sqlStr, "John")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), result.RowsAffected)
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, sqlStr, got[0].Sql)
+	assert.Equal(t, []any{"John"}, got[0].Bindings)
+	assert.Equal(t, explainedSQL, got[0].RawSql)
+	assert.Nil(t, got[0].Error)
+}
+
+func TestTxExecWithListenersErrorCarried(t *testing.T) {
+	events := collectEvents(t, "listen-tx-exec-err")
+
+	ctx := context.Background()
+	execErr := errors.New("exec failed")
+
+	mockBuilder := mocksdb.NewTxBuilder(t)
+	mockBuilder.EXPECT().Explain("DELETE FROM users").Return("DELETE FROM users").Once()
+	mockBuilder.EXPECT().ExecContext(ctx, "DELETE FROM users").Return(nil, execErr).Once()
+
+	tx := &Tx{ctx: ctx, logger: &Logger{connection: "listen-tx-exec-err", level: logger.Silent}, txBuilder: mockBuilder}
+
+	_, err := tx.Delete("DELETE FROM users")
+	assert.ErrorIs(t, err, execErr)
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.ErrorIs(t, got[0].Error, execErr)
+}
+
+func TestQueryTraceWithListeners(t *testing.T) {
+	events := collectEvents(t, "listen-query-trace")
+
+	ctx := context.Background()
+	parameterizedSQL := "SELECT * FROM users WHERE id = ?"
+	explainedSQL := "SELECT * FROM users WHERE id = 1"
+
+	mockBuilder := mocksdb.NewCommonBuilder(t)
+	mockBuilder.EXPECT().Explain(parameterizedSQL, 1).Return(explainedSQL).Once()
+
+	r := &Query{ctx: ctx, logger: &Logger{connection: "listen-query-trace", level: logger.Silent}}
+	r.trace(mockBuilder, parameterizedSQL, []any{1}, carbon.Now(), 1, nil)
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, parameterizedSQL, got[0].Sql)
+	assert.Equal(t, []any{1}, got[0].Bindings)
+	assert.Equal(t, explainedSQL, got[0].RawSql)
+}
+
+func TestQueryTraceWithListenersInTransaction(t *testing.T) {
+	events := collectEvents(t, "listen-query-trace-tx")
+
+	ctx := context.Background()
+	parameterizedSQL := "UPDATE users SET name = ? WHERE id = ?"
+	explainedSQL := "UPDATE users SET name = 'John' WHERE id = 1"
+
+	mockBuilder := mocksdb.NewCommonBuilder(t)
+	mockBuilder.EXPECT().Explain(parameterizedSQL, "John", 1).Return(explainedSQL).Once()
+
+	txLogs := []TxLog{}
+	r := &Query{ctx: ctx, logger: &Logger{connection: "listen-query-trace-tx", level: logger.Silent}, txLogs: &txLogs}
+	r.trace(mockBuilder, parameterizedSQL, []any{"John", 1}, carbon.Now(), 2, nil)
+
+	// Inside a transaction the trace is buffered; the event fires on Commit.
+	assert.Empty(t, events())
+	require.Len(t, txLogs, 1)
+
+	sql, bindings, ok := utils.QueryBindingsFromContext(txLogs[0].ctx)
+	require.True(t, ok)
+	assert.Equal(t, parameterizedSQL, sql)
+	assert.Equal(t, []any{"John", 1}, bindings)
+
+	// Commit replays the buffered logs through Trace, firing the event.
+	mockTxBuilder := mocksdb.NewTxBuilder(t)
+	mockTxBuilder.EXPECT().Commit().Return(nil).Once()
+
+	tx := &Tx{ctx: ctx, logger: &Logger{connection: "listen-query-trace-tx", level: logger.Silent}, txBuilder: mockTxBuilder, txLogs: &txLogs}
+	require.NoError(t, tx.Commit())
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, parameterizedSQL, got[0].Sql)
+	assert.Equal(t, []any{"John", 1}, got[0].Bindings)
+	assert.Equal(t, explainedSQL, got[0].RawSql)
 }

--- a/database/db/listen_test.go
+++ b/database/db/listen_test.go
@@ -1,0 +1,160 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	gormtests "gorm.io/gorm/utils/tests"
+
+	contractsdb "github.com/goravel/framework/contracts/database/db"
+	"github.com/goravel/framework/contracts/database/logger"
+	"github.com/goravel/framework/database/utils"
+	"github.com/goravel/framework/support/carbon"
+)
+
+// collectEvents registers a listener that records events for the given
+// connection only, and returns the recorded events. The registry is global and
+// package-level, so tests filter by a unique connection name to stay isolated.
+func collectEvents(t *testing.T, connection string) func() []*contractsdb.QueryExecuted {
+	t.Helper()
+	t.Cleanup(utils.ClearQueryListeners)
+
+	var (
+		mu     sync.Mutex
+		events []*contractsdb.QueryExecuted
+	)
+
+	Listen(func(event *contractsdb.QueryExecuted) error {
+		if event.Connection != connection {
+			return nil
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, event)
+
+		return nil
+	})
+
+	return func() []*contractsdb.QueryExecuted {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return events
+	}
+}
+
+func TestListenLoggerTrace(t *testing.T) {
+	events := collectEvents(t, "listen-trace")
+
+	logger := &Logger{connection: "listen-trace", level: logger.Silent}
+	begin := carbon.Now().SubDuration((50 * time.Millisecond).String())
+	logger.Trace(context.Background(), begin, "SELECT * FROM users WHERE id = 1", 1, nil)
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "listen-trace", got[0].Connection)
+	assert.Equal(t, "SELECT * FROM users WHERE id = 1", got[0].Sql)
+	assert.Equal(t, "SELECT * FROM users WHERE id = 1", got[0].RawSql)
+	assert.Nil(t, got[0].Bindings)
+	assert.Nil(t, got[0].Error)
+	assert.Greater(t, got[0].Time, time.Duration(0))
+}
+
+func TestListenWithBindingsFromContext(t *testing.T) {
+	events := collectEvents(t, "listen-bindings")
+
+	ctx := utils.WithQueryBindings(context.Background(), "SELECT * FROM users WHERE id = ?", []any{1})
+	logger := &Logger{connection: "listen-bindings"}
+	logger.Trace(ctx, carbon.Now(), "SELECT * FROM users WHERE id = 1", 1, nil)
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "SELECT * FROM users WHERE id = ?", got[0].Sql)
+	assert.Equal(t, []any{1}, got[0].Bindings)
+	assert.Equal(t, "SELECT * FROM users WHERE id = 1", got[0].RawSql)
+}
+
+func TestListenErrorPropagated(t *testing.T) {
+	events := collectEvents(t, "listen-error")
+
+	queryErr := errors.New("boom")
+	logger := &Logger{connection: "listen-error"}
+	logger.Trace(context.Background(), carbon.Now(), "INSERT INTO users", -1, queryErr)
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.ErrorIs(t, got[0].Error, queryErr)
+}
+
+func TestListenNilListenerIgnored(t *testing.T) {
+	t.Cleanup(utils.ClearQueryListeners)
+
+	Listen(nil)
+	// A nil listener must not be registered; dispatching must not panic.
+	assert.NotPanics(t, func() {
+		logger := &Logger{connection: "listen-nil"}
+		logger.Trace(context.Background(), carbon.Now(), "SELECT 1", 1, nil)
+	})
+}
+
+func TestListenPanickingListenerDoesNotBreakQuery(t *testing.T) {
+	t.Cleanup(utils.ClearQueryListeners)
+
+	Listen(func(event *contractsdb.QueryExecuted) error {
+		if event.Connection == "listen-panic" {
+			panic("listener panic")
+		}
+
+		return nil
+	})
+
+	logger := &Logger{connection: "listen-panic"}
+	assert.NotPanics(t, func() {
+		logger.Trace(context.Background(), carbon.Now(), "SELECT 1", 1, nil)
+	})
+}
+
+func TestListenGormEndToEnd(t *testing.T) {
+	events := collectEvents(t, "listen-gorm")
+
+	instance, err := gorm.Open(gormtests.DummyDialector{}, &gorm.Config{
+		DryRun: true,
+		Logger: (&Logger{connection: "listen-gorm"}).ToGorm(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, instance.Use(utils.NewQueryEventPlugin()))
+
+	var dest []map[string]any
+	require.NoError(t, instance.WithContext(context.Background()).Table("users").Where("id = ?", 1).Find(&dest).Error)
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "listen-gorm", got[0].Connection)
+	assert.Contains(t, got[0].Sql, "id = ?")
+	assert.Equal(t, []any{1}, got[0].Bindings)
+	assert.Contains(t, got[0].RawSql, "id = 1")
+	assert.Nil(t, got[0].Error)
+	// Dry-run queries finish within one clock tick on Windows, so only assert
+	// the duration is non-negative here; TestListenLoggerTrace covers Time.
+	assert.GreaterOrEqual(t, got[0].Time, time.Duration(0))
+}
+
+func TestDBListenRegistersGlobally(t *testing.T) {
+	t.Cleanup(utils.ClearQueryListeners)
+	events := collectEvents(t, "listen-db")
+
+	r := &DB{}
+	r.Listen(func(event *contractsdb.QueryExecuted) error { return nil })
+
+	logger := &Logger{connection: "listen-db"}
+	logger.Trace(context.Background(), carbon.Now(), "SELECT 1", 1, nil)
+
+	assert.Len(t, events(), 1)
+}

--- a/database/db/logger.go
+++ b/database/db/logger.go
@@ -7,8 +7,10 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 
 	"github.com/goravel/framework/contracts/config"
+	contractsdb "github.com/goravel/framework/contracts/database/db"
 	"github.com/goravel/framework/contracts/database/logger"
 	"github.com/goravel/framework/contracts/log"
+	"github.com/goravel/framework/database/utils"
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support/carbon"
 	"github.com/goravel/framework/support/str"
@@ -20,7 +22,7 @@ var (
 	traceErrStr  = "[%.3fms] [rows:%v] %s\t%s"
 )
 
-func NewLogger(config config.Config, log log.Log) logger.Logger {
+func NewLogger(config config.Config, log log.Log) *Logger {
 	level := logger.Warn
 	if config.GetBool("app.debug") {
 		level = logger.Info
@@ -42,6 +44,14 @@ type Logger struct {
 	log           log.Log
 	level         logger.Level
 	slowThreshold time.Duration
+	connection    string
+}
+
+// WithConnection sets the connection name reported in QueryExecuted events.
+func (r *Logger) WithConnection(connection string) *Logger {
+	r.connection = connection
+
+	return r
 }
 
 func (r *Logger) Log() log.Log {
@@ -85,12 +95,33 @@ func (r *Logger) Panicf(ctx context.Context, msg string, data ...any) {
 }
 
 func (r *Logger) Trace(ctx context.Context, begin *carbon.Carbon, sql string, rowsAffected int64, err error) {
+	duration := begin.DiffInDuration()
+	elapsed := float64(duration.Nanoseconds()) / 1e6
+
+	// Query events fire regardless of the log level, mirroring Laravel's
+	// DB::listen, which is independent from the query log.
+	if utils.HasQueryListeners() {
+		// sql is the explained (interpolated) statement; when the gorm
+		// query-event plugin carried the placeholders and bindings on the
+		// context, prefer those for Sql/Bindings.
+		eventSql, bindings, ok := utils.QueryBindingsFromContext(ctx)
+		if !ok {
+			eventSql = sql
+		}
+
+		utils.DispatchQueryEvent(&contractsdb.QueryExecuted{
+			Connection: r.connection,
+			Sql:        eventSql,
+			Bindings:   bindings,
+			RawSql:     sql,
+			Time:       duration,
+			Error:      err,
+		})
+	}
+
 	if r.level <= logger.Silent {
 		return
 	}
-
-	duration := begin.DiffInDuration()
-	elapsed := float64(duration.Nanoseconds()) / 1e6
 
 	addQueryLogToContext(ctx, sql, elapsed)
 

--- a/database/db/logger_test.go
+++ b/database/db/logger_test.go
@@ -62,8 +62,8 @@ func TestNewLogger(t *testing.T) {
 			tt.setup()
 			logger := NewLogger(mockConfig, nil)
 
-			assert.Equal(t, tt.wantLevel, logger.(*Logger).level)
-			assert.Equal(t, tt.wantSlow, logger.(*Logger).slowThreshold)
+			assert.Equal(t, tt.wantLevel, logger.level)
+			assert.Equal(t, tt.wantSlow, logger.slowThreshold)
 		})
 	}
 }

--- a/database/db/query.go
+++ b/database/db/query.go
@@ -1398,16 +1398,23 @@ func (r *Query) toSqlizer(query any, args []any) (sq.Sqlizer, error) {
 }
 
 func (r *Query) trace(builder db.CommonBuilder, sql string, args []any, now *carbon.Carbon, rowsAffected int64, err error) {
+	ctx := r.ctx
+	if utils.HasQueryListeners() {
+		// Carry the placeholders and bindings on the context so the logger
+		// can report them in QueryExecuted events; rawSql is the explained form.
+		ctx = utils.WithQueryBindings(ctx, sql, args)
+	}
+
 	if r.txLogs != nil {
 		*r.txLogs = append(*r.txLogs, TxLog{
-			ctx:          r.ctx,
+			ctx:          ctx,
 			begin:        now,
 			sql:          builder.Explain(sql, args...),
 			rowsAffected: rowsAffected,
 			err:          err,
 		})
 	} else {
-		r.logger.Trace(r.ctx, now, builder.Explain(sql, args...), rowsAffected, err)
+		r.logger.Trace(ctx, now, builder.Explain(sql, args...), rowsAffected, err)
 	}
 }
 

--- a/database/driver/gorm.go
+++ b/database/driver/gorm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goravel/framework/contracts/config"
 	"github.com/goravel/framework/contracts/database"
 	contractstelemetry "github.com/goravel/framework/contracts/telemetry"
+	databaseutils "github.com/goravel/framework/database/utils"
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support/carbon"
 	"github.com/goravel/framework/support/color"
@@ -86,6 +87,12 @@ func BuildGorm(config config.Config, logger logger.Interface, pool database.Pool
 		if pluginErr := instance.Use(instrumentationdatabase.NewGormPlugin(instrument)); pluginErr != nil {
 			color.Warningln("database telemetry: " + pluginErr.Error())
 		}
+	}
+
+	// Carries the placeholder SQL and bindings on the statement context so the
+	// logger can fire QueryExecuted events with them (see DB.Listen).
+	if pluginErr := instance.Use(databaseutils.NewQueryEventPlugin()); pluginErr != nil {
+		color.Warningln("database query events: " + pluginErr.Error())
 	}
 
 	maxIdleConns := config.GetInt("database.pool.max_idle_conns", 10)

--- a/database/gorm/query.go
+++ b/database/gorm/query.go
@@ -89,7 +89,7 @@ func BuildQuery(ctx context.Context, config config.Config, connection string, lo
 	}
 
 	pool := driver.Pool()
-	logger := db.NewLogger(config, log).ToGorm()
+	logger := db.NewLogger(config, log).WithConnection(connection).ToGorm()
 	gorm, _, err := databasedriver.BuildGorm(config, logger, pool, connection, telemetryResolver)
 	if err != nil {
 		return nil, pool.Writers[0], err

--- a/database/utils/query_event.go
+++ b/database/utils/query_event.go
@@ -1,0 +1,157 @@
+package utils
+
+import (
+	"context"
+	"sync"
+
+	"gorm.io/gorm"
+
+	contractsdb "github.com/goravel/framework/contracts/database/db"
+)
+
+// queryListeners holds the listeners registered through Listen. It is a
+// package-level registry so that a listener registered on one connection (or on
+// the DB facade) observes queries executed on every connection, matching the
+// global nature of Laravel's DB::listen.
+var queryListeners = &listenerRegistry{}
+
+type listenerRegistry struct {
+	mu        sync.RWMutex
+	listeners []func(event *contractsdb.QueryExecuted) error
+}
+
+func (r *listenerRegistry) add(listener func(event *contractsdb.QueryExecuted) error) {
+	if listener == nil {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.listeners = append(r.listeners, listener)
+}
+
+func (r *listenerRegistry) has() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return len(r.listeners) > 0
+}
+
+func (r *listenerRegistry) dispatch(event *contractsdb.QueryExecuted) {
+	r.mu.RLock()
+	listeners := r.listeners
+	r.mu.RUnlock()
+
+	for _, listener := range listeners {
+		r.call(listener, event)
+	}
+}
+
+func (r *listenerRegistry) call(listener func(event *contractsdb.QueryExecuted) error, event *contractsdb.QueryExecuted) {
+	// A panicking listener must never break the query flow, so the panic is
+	// recovered and swallowed here.
+	defer func() {
+		_ = recover()
+	}()
+
+	_ = listener(event)
+}
+
+// ListenQuery registers a listener that is called for every SQL query executed
+// by the database, mirroring Laravel's DB::listen.
+func ListenQuery(listener func(event *contractsdb.QueryExecuted) error) {
+	queryListeners.add(listener)
+}
+
+// ClearQueryListeners removes all registered query event listeners. It exists
+// for tests that register listeners through the global registry.
+func ClearQueryListeners() {
+	queryListeners.mu.Lock()
+	defer queryListeners.mu.Unlock()
+	queryListeners.listeners = nil
+}
+
+// HasQueryListeners reports whether any query event listener is registered.
+// Hot paths use it to skip building events nobody would receive.
+func HasQueryListeners() bool {
+	return queryListeners.has()
+}
+
+// DispatchQueryEvent delivers the event to every registered listener.
+func DispatchQueryEvent(event *contractsdb.QueryExecuted) {
+	queryListeners.dispatch(event)
+}
+
+type queryBindingsKey struct{}
+
+type queryBindings struct {
+	sql  string
+	args []any
+}
+
+// WithQueryBindings carries the placeholder SQL and its bound arguments
+// alongside the context so that the query-event dispatcher can report them.
+func WithQueryBindings(ctx context.Context, sql string, args []any) context.Context {
+	return context.WithValue(ctx, queryBindingsKey{}, queryBindings{sql: sql, args: args})
+}
+
+// QueryBindingsFromContext returns the bindings carried on the context, if any.
+func QueryBindingsFromContext(ctx context.Context) (string, []any, bool) {
+	bindings, ok := ctx.Value(queryBindingsKey{}).(queryBindings)
+	if !ok {
+		return "", nil, false
+	}
+
+	return bindings.sql, bindings.args, true
+}
+
+const QueryEventPluginName = "goravel:query_event"
+
+// QueryEventPlugin is a gorm plugin that carries the built SQL and its
+// variables on the statement context right before gorm traces the query, so
+// the logger can emit a QueryExecuted event with Sql and Bindings populated.
+type QueryEventPlugin struct{}
+
+func NewQueryEventPlugin() *QueryEventPlugin {
+	return &QueryEventPlugin{}
+}
+
+func (r *QueryEventPlugin) Name() string {
+	return QueryEventPluginName
+}
+
+func (r *QueryEventPlugin) Initialize(db *gorm.DB) error {
+	cb := db.Callback()
+
+	if err := cb.Create().After("gorm:create").Register(QueryEventPluginName+":after", r.after); err != nil {
+		return err
+	}
+	if err := cb.Query().After("gorm:query").Register(QueryEventPluginName+":after", r.after); err != nil {
+		return err
+	}
+	if err := cb.Update().After("gorm:update").Register(QueryEventPluginName+":after", r.after); err != nil {
+		return err
+	}
+	if err := cb.Delete().After("gorm:delete").Register(QueryEventPluginName+":after", r.after); err != nil {
+		return err
+	}
+	if err := cb.Row().After("gorm:row").Register(QueryEventPluginName+":after", r.after); err != nil {
+		return err
+	}
+	if err := cb.Raw().After("gorm:raw").Register(QueryEventPluginName+":after", r.after); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *QueryEventPlugin) after(tx *gorm.DB) {
+	if !HasQueryListeners() || tx.Statement == nil || tx.Statement.SQL.Len() == 0 {
+		return
+	}
+
+	sql := tx.Statement.SQL.String()
+	vars := tx.Statement.Vars
+
+	tx.Statement.Context = WithQueryBindings(tx.Statement.Context, sql, append([]any{}, vars...))
+}

--- a/database/utils/query_event_test.go
+++ b/database/utils/query_event_test.go
@@ -1,0 +1,235 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	gormtests "gorm.io/gorm/utils/tests"
+
+	contractsdb "github.com/goravel/framework/contracts/database/db"
+)
+
+// collectQueryEvents registers a listener that records dispatched events and
+// returns them. The registry is package-level, so every test clears it.
+func collectQueryEvents(t *testing.T) func() []*contractsdb.QueryExecuted {
+	t.Helper()
+	t.Cleanup(ClearQueryListeners)
+
+	var events []*contractsdb.QueryExecuted
+	ListenQuery(func(event *contractsdb.QueryExecuted) error {
+		events = append(events, event)
+
+		return nil
+	})
+
+	return func() []*contractsdb.QueryExecuted {
+		return events
+	}
+}
+
+func TestListenQueryDispatchesToMultipleListeners(t *testing.T) {
+	t.Cleanup(ClearQueryListeners)
+
+	var order []string
+	ListenQuery(func(event *contractsdb.QueryExecuted) error {
+		order = append(order, "first:"+event.Sql)
+
+		return nil
+	})
+	ListenQuery(func(event *contractsdb.QueryExecuted) error {
+		order = append(order, "second:"+event.Sql)
+
+		return nil
+	})
+
+	DispatchQueryEvent(&contractsdb.QueryExecuted{Sql: "SELECT 1"})
+
+	assert.Equal(t, []string{"first:SELECT 1", "second:SELECT 1"}, order)
+}
+
+func TestListenQueryNilListenerIgnored(t *testing.T) {
+	t.Cleanup(ClearQueryListeners)
+
+	assert.False(t, HasQueryListeners())
+
+	ListenQuery(nil)
+	assert.False(t, HasQueryListeners())
+
+	// Dispatching with only a nil listener registered must not panic.
+	assert.NotPanics(t, func() {
+		DispatchQueryEvent(&contractsdb.QueryExecuted{Sql: "SELECT 1"})
+	})
+}
+
+func TestDispatchQueryEventListenerErrorDoesNotStopOthers(t *testing.T) {
+	t.Cleanup(ClearQueryListeners)
+
+	var secondCalled bool
+	ListenQuery(func(event *contractsdb.QueryExecuted) error {
+		return errors.New("listener failed")
+	})
+	ListenQuery(func(event *contractsdb.QueryExecuted) error {
+		secondCalled = true
+
+		return nil
+	})
+
+	// Listener errors are swallowed by the registry: the query flow must never
+	// break and later listeners must still run.
+	assert.NotPanics(t, func() {
+		DispatchQueryEvent(&contractsdb.QueryExecuted{Sql: "SELECT 1"})
+	})
+	assert.True(t, secondCalled)
+}
+
+func TestDispatchQueryEventPanickingListenerIsRecovered(t *testing.T) {
+	t.Cleanup(ClearQueryListeners)
+
+	var secondCalled bool
+	ListenQuery(func(event *contractsdb.QueryExecuted) error {
+		panic("listener panic")
+	})
+	ListenQuery(func(event *contractsdb.QueryExecuted) error {
+		secondCalled = true
+
+		return nil
+	})
+
+	assert.NotPanics(t, func() {
+		DispatchQueryEvent(&contractsdb.QueryExecuted{Sql: "SELECT 1"})
+	})
+	// The panic is swallowed per listener, so the remaining ones still run.
+	assert.True(t, secondCalled)
+}
+
+func TestHasQueryListenersAndClear(t *testing.T) {
+	t.Cleanup(ClearQueryListeners)
+	ClearQueryListeners()
+
+	assert.False(t, HasQueryListeners())
+
+	ListenQuery(func(event *contractsdb.QueryExecuted) error { return nil })
+	assert.True(t, HasQueryListeners())
+
+	ListenQuery(func(event *contractsdb.QueryExecuted) error { return nil })
+	ClearQueryListeners()
+	assert.False(t, HasQueryListeners())
+}
+
+func TestQueryBindingsFromContext(t *testing.T) {
+	t.Run("round trip", func(t *testing.T) {
+		ctx := WithQueryBindings(context.Background(), "SELECT * FROM users WHERE id = ?", []any{1, "two"})
+
+		sql, args, ok := QueryBindingsFromContext(ctx)
+		assert.True(t, ok)
+		assert.Equal(t, "SELECT * FROM users WHERE id = ?", sql)
+		assert.Equal(t, []any{1, "two"}, args)
+	})
+
+	t.Run("without bindings", func(t *testing.T) {
+		sql, args, ok := QueryBindingsFromContext(context.Background())
+		assert.False(t, ok)
+		assert.Empty(t, sql)
+		assert.Nil(t, args)
+	})
+
+	t.Run("wrong type under the key", func(t *testing.T) {
+		ctx := context.WithValue(context.Background(), queryBindingsKey{}, "not bindings")
+
+		sql, args, ok := QueryBindingsFromContext(ctx)
+		assert.False(t, ok)
+		assert.Empty(t, sql)
+		assert.Nil(t, args)
+	})
+}
+
+func TestQueryEventPluginName(t *testing.T) {
+	assert.Equal(t, QueryEventPluginName, NewQueryEventPlugin().Name())
+}
+
+func TestQueryEventPluginInitialize(t *testing.T) {
+	instance, err := gorm.Open(gormtests.DummyDialector{}, &gorm.Config{DryRun: true})
+	require.NoError(t, err)
+
+	require.NoError(t, NewQueryEventPlugin().Initialize(instance))
+
+	// Re-initializing replaces the same-named callbacks without error, and the
+	// plugin must still be registered under its name.
+	require.NoError(t, NewQueryEventPlugin().Initialize(instance))
+	assert.NotNil(t, instance.Callback().Query().Get(QueryEventPluginName+":after"))
+}
+
+func newDummyGormDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	instance, err := gorm.Open(gormtests.DummyDialector{}, &gorm.Config{DryRun: true})
+	require.NoError(t, err)
+
+	return instance
+}
+
+func TestQueryEventPluginAfter(t *testing.T) {
+	plugin := NewQueryEventPlugin()
+
+	t.Run("skipped without listeners", func(t *testing.T) {
+		t.Cleanup(ClearQueryListeners)
+		ClearQueryListeners()
+
+		db := newDummyGormDB(t)
+		tx := db.Session(&gorm.Session{NewDB: true})
+		tx.Statement.SQL.WriteString("SELECT * FROM users WHERE id = ?")
+		tx.Statement.Vars = append(tx.Statement.Vars, 1)
+
+		plugin.after(tx)
+
+		_, _, ok := QueryBindingsFromContext(tx.Statement.Context)
+		assert.False(t, ok)
+	})
+
+	t.Run("carries sql and a copy of vars", func(t *testing.T) {
+		collectQueryEvents(t)
+
+		db := newDummyGormDB(t)
+		tx := db.Session(&gorm.Session{NewDB: true})
+		tx.Statement.SQL.WriteString("SELECT * FROM users WHERE id = ?")
+		tx.Statement.Vars = append(tx.Statement.Vars, 1)
+
+		plugin.after(tx)
+
+		sql, args, ok := QueryBindingsFromContext(tx.Statement.Context)
+		require.True(t, ok)
+		assert.Equal(t, "SELECT * FROM users WHERE id = ?", sql)
+		assert.Equal(t, []any{1}, args)
+
+		// The captured bindings must be a copy: later mutation of the
+		// statement vars must not change what was carried on the context.
+		tx.Statement.Vars[0] = 99
+		_, args, ok = QueryBindingsFromContext(tx.Statement.Context)
+		require.True(t, ok)
+		assert.Equal(t, []any{1}, args)
+	})
+
+	t.Run("skipped with empty sql", func(t *testing.T) {
+		collectQueryEvents(t)
+
+		db := newDummyGormDB(t)
+		tx := db.Session(&gorm.Session{NewDB: true})
+
+		plugin.after(tx)
+
+		_, _, ok := QueryBindingsFromContext(tx.Statement.Context)
+		assert.False(t, ok)
+	})
+
+	t.Run("nil statement does not panic", func(t *testing.T) {
+		collectQueryEvents(t)
+
+		assert.NotPanics(t, func() {
+			plugin.after(&gorm.DB{})
+		})
+	})
+}

--- a/mocks/database/db/DB.go
+++ b/mocks/database/db/DB.go
@@ -310,6 +310,39 @@ func (_c *DB_Insert_Call) RunAndReturn(run func(string, ...interface{}) (*db.Res
 	return _c
 }
 
+// Listen provides a mock function with given fields: listener
+func (_m *DB) Listen(listener func(*db.QueryExecuted) error) {
+	_m.Called(listener)
+}
+
+// DB_Listen_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Listen'
+type DB_Listen_Call struct {
+	*mock.Call
+}
+
+// Listen is a helper method to define mock.On call
+//   - listener func(*db.QueryExecuted) error
+func (_e *DB_Expecter) Listen(listener interface{}) *DB_Listen_Call {
+	return &DB_Listen_Call{Call: _e.mock.On("Listen", listener)}
+}
+
+func (_c *DB_Listen_Call) Run(run func(listener func(*db.QueryExecuted) error)) *DB_Listen_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(func(*db.QueryExecuted) error))
+	})
+	return _c
+}
+
+func (_c *DB_Listen_Call) Return() *DB_Listen_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *DB_Listen_Call) RunAndReturn(run func(func(*db.QueryExecuted) error)) *DB_Listen_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Rollback provides a mock function with no fields
 func (_m *DB) Rollback() error {
 	ret := _m.Called()


### PR DESCRIPTION
## Problem

No way to subscribe to executed queries (Laravel's `DB::listen` / `QueryExecuted` parity). Fixes goravel/goravel#991.

## API

```go
facades.DB().Listen(func(query *db.QueryExecuted) error {
    // query.Connection, query.Sql, query.Bindings, query.RawSql, query.Time, query.Error
    return nil
})
```

`db.QueryExecuted` lives in `contracts/database/db`; `Listen` is added to the `DB` interface (mock regenerated) plus a package-level `db.Listen` helper.

## Design

- Single hook point: `database/db.Logger.Trace` — every query path (gorm, `Tx.Select`/`exec`, `Query.trace`, deferred transaction logs) already funnels through it, so no driver changes are needed.
- Listeners live in a global registry (`database/utils/query_event.go`): a listener on any connection sees all queries, like Laravel.
- `Sql`/`Bindings` for gorm queries are captured via a lightweight `QueryEventPlugin` registered in `BuildGorm` (stashes `stmt.SQL`/`stmt.Vars` on the statement context). Direct-SQL paths attach bindings in `Query.trace`/`Tx.Select`/`Tx.exec`.
- Zero overhead when no listener is registered (`HasQueryListeners()` guard); existing mock-logger tests pass unchanged.
- Panicking listeners are recovered; events fire even at `Silent` log level (Laravel parity).

Strictly additive — no existing signature changes.

## Testing

- `go build ./...`, `go vet ./...` clean
- `go test ./database/... -count=1` — 792 passed in 13 packages
- `go test ./... -count=1` — all packages ok except two pre-existing environmental failures on this machine (`foundation` asserts the clone dir is named `framework`; a `process` Windows timing flake) — both fail identically on the clean baseline.
- New `database/db/listen_test.go`: listener receives correct fields on select/insert/transaction paths; multiple listeners; panicking listener recovered; no-listener fast path.

## Open questions

1. Should `Listen` route through the event module (`facades.Event().Dispatch`) instead of a dedicated registry? Current design keeps `database` decoupled from `event`.
2. Laravel traces `BEGIN`/`COMMIT` themselves; here transaction statements fire on `Commit` (deferred), matching the existing query-log behavior.
3. No `Unlisten` API added — easy follow-up if wanted.