### PR TITLE
feat: [#880] make all make:* commands accept multiple names

### DIFF
--- a/ai/console/agent_make_command.go
+++ b/ai/console/agent_make_command.go
@@ -39,15 +39,23 @@ func (r *AgentMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *AgentMakeCommand) Handle(ctx console.Context) error {
-	make, err := supportconsole.NewMake(ctx, "agent", ctx.Argument(0), support.Config.Paths.Agents)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *AgentMakeCommand) makeOne(ctx console.Context, name string) error {
+	make, err := supportconsole.NewMake(ctx, "agent", name, support.Config.Paths.Agents)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(make.GetFilePath(), r.populateStub(r.getStub(), make.GetPackageName(), make.GetStructName())); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Agent created successfully")

--- a/ai/console/agent_make_command_test.go
+++ b/ai/console/agent_make_command_test.go
@@ -38,23 +38,23 @@ func TestAgentMakeCommand(t *testing.T) {
 		}
 	}
 
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the agent name", mock.Anything).Return("", errors.New("the agent name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the agent name cannot be empty").Once()
 	assert.NoError(t, agentMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("UserAgent").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserAgent"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Agent created successfully").Once()
 	assert.NoError(t, agentMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/ai/agents/user_agent.go"))
 
-	mockContext.EXPECT().Argument(0).Return("UserAgent").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserAgent"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the agent already exists. Use the --force or -f flag to overwrite").Once()
 	assert.NoError(t, agentMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("user/SupportAgent").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"user/SupportAgent"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Agent created successfully").Once()
 	assert.NoError(t, agentMakeCommand.Handle(mockContext))
@@ -66,9 +66,25 @@ func TestAgentMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("app/ai/agents/user/support_agent.go", "func (r *SupportAgent) Middleware() []ai.Middleware"))
 
 	support.Config.Paths.Agents = "custom/agents"
-	mockContext.EXPECT().Argument(0).Return("BillingAgent").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"BillingAgent"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Agent created successfully").Once()
 	assert.NoError(t, agentMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("custom/agents/billing_agent.go"))
+}
+
+func TestAgentMakeCommand_MultipleNames(t *testing.T) {
+	agentMakeCommand := &AgentMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+	defer func() {
+		_ = file.Remove("app")
+	}()
+
+	mockContext.EXPECT().Arguments().Return([]string{"SupportAgent", "BillingAgent"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Agent created successfully").Times(2)
+	assert.NoError(t, agentMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/ai/agents/support_agent.go"))
+	assert.True(t, file.Exists("app/ai/agents/billing_agent.go"))
 }

--- a/ai/console/tool_make_command.go
+++ b/ai/console/tool_make_command.go
@@ -40,15 +40,23 @@ func (r *ToolMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *ToolMakeCommand) Handle(ctx console.Context) error {
-	make, err := supportconsole.NewMake(ctx, "tool", ctx.Argument(0), support.Config.Paths.Tools)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *ToolMakeCommand) makeOne(ctx console.Context, name string) error {
+	make, err := supportconsole.NewMake(ctx, "tool", name, support.Config.Paths.Tools)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(make.GetFilePath(), r.populateStub(r.getStub(), make.GetPackageName(), make.GetStructName())); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Tool created successfully")

--- a/ai/console/tool_make_command_test.go
+++ b/ai/console/tool_make_command_test.go
@@ -38,23 +38,23 @@ func TestToolMakeCommand(t *testing.T) {
 		}
 	}
 
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the tool name", mock.Anything).Return("", errors.New("the tool name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the tool name cannot be empty").Once()
 	assert.NoError(t, toolMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("WeatherTool").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"WeatherTool"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Tool created successfully").Once()
 	assert.NoError(t, toolMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/ai/tools/weather_tool.go"))
 
-	mockContext.EXPECT().Argument(0).Return("WeatherTool").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"WeatherTool"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the tool already exists. Use the --force or -f flag to overwrite").Once()
 	assert.NoError(t, toolMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("user/WeatherTool").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"user/WeatherTool"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Tool created successfully").Once()
 	assert.NoError(t, toolMakeCommand.Handle(mockContext))
@@ -70,9 +70,25 @@ func TestToolMakeCommand(t *testing.T) {
 	assert.False(t, file.Contain("app/ai/tools/user/weather_tool.go", "var _ ai.Tool = (*WeatherTool)(nil)"))
 
 	support.Config.Paths.Tools = "custom/tools"
-	mockContext.EXPECT().Argument(0).Return("CurrencyTool").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"CurrencyTool"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Tool created successfully").Once()
 	assert.NoError(t, toolMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("custom/tools/currency_tool.go"))
+}
+
+func TestToolMakeCommand_MultipleNames(t *testing.T) {
+	toolMakeCommand := &ToolMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+	defer func() {
+		_ = file.Remove("app")
+	}()
+
+	mockContext.EXPECT().Arguments().Return([]string{"WeatherTool", "CurrencyTool"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Tool created successfully").Times(2)
+	assert.NoError(t, toolMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/ai/tools/weather_tool.go"))
+	assert.True(t, file.Exists("app/ai/tools/currency_tool.go"))
 }

--- a/auth/console/policy_make_command.go
+++ b/auth/console/policy_make_command.go
@@ -43,10 +43,19 @@ func (r *PolicyMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *PolicyMakeCommand) Handle(ctx console.Context) error {
-	m, err := supportconsole.NewMake(ctx, "policy", ctx.Argument(0), support.Config.Paths.Policies)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *PolicyMakeCommand) makeOne(ctx console.Context, name string) error {
+	m, err := supportconsole.NewMake(ctx, "policy", name, support.Config.Paths.Policies)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {

--- a/auth/console/policy_make_command_test.go
+++ b/auth/console/policy_make_command_test.go
@@ -14,23 +14,23 @@ import (
 func TestPolicyMakeCommand(t *testing.T) {
 	policyMakeCommand := &PolicyMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the policy name", mock.Anything).Return("", errors.New("the policy name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the policy name cannot be empty").Once()
 	assert.Nil(t, policyMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("UserPolicy").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserPolicy"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Policy created successfully").Once()
 	assert.Nil(t, policyMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/policies/user_policy.go"))
 
-	mockContext.EXPECT().Argument(0).Return("UserPolicy").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserPolicy"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the policy already exists. Use the --force or -f flag to overwrite").Once()
 	assert.Nil(t, policyMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("User/AuthPolicy").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"User/AuthPolicy"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Policy created successfully").Once()
 	assert.Nil(t, policyMakeCommand.Handle(mockContext))
@@ -38,5 +38,19 @@ func TestPolicyMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("app/policies/User/auth_policy.go", "package User"))
 	assert.True(t, file.Contain("app/policies/User/auth_policy.go", "type AuthPolicy struct {"))
 
+	assert.Nil(t, file.Remove("app"))
+}
+
+func TestPolicyMakeCommand_MultipleNames(t *testing.T) {
+	policyMakeCommand := &PolicyMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+
+	mockContext.EXPECT().Arguments().Return([]string{"PostPolicy", "CommentPolicy"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Policy created successfully").Times(2)
+	assert.Nil(t, policyMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/policies/post_policy.go"))
+	assert.True(t, file.Exists("app/policies/comment_policy.go"))
 	assert.Nil(t, file.Remove("app"))
 }

--- a/broadcasting/console/channel_make_command.go
+++ b/broadcasting/console/channel_make_command.go
@@ -38,10 +38,19 @@ func (r *ChannelMakeCommand) Extend() command.Extend {
 }
 
 func (r *ChannelMakeCommand) Handle(ctx console.Context) error {
-	m, err := supportconsole.NewMake(ctx, "channel", ctx.Argument(0), support.Config.Paths.Broadcasting)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *ChannelMakeCommand) makeOne(ctx console.Context, name string) error {
+	m, err := supportconsole.NewMake(ctx, "channel", name, support.Config.Paths.Broadcasting)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {

--- a/broadcasting/console/channel_make_command_test.go
+++ b/broadcasting/console/channel_make_command_test.go
@@ -21,7 +21,7 @@ func TestChannelMakeCommand(t *testing.T) {
 
 	t.Run("empty name", func(t *testing.T) {
 		mockContext := mocksconsole.NewContext(t)
-		mockContext.EXPECT().Argument(0).Return("").Once()
+		mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 		mockContext.EXPECT().Ask("Enter the channel name", mock.Anything).Return("", errors.New("the channel name cannot be empty")).Once()
 		mockContext.EXPECT().Error("the channel name cannot be empty").Once()
 		assert.Nil(t, cmd.Handle(mockContext))
@@ -29,7 +29,7 @@ func TestChannelMakeCommand(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		mockContext := mocksconsole.NewContext(t)
-		mockContext.EXPECT().Argument(0).Return("TestChannel").Once()
+		mockContext.EXPECT().Arguments().Return([]string{"TestChannel"}).Once()
 		mockContext.EXPECT().OptionBool("force").Return(false).Once()
 		mockContext.EXPECT().Success("Channel created successfully").Once()
 		assert.Nil(t, cmd.Handle(mockContext))
@@ -40,4 +40,21 @@ func TestChannelMakeCommand(t *testing.T) {
 		assert.True(t, file.Contain(channelPath, "func TestChannel("))
 		assert.True(t, file.Contain(channelPath, "var _ broadcasting.ChannelAuthFunc = TestChannel"))
 	})
+}
+
+func TestChannelMakeCommand_MultipleNames(t *testing.T) {
+	defer func() {
+		assert.Nil(t, file.Remove("app"))
+	}()
+
+	cmd := &ChannelMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+
+	mockContext.EXPECT().Arguments().Return([]string{"OrderChannel", "UserChannel"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Channel created successfully").Times(2)
+	assert.Nil(t, cmd.Handle(mockContext))
+
+	assert.True(t, file.Exists(filepath.Join("app", "broadcasting", "order_channel.go")))
+	assert.True(t, file.Exists(filepath.Join("app", "broadcasting", "user_channel.go")))
 }

--- a/database/console/factory_make_command.go
+++ b/database/console/factory_make_command.go
@@ -43,15 +43,23 @@ func (r *FactoryMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *FactoryMakeCommand) Handle(ctx console.Context) error {
-	m, err := supportconsole.NewMake(ctx, "factory", ctx.Argument(0), support.Config.Paths.Factories)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *FactoryMakeCommand) makeOne(ctx console.Context, name string) error {
+	m, err := supportconsole.NewMake(ctx, "factory", name, support.Config.Paths.Factories)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Factory created successfully")

--- a/database/console/factory_make_command_test.go
+++ b/database/console/factory_make_command_test.go
@@ -14,12 +14,12 @@ import (
 func TestFactoryMakeCommand(t *testing.T) {
 	factoryMakeCommand := &FactoryMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the factory name", mock.Anything).Return("", errors.New("the factory name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the factory name cannot be empty").Once()
 	assert.NoError(t, factoryMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("UserFactory").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserFactory"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Factory created successfully").Once()
 	assert.NoError(t, factoryMakeCommand.Handle(mockContext))
@@ -27,18 +27,32 @@ func TestFactoryMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("database/factories/user_factory.go", "package factories"))
 	assert.True(t, file.Contain("database/factories/user_factory.go", "type UserFactory struct"))
 
-	mockContext.EXPECT().Argument(0).Return("UserFactory").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserFactory"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the factory already exists. Use the --force or -f flag to overwrite").Once()
 	assert.NoError(t, factoryMakeCommand.Handle(mockContext))
 	assert.NoError(t, file.Remove("database"))
 
-	mockContext.EXPECT().Argument(0).Return("subdir/DemoFactory").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"subdir/DemoFactory"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Factory created successfully").Once()
 	assert.NoError(t, factoryMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("database/factories/subdir/demo_factory.go"))
 	assert.True(t, file.Contain("database/factories/subdir/demo_factory.go", "package subdir"))
 	assert.True(t, file.Contain("database/factories/subdir/demo_factory.go", "type DemoFactory struct"))
+	assert.NoError(t, file.Remove("database"))
+}
+
+func TestFactoryMakeCommand_MultipleNames(t *testing.T) {
+	factoryMakeCommand := &FactoryMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+
+	mockContext.EXPECT().Arguments().Return([]string{"UserFactory", "PostFactory"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Factory created successfully").Times(2)
+	assert.NoError(t, factoryMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("database/factories/user_factory.go"))
+	assert.True(t, file.Exists("database/factories/post_factory.go"))
 	assert.NoError(t, file.Remove("database"))
 }

--- a/database/console/migration/migrate_make_command.go
+++ b/database/console/migration/migrate_make_command.go
@@ -51,17 +51,25 @@ func (r *MigrateMakeCommand) Extend() command.Extend {
 
 // Handle Executes the console command.
 func (r *MigrateMakeCommand) Handle(ctx console.Context) error {
-	makeMigration, err := supportconsole.NewMake(ctx, "migration", ctx.Argument(0), support.Config.Paths.Migrations)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *MigrateMakeCommand) makeOne(ctx console.Context, name string) error {
+	makeMigration, err := supportconsole.NewMake(ctx, "migration", name, support.Config.Paths.Migrations)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 	modelName := ctx.Option("model")
 
 	fileName, err := r.migrator.Create(makeMigration.GetName(), modelName)
 	if err != nil {
-		ctx.Error(errors.MigrationCreateFailed.Args(err).Error())
-		return nil
+		return errors.MigrationCreateFailed.Args(err)
 	}
 
 	ctx.Success(fmt.Sprintf("Created Migration: %s", makeMigration.GetName()))
@@ -74,8 +82,7 @@ func (r *MigrateMakeCommand) Handle(ctx console.Context) error {
 	}
 
 	if err != nil {
-		ctx.Error(errors.MigrationRegisterFailed.Args(err).Error())
-		return nil
+		return errors.MigrationRegisterFailed.Args(err)
 	}
 
 	ctx.Success("Migration registered successfully")

--- a/database/console/migration/migrate_make_command_test.go
+++ b/database/console/migration/migrate_make_command_test.go
@@ -34,7 +34,7 @@ func TestMigrateMakeCommand(t *testing.T) {
 		{
 			name: "Happy path",
 			setup: func() {
-				mockContext.EXPECT().Argument(0).Return("").Once()
+				mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 				mockContext.EXPECT().Ask("Enter the migration name", mock.Anything).Return("create_users_table", nil).Once()
 				mockContext.EXPECT().OptionBool("force").Return(false).Once()
 				mockContext.EXPECT().Option("model").Return("").Once()
@@ -49,7 +49,7 @@ func TestMigrateMakeCommand(t *testing.T) {
 		{
 			name: "Happy path - name is not empty",
 			setup: func() {
-				mockContext.EXPECT().Argument(0).Return("create_users_table").Once()
+				mockContext.EXPECT().Arguments().Return([]string{"create_users_table"}).Once()
 				mockContext.EXPECT().OptionBool("force").Return(false).Once()
 				mockContext.EXPECT().Option("model").Return("").Once()
 				mockMigrator.EXPECT().Create("create_users_table", "").Return("20240915060148_create_users_table", nil).Once()
@@ -63,7 +63,7 @@ func TestMigrateMakeCommand(t *testing.T) {
 		{
 			name: "Happy path - with model option",
 			setup: func() {
-				mockContext.EXPECT().Argument(0).Return("create_products_table").Once()
+				mockContext.EXPECT().Arguments().Return([]string{"create_products_table"}).Once()
 				mockContext.EXPECT().OptionBool("force").Return(false).Once()
 				mockContext.EXPECT().Option("model").Return("Product").Once()
 				mockMigrator.EXPECT().Create("create_products_table", "Product").Return("20240915060148_create_products_table", nil).Once()
@@ -77,7 +77,7 @@ func TestMigrateMakeCommand(t *testing.T) {
 		{
 			name: "Sad path - failed to ask",
 			setup: func() {
-				mockContext.EXPECT().Argument(0).Return("").Once()
+				mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 				mockContext.EXPECT().Ask("Enter the migration name", mock.Anything).Return("", assert.AnError).Once()
 				mockContext.EXPECT().Error(assert.AnError.Error()).Once()
 			},
@@ -85,7 +85,7 @@ func TestMigrateMakeCommand(t *testing.T) {
 		{
 			name: "Sad path - failed to create",
 			setup: func() {
-				mockContext.EXPECT().Argument(0).Return("create_users_table").Once()
+				mockContext.EXPECT().Arguments().Return([]string{"create_users_table"}).Once()
 				mockContext.EXPECT().OptionBool("force").Return(false).Once()
 				mockContext.EXPECT().Option("model").Return("").Once()
 				mockMigrator.EXPECT().Create("create_users_table", "").Return("", assert.AnError).Once()
@@ -95,7 +95,7 @@ func TestMigrateMakeCommand(t *testing.T) {
 		{
 			name: "Sad path - model not found",
 			setup: func() {
-				mockContext.EXPECT().Argument(0).Return("create_products_table").Once()
+				mockContext.EXPECT().Arguments().Return([]string{"create_products_table"}).Once()
 				mockContext.EXPECT().OptionBool("force").Return(false).Once()
 				mockContext.EXPECT().Option("model").Return("NonExistentModel").Once()
 				mockMigrator.EXPECT().Create("create_products_table", "NonExistentModel").Return("", errors.SchemaModelNotFound.Args("NonExistentModel")).Once()
@@ -105,7 +105,7 @@ func TestMigrateMakeCommand(t *testing.T) {
 		{
 			name: "Register success",
 			setup: func() {
-				mockContext.EXPECT().Argument(0).Return("create_users_table").Once()
+				mockContext.EXPECT().Arguments().Return([]string{"create_users_table"}).Once()
 				mockContext.EXPECT().OptionBool("force").Return(false).Once()
 				mockContext.EXPECT().Option("model").Return("").Once()
 				mockMigrator.EXPECT().Create("create_users_table", "").Return("20240915060148_create_users_table", nil).Once()
@@ -186,7 +186,7 @@ func Boot() contractsfoundation.Application {
 		mockMigrator = mocksmigration.NewMigrator(t)
 		mockApp := mocksfoundation.NewApplication(t)
 
-		mockContext.EXPECT().Argument(0).Return("create_posts_table").Once()
+		mockContext.EXPECT().Arguments().Return([]string{"create_posts_table"}).Once()
 		mockContext.EXPECT().OptionBool("force").Return(false).Once()
 		mockContext.EXPECT().Option("model").Return("").Once()
 		mockMigrator.EXPECT().Create("create_posts_table", "").Return("20240915060148_create_posts_table", nil).Once()
@@ -222,7 +222,7 @@ func Boot() {
 		mockMigrator = mocksmigration.NewMigrator(t)
 		mockApp := mocksfoundation.NewApplication(t)
 
-		mockContext.EXPECT().Argument(0).Return("create_comments_table").Once()
+		mockContext.EXPECT().Arguments().Return([]string{"create_comments_table"}).Once()
 		mockContext.EXPECT().OptionBool("force").Return(false).Once()
 		mockContext.EXPECT().Option("model").Return("").Once()
 		mockMigrator.EXPECT().Create("create_comments_table", "").Return("20240915060149_create_comments_table", nil).Once()
@@ -236,4 +236,25 @@ func Boot() {
 
 		assert.NoError(t, err)
 	})
+}
+
+func TestMigrateMakeCommand_MultipleNames(t *testing.T) {
+	mockApp := mocksfoundation.NewApplication(t)
+	mockContext := mocksconsole.NewContext(t)
+	mockMigrator := mocksmigration.NewMigrator(t)
+
+	mockContext.EXPECT().Arguments().Return([]string{"create_users_table", "create_posts_table"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Option("model").Return("").Times(2)
+	mockMigrator.EXPECT().Create("create_users_table", "").Return("20240915060148_create_users_table", nil).Once()
+	mockMigrator.EXPECT().Create("create_posts_table", "").Return("20240915060149_create_posts_table", nil).Once()
+	mockContext.EXPECT().Success("Created Migration: create_users_table").Once()
+	mockContext.EXPECT().Success("Created Migration: create_posts_table").Once()
+	mockApp.EXPECT().DatabasePath("kernel.go").Return("database/kernel.go").Times(2)
+	mockContext.EXPECT().Error(mock.MatchedBy(func(msg string) bool {
+		return strings.Contains(msg, "migration register failed")
+	})).Times(2)
+
+	migrateMakeCommand := NewMigrateMakeCommand(mockApp, mockMigrator)
+	assert.NoError(t, migrateMakeCommand.Handle(mockContext))
 }

--- a/database/console/model_make_command.go
+++ b/database/console/model_make_command.go
@@ -72,10 +72,19 @@ func (r *ModelMakeCommand) Extend() command.Extend {
 }
 
 func (r *ModelMakeCommand) Handle(ctx console.Context) error {
-	m, err := supportconsole.NewMake(ctx, "model", ctx.Argument(0), support.Config.Paths.Models)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *ModelMakeCommand) makeOne(ctx console.Context, name string) error {
+	m, err := supportconsole.NewMake(ctx, "model", name, support.Config.Paths.Models)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	table := ctx.Option("table")
@@ -86,32 +95,27 @@ func (r *ModelMakeCommand) Handle(ctx console.Context) error {
 
 	if table != "" {
 		if !r.schema.HasTable(table) {
-			ctx.Error(errors.SchemaTableNotFound.Args(table).Error())
-			return nil
+			return errors.SchemaTableNotFound.Args(table)
 		}
 
 		columns, err := r.schema.GetColumns(table)
 		if err != nil {
-			ctx.Error(err.Error())
-			return nil
+			return err
 		}
 
 		model, err = r.generateModelInfo(columns, structName, table)
 		if err != nil {
-			ctx.Error(err.Error())
-			return nil
+			return err
 		}
 	}
 
 	stubContent, err := r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName(), model)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(m.GetFilePath(), stubContent); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Model created successfully")

--- a/database/console/model_make_command_test.go
+++ b/database/console/model_make_command_test.go
@@ -23,14 +23,14 @@ func TestModelMakeCommand(t *testing.T) {
 	mockContext := mocksconsole.NewContext(t)
 
 	// Test: Empty model name
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the model name", mock.Anything).Return("", errors.New("the model name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the model name cannot be empty").Once()
 	assert.Nil(t, modelMakeCommand.Handle(mockContext))
 	assert.False(t, file.Exists("app/models/user.go"))
 
 	// Test: Create model successfully
-	mockContext.EXPECT().Argument(0).Return("User").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"User"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Option("table").Return("").Once()
 	mockContext.EXPECT().Success("Model created successfully").Once()
@@ -53,13 +53,13 @@ type User struct {
 	assert.Equal(t, expectedUserContent, userModel)
 
 	// Test: Model already exists
-	mockContext.EXPECT().Argument(0).Return("User").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"User"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the model already exists. Use the --force or -f flag to overwrite").Once()
 	assert.Nil(t, modelMakeCommand.Handle(mockContext))
 
 	// Test: Create model in subdirectory
-	mockContext.EXPECT().Argument(0).Return("User/Phone").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"User/Phone"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Option("table").Return("").Once()
 	mockContext.EXPECT().Success("Model created successfully").Once()
@@ -84,7 +84,7 @@ type Phone struct {
 	assert.Equal(t, expectedPhoneContent, phoneModel)
 
 	// Test: Create model from table schema
-	mockContext.EXPECT().Argument(0).Return("Product").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"Product"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Option("table").Return("products").Once()
 
@@ -140,7 +140,7 @@ func (r *Product) TableName() string {
 	assert.Equal(t, expectedContent, model)
 
 	// Test: Table doesn't exist
-	mockContext.EXPECT().Argument(0).Return("Invalid").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"Invalid"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Option("table").Return("nonexistent").Once()
 	mockSchema.EXPECT().HasTable("nonexistent").Return(false).Once()
@@ -148,7 +148,7 @@ func (r *Product) TableName() string {
 	assert.Nil(t, modelMakeCommand.Handle(mockContext))
 
 	//Test: Error fetching columns
-	mockContext.EXPECT().Argument(0).Return("Error").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"Error"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Option("table").Return("error_table").Once()
 	mockSchema.EXPECT().HasTable("error_table").Return(true).Once()
@@ -540,4 +540,49 @@ func TestGenerateField(t *testing.T) {
 	assert.Equal(t, "any", field.Type)
 	assert.Equal(t, "`json:\"custom_field\" db:\"custom_field\"`", field.Tags)
 	assert.Empty(t, field.Imports)
+}
+
+func TestModelMakeCommand_MultipleNames(t *testing.T) {
+	mockSchema := mocksschema.NewSchema(t)
+	mockArtisan := mocksconsole.NewArtisan(t)
+
+	modelMakeCommand := NewModelMakeCommand(mockArtisan, mockSchema)
+	mockContext := mocksconsole.NewContext(t)
+
+	mockContext.EXPECT().Arguments().Return([]string{"User", "Post"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Option("table").Return("").Times(2)
+	mockContext.EXPECT().Success("Model created successfully").Times(2)
+	assert.Nil(t, modelMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/models/user.go"))
+	assert.True(t, file.Exists("app/models/post.go"))
+	assert.Nil(t, file.Remove("app"))
+}
+
+// TestModelMakeCommand_MultipleNamesPartialFailure verifies that a failure for
+// one name (e.g. the file already exists) does not stop the remaining names.
+func TestModelMakeCommand_MultipleNamesPartialFailure(t *testing.T) {
+	mockSchema := mocksschema.NewSchema(t)
+	mockArtisan := mocksconsole.NewArtisan(t)
+
+	modelMakeCommand := NewModelMakeCommand(mockArtisan, mockSchema)
+	mockContext := mocksconsole.NewContext(t)
+
+	mockContext.EXPECT().Arguments().Return([]string{"User"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Once()
+	mockContext.EXPECT().Option("table").Return("").Once()
+	mockContext.EXPECT().Success("Model created successfully").Once()
+	assert.Nil(t, modelMakeCommand.Handle(mockContext))
+
+	mockContext.EXPECT().Arguments().Return([]string{"User", "Post"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Option("table").Return("").Once()
+	mockContext.EXPECT().Error("the model already exists. Use the --force or -f flag to overwrite").Once()
+	mockContext.EXPECT().Success("Model created successfully").Once()
+	assert.Nil(t, modelMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/models/user.go"))
+	assert.True(t, file.Exists("app/models/post.go"))
+	assert.Nil(t, file.Remove("app"))
 }

--- a/database/console/observer_make_command.go
+++ b/database/console/observer_make_command.go
@@ -43,10 +43,19 @@ func (r *ObserverMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *ObserverMakeCommand) Handle(ctx console.Context) error {
-	m, err := supportconsole.NewMake(ctx, "observer", ctx.Argument(0), support.Config.Paths.Observers)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *ObserverMakeCommand) makeOne(ctx console.Context, name string) error {
+	m, err := supportconsole.NewMake(ctx, "observer", name, support.Config.Paths.Observers)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {

--- a/database/console/observer_make_command_test.go
+++ b/database/console/observer_make_command_test.go
@@ -14,24 +14,24 @@ import (
 func TestObserverMakeCommand(t *testing.T) {
 	observerMakeCommand := &ObserverMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the observer name", mock.Anything).Return("", errors.New("the observer name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the observer name cannot be empty").Once()
 	assert.Nil(t, observerMakeCommand.Handle(mockContext))
 	assert.False(t, file.Exists("app/observers/user_observer.go"))
 
-	mockContext.EXPECT().Argument(0).Return("UserObserver").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserObserver"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Observer created successfully").Once()
 	assert.Nil(t, observerMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/observers/user_observer.go"))
 
-	mockContext.EXPECT().Argument(0).Return("UserObserver").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserObserver"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the observer already exists. Use the --force or -f flag to overwrite").Once()
 	assert.Nil(t, observerMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("User/PhoneObserver").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"User/PhoneObserver"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Observer created successfully").Once()
 	assert.Nil(t, observerMakeCommand.Handle(mockContext))
@@ -39,5 +39,19 @@ func TestObserverMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("app/observers/User/phone_observer.go", "package User"))
 	assert.True(t, file.Contain("app/observers/User/phone_observer.go", "type PhoneObserver struct"))
 
+	assert.Nil(t, file.Remove("app"))
+}
+
+func TestObserverMakeCommand_MultipleNames(t *testing.T) {
+	observerMakeCommand := &ObserverMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+
+	mockContext.EXPECT().Arguments().Return([]string{"UserObserver", "PostObserver"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Observer created successfully").Times(2)
+	assert.NoError(t, observerMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/observers/user_observer.go"))
+	assert.True(t, file.Exists("app/observers/post_observer.go"))
 	assert.Nil(t, file.Remove("app"))
 }

--- a/database/console/seeder_make_command.go
+++ b/database/console/seeder_make_command.go
@@ -52,10 +52,19 @@ func (r *SeederMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *SeederMakeCommand) Handle(ctx console.Context) error {
-	make, err := supportconsole.NewMake(ctx, "seeder", ctx.Argument(0), support.Config.Paths.Seeders)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *SeederMakeCommand) makeOne(ctx console.Context, name string) error {
+	make, err := supportconsole.NewMake(ctx, "seeder", name, support.Config.Paths.Seeders)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err = file.PutContent(make.GetFilePath(), r.populateStub(r.getStub(), make.GetPackageName(), make.GetStructName(), make.GetSignature())); err != nil {

--- a/database/console/seeder_make_command_test.go
+++ b/database/console/seeder_make_command_test.go
@@ -36,12 +36,12 @@ func TestSeederMakeCommand(t *testing.T) {
 	seederMakeCommand := &SeederMakeCommand{app: mockApp}
 
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the seeder name", mock.Anything).Return("", errors.New("the seeder name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the seeder name cannot be empty").Once()
 	assert.Nil(t, seederMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("UserSeeder").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserSeeder"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockApp.EXPECT().DatabasePath("kernel.go").Return("database/kernel.go").Once()
 	mockContext.EXPECT().Success("Seeder created successfully").Once()
@@ -54,13 +54,13 @@ func TestSeederMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("database/kernel.go", "database/seeders"))
 	assert.True(t, file.Contain("database/kernel.go", "&seeders.UserSeeder{}"))
 
-	mockContext.EXPECT().Argument(0).Return("UserSeeder").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserSeeder"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the seeder already exists. Use the --force or -f flag to overwrite").Once()
 	assert.NoError(t, seederMakeCommand.Handle(mockContext))
 	assert.NoError(t, file.Remove("database"))
 
-	mockContext.EXPECT().Argument(0).Return("subdir/DemoSeeder").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"subdir/DemoSeeder"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Seeder created successfully").Once()
 	mockApp.EXPECT().DatabasePath("kernel.go").Return("database/kernel.go").Once()
@@ -107,7 +107,7 @@ func Boot() contractsfoundation.Application {
 		mockContext = mocksconsole.NewContext(t)
 		mockApp = mocksfoundation.NewApplication(t)
 
-		mockContext.EXPECT().Argument(0).Return("UserSeeder").Once()
+		mockContext.EXPECT().Arguments().Return([]string{"UserSeeder"}).Once()
 		mockContext.EXPECT().OptionBool("force").Return(false).Once()
 		mockContext.EXPECT().Success("Seeder created successfully").Once()
 		mockContext.EXPECT().Success("Seeder registered successfully").Once()
@@ -144,7 +144,7 @@ func Boot() {
 		mockContext = mocksconsole.NewContext(t)
 		mockApp = mocksfoundation.NewApplication(t)
 
-		mockContext.EXPECT().Argument(0).Return("PostSeeder").Once()
+		mockContext.EXPECT().Arguments().Return([]string{"PostSeeder"}).Once()
 		mockContext.EXPECT().OptionBool("force").Return(false).Once()
 		mockContext.EXPECT().Success("Seeder created successfully").Once()
 		mockContext.EXPECT().Warning(mock.MatchedBy(func(msg string) bool {
@@ -159,4 +159,23 @@ func Boot() {
 		assert.True(t, file.Contain("database/seeders/post_seeder.go", "package seeders"))
 		assert.True(t, file.Contain("database/seeders/post_seeder.go", "type PostSeeder struct"))
 	})
+}
+
+func TestSeederMakeCommand_MultipleNames(t *testing.T) {
+	mockApp := mocksfoundation.NewApplication(t)
+	seederMakeCommand := &SeederMakeCommand{app: mockApp}
+	mockContext := mocksconsole.NewContext(t)
+
+	assert.NoError(t, file.PutContent("database/kernel.go", databaseKernel))
+
+	mockContext.EXPECT().Arguments().Return([]string{"UserSeeder", "PostSeeder"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockApp.EXPECT().DatabasePath("kernel.go").Return("database/kernel.go").Times(2)
+	mockContext.EXPECT().Success("Seeder created successfully").Times(2)
+	mockContext.EXPECT().Success("Seeder registered successfully").Times(2)
+	assert.NoError(t, seederMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("database/seeders/user_seeder.go"))
+	assert.True(t, file.Exists("database/seeders/post_seeder.go"))
+	assert.NoError(t, file.Remove("database"))
 }

--- a/event/console/event_make_command.go
+++ b/event/console/event_make_command.go
@@ -47,10 +47,19 @@ func (r *EventMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *EventMakeCommand) Handle(ctx console.Context) error {
-	m, err := supportconsole.NewMake(ctx, "event", ctx.Argument(0), support.Config.Paths.Events)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *EventMakeCommand) makeOne(ctx console.Context, name string) error {
+	m, err := supportconsole.NewMake(ctx, "event", name, support.Config.Paths.Events)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(m.GetFilePath(), r.populateStub(r.getStub(ctx), m.GetPackageName(), m.GetStructName())); err != nil {

--- a/event/console/event_make_command_test.go
+++ b/event/console/event_make_command_test.go
@@ -14,24 +14,24 @@ import (
 func TestEventMakeCommand(t *testing.T) {
 	eventMakeCommand := &EventMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the event name", mock.Anything).Return("", errors.New("the event name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the event name cannot be empty").Once()
 	assert.Nil(t, eventMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("GoravelEvent").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"GoravelEvent"}).Once()
 	mockContext.EXPECT().OptionBool("broadcast").Return(false).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Event created successfully").Once()
 	assert.Nil(t, eventMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/events/goravel_event.go"))
 
-	mockContext.EXPECT().Argument(0).Return("GoravelEvent").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"GoravelEvent"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the event already exists. Use the --force or -f flag to overwrite").Once()
 	assert.Nil(t, eventMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("Goravel/Event").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"Goravel/Event"}).Once()
 	mockContext.EXPECT().OptionBool("broadcast").Return(false).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Event created successfully").Once()
@@ -40,7 +40,7 @@ func TestEventMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("app/events/Goravel/event.go", "package Goravel"))
 	assert.True(t, file.Contain("app/events/Goravel/event.go", "type Event struct {"))
 
-	mockContext.EXPECT().Argument(0).Return("GoravelBroadcastEvent").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"GoravelBroadcastEvent"}).Once()
 	mockContext.EXPECT().OptionBool("broadcast").Return(true).Once()
 	mockContext.EXPECT().OptionBool("now").Return(false).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
@@ -55,7 +55,7 @@ func TestEventMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("app/events/goravel_broadcast_event.go", "func (receiver *GoravelBroadcastEvent) BroadcastWhen() bool {"))
 	assert.False(t, file.Contain("app/events/goravel_broadcast_event.go", "Handle("))
 
-	mockContext.EXPECT().Argument(0).Return("GoravelBroadcastEventNow").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"GoravelBroadcastEventNow"}).Once()
 	mockContext.EXPECT().OptionBool("broadcast").Return(true).Once()
 	mockContext.EXPECT().OptionBool("now").Return(true).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
@@ -71,5 +71,20 @@ func TestEventMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("app/events/goravel_broadcast_event_now.go", "func (receiver *GoravelBroadcastEventNow) BroadcastNow() bool {"))
 	assert.False(t, file.Contain("app/events/goravel_broadcast_event_now.go", "Handle("))
 
+	assert.Nil(t, file.Remove("app"))
+}
+
+func TestEventMakeCommand_MultipleNames(t *testing.T) {
+	eventMakeCommand := &EventMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+
+	mockContext.EXPECT().Arguments().Return([]string{"OrderShipped", "OrderPaid"}).Once()
+	mockContext.EXPECT().OptionBool("broadcast").Return(false).Times(2)
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Event created successfully").Times(2)
+	assert.Nil(t, eventMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/events/order_shipped.go"))
+	assert.True(t, file.Exists("app/events/order_paid.go"))
 	assert.Nil(t, file.Remove("app"))
 }

--- a/event/console/listener_make_command.go
+++ b/event/console/listener_make_command.go
@@ -40,15 +40,23 @@ func (r *ListenerMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *ListenerMakeCommand) Handle(ctx console.Context) error {
-	m, err := supportconsole.NewMake(ctx, "listener", ctx.Argument(0), support.Config.Paths.Listeners)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *ListenerMakeCommand) makeOne(ctx console.Context, name string) error {
+	m, err := supportconsole.NewMake(ctx, "listener", name, support.Config.Paths.Listeners)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Listener created successfully")

--- a/event/console/listener_make_command_test.go
+++ b/event/console/listener_make_command_test.go
@@ -14,28 +14,42 @@ import (
 func TestListenerMakeCommand(t *testing.T) {
 	listenerMakeCommand := &ListenerMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the listener name", mock.Anything).Return("", errors.New("the listener name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the listener name cannot be empty").Once()
 	assert.Nil(t, listenerMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("GoravelListen").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"GoravelListen"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Listener created successfully").Once()
 	assert.Nil(t, listenerMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/listeners/goravel_listen.go"))
 
-	mockContext.EXPECT().Argument(0).Return("GoravelListen").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"GoravelListen"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the listener already exists. Use the --force or -f flag to overwrite").Once()
 	assert.Nil(t, listenerMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("Goravel/Listen").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"Goravel/Listen"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Listener created successfully").Once()
 	assert.Nil(t, listenerMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/listeners/Goravel/listen.go"))
 	assert.True(t, file.Contain("app/listeners/Goravel/listen.go", "package Goravel"))
 	assert.True(t, file.Contain("app/listeners/Goravel/listen.go", "type Listen struct {"))
+	assert.Nil(t, file.Remove("app"))
+}
+
+func TestListenerMakeCommand_MultipleNames(t *testing.T) {
+	listenerMakeCommand := &ListenerMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+
+	mockContext.EXPECT().Arguments().Return([]string{"SendOrderEmail", "SendReceiptEmail"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Listener created successfully").Times(2)
+	assert.Nil(t, listenerMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/listeners/send_order_email.go"))
+	assert.True(t, file.Exists("app/listeners/send_receipt_email.go"))
 	assert.Nil(t, file.Remove("app"))
 }

--- a/foundation/console/package_make_command.go
+++ b/foundation/console/package_make_command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/goravel/framework/contracts/console/command"
 	"github.com/goravel/framework/errors"
 	"github.com/goravel/framework/support"
+	supportconsole "github.com/goravel/framework/support/console"
 	"github.com/goravel/framework/support/env"
 	"github.com/goravel/framework/support/file"
 )
@@ -45,7 +46,16 @@ func (r *PackageMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *PackageMakeCommand) Handle(ctx console.Context) error {
-	pkg := ctx.Argument(0)
+	for _, pkg := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, pkg); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *PackageMakeCommand) makeOne(ctx console.Context, pkg string) error {
 	if pkg == "" {
 		var err error
 		pkg, err = ctx.Ask("Enter the package name", console.AskOption{
@@ -58,8 +68,7 @@ func (r *PackageMakeCommand) Handle(ctx console.Context) error {
 			},
 		})
 		if err != nil {
-			ctx.Error(err.Error())
-			return nil
+			return err
 		}
 	}
 
@@ -90,8 +99,7 @@ func (r *PackageMakeCommand) Handle(ctx console.Context) error {
 
 	for path, content := range files {
 		if err := file.PutContent(filepath.Join(root, path), content()); err != nil {
-			ctx.Error(err.Error())
-			return nil
+			return err
 		}
 	}
 

--- a/foundation/console/package_make_command_test.go
+++ b/foundation/console/package_make_command_test.go
@@ -97,7 +97,7 @@ func Boot() {
 		{
 			name: "name is empty",
 			setup: func() {
-				mockContext.EXPECT().Argument(0).Return("").Once()
+				mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 				mockContext.EXPECT().Ask("Enter the package name", mock.Anything).Return("", errors.New("the package name cannot be empty")).Once()
 				mockContext.EXPECT().Error("the package name cannot be empty").Once()
 			},
@@ -108,7 +108,7 @@ func Boot() {
 		{
 			name: "name is sms and use default root",
 			setup: func() {
-				mockContext.EXPECT().Argument(0).Return("sms").Once()
+				mockContext.EXPECT().Arguments().Return([]string{"sms"}).Once()
 				mockContext.EXPECT().Option("root").Return("packages").Once()
 				mockContext.EXPECT().Success("Package created successfully: packages/sms").Once()
 			},
@@ -129,7 +129,7 @@ func Boot() {
 		{
 			name: "name is github.com/goravel/sms and use other root",
 			setup: func() {
-				mockContext.EXPECT().Argument(0).Return("github.com/goravel/sms-aws").Once()
+				mockContext.EXPECT().Arguments().Return([]string{"github.com/goravel/sms-aws"}).Once()
 				mockContext.EXPECT().Option("root").Return("package").Once()
 				mockContext.EXPECT().Success("Package created successfully: package/github_com_goravel_sms_aws").Once()
 			},
@@ -162,4 +162,31 @@ func (s *PackageMakeCommandTestSuite) TestPackageName() {
 	input2 := "example.com/another_package.name"
 	expected2 := "another_package_name"
 	s.Equal(expected2, packageName(input2))
+}
+
+func (s *PackageMakeCommandTestSuite) TestHandleMultipleNames() {
+	// Create bootstrap/app.go to trigger IsBootstrapSetup() == true
+	s.Require().NoError(file.Create("bootstrap/app.go", `package bootstrap
+
+import "github.com/goravel/framework/foundation"
+
+func Boot() {
+	foundation.Setup().Start()
+}
+`))
+	s.T().Cleanup(func() {
+		_ = file.Remove("bootstrap")
+		_ = file.Remove("packages")
+	})
+
+	mockContext := mocksconsole.NewContext(s.T())
+	mockContext.EXPECT().Arguments().Return([]string{"sms", "email"}).Once()
+	mockContext.EXPECT().Option("root").Return("packages").Times(2)
+	mockContext.EXPECT().Success("Package created successfully: packages/sms").Once()
+	mockContext.EXPECT().Success("Package created successfully: packages/email").Once()
+
+	s.NoError(NewPackageMakeCommand().Handle(mockContext))
+
+	s.True(file.Exists("packages/sms/sms.go"))
+	s.True(file.Exists("packages/email/email.go"))
 }

--- a/foundation/console/provider_make_command.go
+++ b/foundation/console/provider_make_command.go
@@ -47,25 +47,32 @@ func (r *ProviderMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *ProviderMakeCommand) Handle(ctx console.Context) error {
-	make, err := supportconsole.NewMake(ctx, "provider", ctx.Argument(0), support.Config.Paths.Providers)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *ProviderMakeCommand) makeOne(ctx console.Context, name string) error {
+	make, err := supportconsole.NewMake(ctx, "provider", name, support.Config.Paths.Providers)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	stub := r.getStub()
 
 	if err := file.PutContent(make.GetFilePath(), r.populateStub(stub, make.GetPackageName(), make.GetStructName())); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Provider created successfully")
 
 	if env.IsBootstrapSetup() {
 		if err := modify.AddProvider(make.GetPackageImportPath(), fmt.Sprintf("&%s.%s{}", make.GetPackageName(), make.GetStructName())); err != nil {
-			ctx.Error(errors.ProviderRegisterFailed.Args(make.GetStructName(), err).Error())
-			return nil
+			return errors.ProviderRegisterFailed.Args(make.GetStructName(), err)
 		}
 
 		ctx.Success("Provider registered successfully")

--- a/foundation/console/provider_make_command_test.go
+++ b/foundation/console/provider_make_command_test.go
@@ -79,33 +79,33 @@ func (s *ProviderMakeCommandTestSuite) TestHandle() {
 	mockContext := mocksconsole.NewContext(s.T())
 
 	// Test empty name
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the provider name", mock.Anything).Return("", errors.New("the provider name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the provider name cannot be empty").Once()
 	s.Nil(cmd.Handle(mockContext))
 
 	// Test successful creation
-	mockContext.EXPECT().Argument(0).Return("UserServiceProvider").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserServiceProvider"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Provider created successfully").Once()
 	s.NoError(cmd.Handle(mockContext))
 	s.True(file.Exists("app/providers/user_service_provider.go"))
 
 	// Test file already exists without force
-	mockContext.EXPECT().Argument(0).Return("UserServiceProvider").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserServiceProvider"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the provider already exists. Use the --force or -f flag to overwrite").Once()
 	s.Nil(cmd.Handle(mockContext))
 
 	// Test file already exists with force
-	mockContext.EXPECT().Argument(0).Return("UserServiceProvider").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserServiceProvider"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(true).Once()
 	mockContext.EXPECT().Success("Provider created successfully").Once()
 	s.NoError(cmd.Handle(mockContext))
 	s.True(file.Exists("app/providers/user_service_provider.go"))
 
 	// Test nested provider creation
-	mockContext.EXPECT().Argument(0).Return("auth/AuthServiceProvider").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"auth/AuthServiceProvider"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Provider created successfully").Once()
 	s.NoError(cmd.Handle(mockContext))
@@ -115,5 +115,18 @@ func (s *ProviderMakeCommandTestSuite) TestHandle() {
 	s.True(file.Contain("app/providers/auth/auth_service_provider.go", "func (r *AuthServiceProvider) Register(app foundation.Application) {"))
 	
 	// Clean up test files
+	s.NoError(file.Remove("app"))
+}
+func (s *ProviderMakeCommandTestSuite) TestHandleMultipleNames() {
+	cmd := &ProviderMakeCommand{}
+	mockContext := mocksconsole.NewContext(s.T())
+
+	mockContext.EXPECT().Arguments().Return([]string{"AuthServiceProvider", "EventServiceProvider"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Provider created successfully").Times(2)
+	s.NoError(cmd.Handle(mockContext))
+
+	s.True(file.Exists("app/providers/auth_service_provider.go"))
+	s.True(file.Exists("app/providers/event_service_provider.go"))
 	s.NoError(file.Remove("app"))
 }

--- a/foundation/console/test_make_command.go
+++ b/foundation/console/test_make_command.go
@@ -46,11 +46,19 @@ func (r *TestMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *TestMakeCommand) Handle(ctx console.Context) error {
-	filePath := ctx.Argument(0)
+	for _, filePath := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, filePath); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *TestMakeCommand) makeOne(ctx console.Context, filePath string) error {
 	m, err := supportconsole.NewMake(ctx, "test", filePath, support.Config.Paths.Tests)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	stub := r.getStub()
@@ -64,8 +72,7 @@ func (r *TestMakeCommand) Handle(ctx console.Context) error {
 	}
 
 	if err := file.PutContent(m.GetFilePath(), r.populateStub(stub, m.GetPackageName(), m.GetStructName(), testsImport, testCase)); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Test created successfully")

--- a/foundation/console/test_make_command_test.go
+++ b/foundation/console/test_make_command_test.go
@@ -72,23 +72,23 @@ func (s *TestMakeCommandTestSuite) TestTestHandle() {
 	cmd := NewTestMakeCommand()
 	mockContext := mocksconsole.NewContext(s.T())
 
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the test name", mock.Anything).Return("", errors.New("the test name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the test name cannot be empty").Once()
 	s.Nil(cmd.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("UserTest").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserTest"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Test created successfully").Once()
 	s.NoError(cmd.Handle(mockContext))
 	s.True(file.Exists("tests/user_test.go"))
 
-	mockContext.EXPECT().Argument(0).Return("UserTest").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"UserTest"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the test already exists. Use the --force or -f flag to overwrite").Once()
 	s.Nil(cmd.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("user/UserTest").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"user/UserTest"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Test created successfully").Once()
 	s.NoError(cmd.Handle(mockContext))
@@ -98,5 +98,19 @@ func (s *TestMakeCommandTestSuite) TestTestHandle() {
 	s.True(file.Contain("tests/user/user_test.go", "func (s *UserTestSuite) SetupTest() {"))
 	s.True(file.Contain("tests/user/user_test.go", `"github.com/goravel/framework/tests"`))
 	s.True(file.Contain("tests/user/user_test.go", "tests.TestCase"))
+	s.NoError(file.Remove("tests"))
+}
+
+func (s *TestMakeCommandTestSuite) TestTestHandleMultipleNames() {
+	cmd := NewTestMakeCommand()
+	mockContext := mocksconsole.NewContext(s.T())
+
+	mockContext.EXPECT().Arguments().Return([]string{"UserTest", "PostTest"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Test created successfully").Times(2)
+	s.NoError(cmd.Handle(mockContext))
+
+	s.True(file.Exists("tests/user_test.go"))
+	s.True(file.Exists("tests/post_test.go"))
 	s.NoError(file.Remove("tests"))
 }

--- a/mail/console/mail_make_command.go
+++ b/mail/console/mail_make_command.go
@@ -43,15 +43,23 @@ func (r *MailMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *MailMakeCommand) Handle(ctx console.Context) error {
-	m, err := supportconsole.NewMake(ctx, "mail", ctx.Argument(0), support.Config.Paths.Mails)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *MailMakeCommand) makeOne(ctx console.Context, name string) error {
+	m, err := supportconsole.NewMake(ctx, "mail", name, support.Config.Paths.Mails)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName())); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Mail created successfully")

--- a/mail/console/mail_make_command_test.go
+++ b/mail/console/mail_make_command_test.go
@@ -14,24 +14,24 @@ import (
 func TestMailMakeCommand(t *testing.T) {
 	modelMakeCommand := &MailMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the mail name", mock.Anything).Return("", errors.New("the mail name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the mail name cannot be empty").Once()
 	assert.NoError(t, modelMakeCommand.Handle(mockContext))
 	assert.False(t, file.Exists("app/mails/new_user.go"))
 
-	mockContext.EXPECT().Argument(0).Return("NewUser").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"NewUser"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Mail created successfully").Once()
 	assert.NoError(t, modelMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/mails/new_user.go"))
 
-	mockContext.EXPECT().Argument(0).Return("NewUser").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"NewUser"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the mail already exists. Use the --force or -f flag to overwrite").Once()
 	assert.NoError(t, modelMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("User/VerifyEmail").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"User/VerifyEmail"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Mail created successfully").Once()
 	assert.NoError(t, modelMakeCommand.Handle(mockContext))
@@ -39,5 +39,19 @@ func TestMailMakeCommand(t *testing.T) {
 	assert.True(t, file.Contain("app/mails/User/verify_email.go", "package User"))
 	assert.True(t, file.Contain("app/mails/User/verify_email.go", "type VerifyEmail struct"))
 
+	assert.Nil(t, file.Remove("app"))
+}
+
+func TestMailMakeCommand_MultipleNames(t *testing.T) {
+	mailMakeCommand := &MailMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+
+	mockContext.EXPECT().Arguments().Return([]string{"VerifyEmail", "ResetPassword"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Mail created successfully").Times(2)
+	assert.NoError(t, mailMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/mails/verify_email.go"))
+	assert.True(t, file.Exists("app/mails/reset_password.go"))
 	assert.Nil(t, file.Remove("app"))
 }

--- a/notification/console/make_command.go
+++ b/notification/console/make_command.go
@@ -42,15 +42,23 @@ func (r *NotificationMakeCommand) Extend() command.Extend {
 }
 
 func (r *NotificationMakeCommand) Handle(ctx console.Context) error {
-	m, err := supportconsole.NewMake(ctx, "notification", ctx.Argument(0), support.Config.Paths.Notifications)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *NotificationMakeCommand) makeOne(ctx console.Context, name string) error {
+	m, err := supportconsole.NewMake(ctx, "notification", name, support.Config.Paths.Notifications)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(m.GetFilePath(), r.populateStub(r.getStub(ctx), m.GetPackageName(), m.GetStructName())); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Notification created successfully")

--- a/notification/console/make_command_test.go
+++ b/notification/console/make_command_test.go
@@ -15,13 +15,13 @@ import (
 func TestNotificationMakeCommand(t *testing.T) {
 	notificationMakeCommand := &NotificationMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the notification name", mock.Anything).Return("", errors.New("the notification name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the notification name cannot be empty").Once()
 	assert.NoError(t, notificationMakeCommand.Handle(mockContext))
 	assert.False(t, file.Exists("app/notifications/invoice_paid.go"))
 
-	mockContext.EXPECT().Argument(0).Return("InvoicePaid").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"InvoicePaid"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().OptionBool("database").Return(false).Once()
 	mockContext.EXPECT().Success("Notification created successfully").Once()
@@ -29,12 +29,12 @@ func TestNotificationMakeCommand(t *testing.T) {
 	assert.True(t, file.Exists("app/notifications/invoice_paid.go"))
 	assert.True(t, file.Contain("app/notifications/invoice_paid.go", "func (r *InvoicePaid) ToMail"))
 
-	mockContext.EXPECT().Argument(0).Return("InvoicePaid").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"InvoicePaid"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Error("the notification already exists. Use the --force or -f flag to overwrite").Once()
 	assert.NoError(t, notificationMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("Billing/InvoicePaid").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"Billing/InvoicePaid"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().OptionBool("database").Return(false).Once()
 	mockContext.EXPECT().Success("Notification created successfully").Once()
@@ -49,7 +49,7 @@ func TestNotificationMakeCommand(t *testing.T) {
 func TestNotificationMakeCommand_DatabaseFlag_GeneratesDatabaseTemplate(t *testing.T) {
 	notificationMakeCommand := &NotificationMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("InvoicePaid").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"InvoicePaid"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().OptionBool("database").Return(true).Once()
 	mockContext.EXPECT().Success("Notification created successfully").Once()
@@ -72,4 +72,19 @@ func TestNotificationMakeCommand_Metadata(t *testing.T) {
 	assert.Len(t, extend.Flags, 2)
 	assert.Equal(t, "force", extend.Flags[0].(*command.BoolFlag).Name)
 	assert.Equal(t, "database", extend.Flags[1].(*command.BoolFlag).Name)
+}
+
+func TestNotificationMakeCommand_MultipleNames(t *testing.T) {
+	notificationMakeCommand := &NotificationMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+
+	mockContext.EXPECT().Arguments().Return([]string{"InvoicePaid", "InvoiceRefunded"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().OptionBool("database").Return(false).Times(2)
+	mockContext.EXPECT().Success("Notification created successfully").Times(2)
+	assert.NoError(t, notificationMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/notifications/invoice_paid.go"))
+	assert.True(t, file.Exists("app/notifications/invoice_refunded.go"))
+	assert.Nil(t, file.Remove("app"))
 }

--- a/queue/console/job_make_command.go
+++ b/queue/console/job_make_command.go
@@ -46,15 +46,23 @@ func (r *JobMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *JobMakeCommand) Handle(ctx console.Context) error {
-	make, err := supportconsole.NewMake(ctx, "job", ctx.Argument(0), support.Config.Paths.Jobs)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *JobMakeCommand) makeOne(ctx console.Context, name string) error {
+	make, err := supportconsole.NewMake(ctx, "job", name, support.Config.Paths.Jobs)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(make.GetFilePath(), r.populateStub(r.getStub(), make.GetPackageName(), make.GetStructName(), make.GetSignature())); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Job created successfully")
@@ -66,8 +74,7 @@ func (r *JobMakeCommand) Handle(ctx console.Context) error {
 	}
 
 	if err != nil {
-		ctx.Error(errors.QueueJobRegisterFailed.Args(err).Error())
-		return nil
+		return errors.QueueJobRegisterFailed.Args(err)
 	}
 
 	ctx.Success("Job registered successfully")

--- a/queue/console/job_make_command_test.go
+++ b/queue/console/job_make_command_test.go
@@ -84,12 +84,12 @@ func Jobs() []queue.Job {
 func TestJobMakeCommand(t *testing.T) {
 	jobMakeCommand := &JobMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the job name", mock.Anything).Return("", errors.New("the job name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the job name cannot be empty").Once()
 	assert.NoError(t, jobMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("GoravelJob").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"GoravelJob"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Job created successfully").Once()
 	mockContext.EXPECT().Error(mock.MatchedBy(func(msg string) bool {
@@ -98,12 +98,12 @@ func TestJobMakeCommand(t *testing.T) {
 	assert.NoError(t, jobMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/jobs/goravel_job.go"))
 
-	mockContext.On("Argument", 0).Return("GoravelJob").Once()
+	mockContext.On("Arguments").Return([]string{"GoravelJob"}).Once()
 	mockContext.On("OptionBool", "force").Return(false).Once()
 	mockContext.EXPECT().Error("the job already exists. Use the --force or -f flag to overwrite").Once()
 	assert.NoError(t, jobMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("Goravel/Job").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"Goravel/Job"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Job created successfully").Once()
 	mockContext.EXPECT().Success("Job registered successfully").Once()
@@ -173,7 +173,7 @@ func TestJobMakeCommand_WithBootstrapSetup(t *testing.T) {
 			// Setup mock context
 			jobMakeCommand := &JobMakeCommand{}
 			mockContext := mocksconsole.NewContext(t)
-			mockContext.EXPECT().Argument(0).Return(tt.jobName).Once()
+			mockContext.EXPECT().Arguments().Return([]string{tt.jobName}).Once()
 			mockContext.EXPECT().OptionBool("force").Return(false).Once()
 			mockContext.EXPECT().Success("Job created successfully").Once()
 
@@ -251,7 +251,7 @@ func TestJobMakeCommand_WithNonBootstrapSetup(t *testing.T) {
 			// Setup mock context
 			jobMakeCommand := &JobMakeCommand{}
 			mockContext := mocksconsole.NewContext(t)
-			mockContext.EXPECT().Argument(0).Return(tt.jobName).Once()
+			mockContext.EXPECT().Arguments().Return([]string{tt.jobName}).Once()
 			mockContext.EXPECT().OptionBool("force").Return(false).Once()
 			mockContext.EXPECT().Success("Job created successfully").Once()
 
@@ -310,7 +310,7 @@ func TestJobMakeCommand_RegistrationError(t *testing.T) {
 		// Setup mock context
 		jobMakeCommand := &JobMakeCommand{}
 		mockContext := mocksconsole.NewContext(t)
-		mockContext.EXPECT().Argument(0).Return("FailJob").Once()
+		mockContext.EXPECT().Arguments().Return([]string{"FailJob"}).Once()
 		mockContext.EXPECT().OptionBool("force").Return(false).Once()
 		mockContext.EXPECT().Success("Job created successfully").Once()
 		mockContext.EXPECT().Error(mock.MatchedBy(func(msg string) bool {
@@ -335,7 +335,7 @@ func TestJobMakeCommand_RegistrationError(t *testing.T) {
 		// Setup mock context
 		jobMakeCommand := &JobMakeCommand{}
 		mockContext := mocksconsole.NewContext(t)
-		mockContext.EXPECT().Argument(0).Return("ErrorJob").Once()
+		mockContext.EXPECT().Arguments().Return([]string{"ErrorJob"}).Once()
 		mockContext.EXPECT().OptionBool("force").Return(false).Once()
 		mockContext.EXPECT().Success("Job created successfully").Once()
 		mockContext.EXPECT().Error(mock.MatchedBy(func(msg string) bool {
@@ -345,4 +345,23 @@ func TestJobMakeCommand_RegistrationError(t *testing.T) {
 		// Execute command
 		assert.NoError(t, jobMakeCommand.Handle(mockContext))
 	})
+}
+
+func TestJobMakeCommand_MultipleNames(t *testing.T) {
+	jobMakeCommand := &JobMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+	defer func() {
+		assert.NoError(t, file.Remove("app"))
+	}()
+
+	assert.NoError(t, file.PutContent("app/providers/queue_service_provider.go", queueServiceProvider))
+
+	mockContext.EXPECT().Arguments().Return([]string{"SendEmail", "ProcessImage"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Job created successfully").Times(2)
+	mockContext.EXPECT().Success("Job registered successfully").Times(2)
+	assert.NoError(t, jobMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/jobs/send_email.go"))
+	assert.True(t, file.Exists("app/jobs/process_image.go"))
 }

--- a/validation/console/filter_make_command.go
+++ b/validation/console/filter_make_command.go
@@ -46,15 +46,23 @@ func (r *FilterMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *FilterMakeCommand) Handle(ctx console.Context) error {
-	m, err := supportconsole.NewMake(ctx, "filter", ctx.Argument(0), support.Config.Paths.Filters)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *FilterMakeCommand) makeOne(ctx console.Context, name string) error {
+	m, err := supportconsole.NewMake(ctx, "filter", name, support.Config.Paths.Filters)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(m.GetFilePath(), r.populateStub(r.getStub(), m.GetPackageName(), m.GetStructName(), m.GetSignature())); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Filter created successfully")
@@ -66,8 +74,7 @@ func (r *FilterMakeCommand) Handle(ctx console.Context) error {
 	}
 
 	if err != nil {
-		ctx.Error(errors.ValidationFilterRegisterFailed.Args(err).Error())
-		return nil
+		return errors.ValidationFilterRegisterFailed.Args(err)
 	}
 
 	ctx.Success("Filter registered successfully")

--- a/validation/console/filter_make_command_test.go
+++ b/validation/console/filter_make_command_test.go
@@ -93,12 +93,12 @@ func Filters() []validation.Filter {
 func TestFilterMakeCommand(t *testing.T) {
 	filterMakeCommand := &FilterMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the filter name", mock.Anything).Return("", errors.New("the filter name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the filter name cannot be empty").Once()
 	assert.NoError(t, filterMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("Uppercase").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"Uppercase"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Filter created successfully").Once()
 	mockContext.EXPECT().Error(mock.MatchedBy(func(msg string) bool {
@@ -107,12 +107,12 @@ func TestFilterMakeCommand(t *testing.T) {
 	assert.NoError(t, filterMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/filters/uppercase.go"))
 
-	mockContext.On("Argument", 0).Return("Uppercase").Once()
+	mockContext.On("Arguments").Return([]string{"Uppercase"}).Once()
 	mockContext.On("OptionBool", "force").Return(false).Once()
 	mockContext.EXPECT().Error("the filter already exists. Use the --force or -f flag to overwrite").Once()
 	assert.NoError(t, filterMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("User/Phone").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"User/Phone"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Filter created successfully").Once()
 	mockContext.EXPECT().Success("Filter registered successfully").Once()
@@ -182,7 +182,7 @@ func TestFilterMakeCommand_WithBootstrapSetup(t *testing.T) {
 			// Setup mock context
 			filterMakeCommand := &FilterMakeCommand{}
 			mockContext := mocksconsole.NewContext(t)
-			mockContext.EXPECT().Argument(0).Return(tt.filterName).Once()
+			mockContext.EXPECT().Arguments().Return([]string{tt.filterName}).Once()
 			mockContext.EXPECT().OptionBool("force").Return(false).Once()
 			mockContext.EXPECT().Success("Filter created successfully").Once()
 
@@ -260,7 +260,7 @@ func TestFilterMakeCommand_WithNonBootstrapSetup(t *testing.T) {
 			// Setup mock context
 			filterMakeCommand := &FilterMakeCommand{}
 			mockContext := mocksconsole.NewContext(t)
-			mockContext.EXPECT().Argument(0).Return(tt.filterName).Once()
+			mockContext.EXPECT().Arguments().Return([]string{tt.filterName}).Once()
 			mockContext.EXPECT().OptionBool("force").Return(false).Once()
 			mockContext.EXPECT().Success("Filter created successfully").Once()
 
@@ -319,7 +319,7 @@ func TestFilterMakeCommand_RegistrationError(t *testing.T) {
 		// Setup mock context
 		filterMakeCommand := &FilterMakeCommand{}
 		mockContext := mocksconsole.NewContext(t)
-		mockContext.EXPECT().Argument(0).Return("FailFilter").Once()
+		mockContext.EXPECT().Arguments().Return([]string{"FailFilter"}).Once()
 		mockContext.EXPECT().OptionBool("force").Return(false).Once()
 		mockContext.EXPECT().Success("Filter created successfully").Once()
 		mockContext.EXPECT().Error(mock.MatchedBy(func(msg string) bool {
@@ -344,7 +344,7 @@ func TestFilterMakeCommand_RegistrationError(t *testing.T) {
 		// Setup mock context
 		filterMakeCommand := &FilterMakeCommand{}
 		mockContext := mocksconsole.NewContext(t)
-		mockContext.EXPECT().Argument(0).Return("ErrorFilter").Once()
+		mockContext.EXPECT().Arguments().Return([]string{"ErrorFilter"}).Once()
 		mockContext.EXPECT().OptionBool("force").Return(false).Once()
 		mockContext.EXPECT().Success("Filter created successfully").Once()
 		mockContext.EXPECT().Error(mock.MatchedBy(func(msg string) bool {
@@ -354,4 +354,23 @@ func TestFilterMakeCommand_RegistrationError(t *testing.T) {
 		// Execute command
 		assert.NoError(t, filterMakeCommand.Handle(mockContext))
 	})
+}
+
+func TestFilterMakeCommand_MultipleNames(t *testing.T) {
+	filterMakeCommand := &FilterMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+	defer func() {
+		assert.NoError(t, file.Remove("app"))
+	}()
+
+	assert.NoError(t, file.PutContent("app/providers/validation_service_provider.go", filterValidationServiceProvider))
+
+	mockContext.EXPECT().Arguments().Return([]string{"Uppercase", "Lowercase"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Filter created successfully").Times(2)
+	mockContext.EXPECT().Success("Filter registered successfully").Times(2)
+	assert.NoError(t, filterMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/filters/uppercase.go"))
+	assert.True(t, file.Exists("app/filters/lowercase.go"))
 }

--- a/validation/console/rule_make_command.go
+++ b/validation/console/rule_make_command.go
@@ -46,15 +46,23 @@ func (r *RuleMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *RuleMakeCommand) Handle(ctx console.Context) error {
-	make, err := supportconsole.NewMake(ctx, "rule", ctx.Argument(0), support.Config.Paths.Rules)
+	for _, name := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, name); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *RuleMakeCommand) makeOne(ctx console.Context, name string) error {
+	make, err := supportconsole.NewMake(ctx, "rule", name, support.Config.Paths.Rules)
 	if err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	if err := file.PutContent(make.GetFilePath(), r.populateStub(r.getStub(), make.GetPackageName(), make.GetStructName(), make.GetSignature())); err != nil {
-		ctx.Error(err.Error())
-		return nil
+		return err
 	}
 
 	ctx.Success("Rule created successfully")
@@ -66,8 +74,7 @@ func (r *RuleMakeCommand) Handle(ctx console.Context) error {
 	}
 
 	if err != nil {
-		ctx.Error(errors.ValidationRuleRegisterFailed.Args(err).Error())
-		return nil
+		return errors.ValidationRuleRegisterFailed.Args(err)
 	}
 
 	ctx.Success("Rule registered successfully")

--- a/validation/console/rule_make_command_test.go
+++ b/validation/console/rule_make_command_test.go
@@ -86,12 +86,12 @@ func Rules() []validation.Rule {
 func TestRuleMakeCommand(t *testing.T) {
 	ruleMakeCommand := &RuleMakeCommand{}
 	mockContext := mocksconsole.NewContext(t)
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Ask("Enter the rule name", mock.Anything).Return("", errors.New("the rule name cannot be empty")).Once()
 	mockContext.EXPECT().Error("the rule name cannot be empty").Once()
 	assert.NoError(t, ruleMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("Uppercase").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"Uppercase"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Rule created successfully").Once()
 	mockContext.EXPECT().Error(mock.MatchedBy(func(msg string) bool {
@@ -100,12 +100,12 @@ func TestRuleMakeCommand(t *testing.T) {
 	assert.NoError(t, ruleMakeCommand.Handle(mockContext))
 	assert.True(t, file.Exists("app/rules/uppercase.go"))
 
-	mockContext.On("Argument", 0).Return("Uppercase").Once()
+	mockContext.On("Arguments").Return([]string{"Uppercase"}).Once()
 	mockContext.On("OptionBool", "force").Return(false).Once()
 	mockContext.EXPECT().Error("the rule already exists. Use the --force or -f flag to overwrite").Once()
 	assert.NoError(t, ruleMakeCommand.Handle(mockContext))
 
-	mockContext.EXPECT().Argument(0).Return("User/Phone").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"User/Phone"}).Once()
 	mockContext.EXPECT().OptionBool("force").Return(false).Once()
 	mockContext.EXPECT().Success("Rule created successfully").Once()
 	mockContext.EXPECT().Success("Rule registered successfully").Once()
@@ -175,7 +175,7 @@ func TestRuleMakeCommand_WithBootstrapSetup(t *testing.T) {
 			// Setup mock context
 			ruleMakeCommand := &RuleMakeCommand{}
 			mockContext := mocksconsole.NewContext(t)
-			mockContext.EXPECT().Argument(0).Return(tt.ruleName).Once()
+			mockContext.EXPECT().Arguments().Return([]string{tt.ruleName}).Once()
 			mockContext.EXPECT().OptionBool("force").Return(false).Once()
 			mockContext.EXPECT().Success("Rule created successfully").Once()
 
@@ -253,7 +253,7 @@ func TestRuleMakeCommand_WithNonBootstrapSetup(t *testing.T) {
 			// Setup mock context
 			ruleMakeCommand := &RuleMakeCommand{}
 			mockContext := mocksconsole.NewContext(t)
-			mockContext.EXPECT().Argument(0).Return(tt.ruleName).Once()
+			mockContext.EXPECT().Arguments().Return([]string{tt.ruleName}).Once()
 			mockContext.EXPECT().OptionBool("force").Return(false).Once()
 			mockContext.EXPECT().Success("Rule created successfully").Once()
 
@@ -312,7 +312,7 @@ func TestRuleMakeCommand_RegistrationError(t *testing.T) {
 		// Setup mock context
 		ruleMakeCommand := &RuleMakeCommand{}
 		mockContext := mocksconsole.NewContext(t)
-		mockContext.EXPECT().Argument(0).Return("FailRule").Once()
+		mockContext.EXPECT().Arguments().Return([]string{"FailRule"}).Once()
 		mockContext.EXPECT().OptionBool("force").Return(false).Once()
 		mockContext.EXPECT().Success("Rule created successfully").Once()
 		mockContext.EXPECT().Error(mock.MatchedBy(func(msg string) bool {
@@ -337,7 +337,7 @@ func TestRuleMakeCommand_RegistrationError(t *testing.T) {
 		// Setup mock context
 		ruleMakeCommand := &RuleMakeCommand{}
 		mockContext := mocksconsole.NewContext(t)
-		mockContext.EXPECT().Argument(0).Return("ErrorRule").Once()
+		mockContext.EXPECT().Arguments().Return([]string{"ErrorRule"}).Once()
 		mockContext.EXPECT().OptionBool("force").Return(false).Once()
 		mockContext.EXPECT().Success("Rule created successfully").Once()
 		mockContext.EXPECT().Error(mock.MatchedBy(func(msg string) bool {
@@ -347,4 +347,23 @@ func TestRuleMakeCommand_RegistrationError(t *testing.T) {
 		// Execute command
 		assert.NoError(t, ruleMakeCommand.Handle(mockContext))
 	})
+}
+
+func TestRuleMakeCommand_MultipleNames(t *testing.T) {
+	ruleMakeCommand := &RuleMakeCommand{}
+	mockContext := mocksconsole.NewContext(t)
+	defer func() {
+		assert.NoError(t, file.Remove("app"))
+	}()
+
+	assert.NoError(t, file.PutContent("app/providers/validation_service_provider.go", ruleValidationServiceProvider))
+
+	mockContext.EXPECT().Arguments().Return([]string{"Uppercase", "Lowercase"}).Once()
+	mockContext.EXPECT().OptionBool("force").Return(false).Times(2)
+	mockContext.EXPECT().Success("Rule created successfully").Times(2)
+	mockContext.EXPECT().Success("Rule registered successfully").Times(2)
+	assert.NoError(t, ruleMakeCommand.Handle(mockContext))
+
+	assert.True(t, file.Exists("app/rules/uppercase.go"))
+	assert.True(t, file.Exists("app/rules/lowercase.go"))
 }

--- a/view/console/view_make_command.go
+++ b/view/console/view_make_command.go
@@ -7,6 +7,7 @@ import (
 	"github.com/goravel/framework/contracts/console"
 	"github.com/goravel/framework/contracts/console/command"
 	"github.com/goravel/framework/errors"
+	supportconsole "github.com/goravel/framework/support/console"
 	"github.com/goravel/framework/support/file"
 	"github.com/goravel/framework/support/path"
 )
@@ -51,10 +52,18 @@ func (r *ViewMakeCommand) Extend() command.Extend {
 
 // Handle Execute the console command.
 func (r *ViewMakeCommand) Handle(ctx console.Context) error {
-	viewName := ctx.Argument(0)
+	for _, viewName := range supportconsole.MakeNames(ctx) {
+		if err := r.makeOne(ctx, viewName); err != nil {
+			ctx.Error(err.Error())
+		}
+	}
+
+	return nil
+}
+
+func (r *ViewMakeCommand) makeOne(ctx console.Context, viewName string) error {
 	if viewName == "" {
-		ctx.Error(errors.ConsoleEmptyFieldValue.Args("view name").Error())
-		return nil
+		return errors.ConsoleEmptyFieldValue.Args("view name")
 	}
 
 	// Get the view extension from configuration
@@ -69,8 +78,7 @@ func (r *ViewMakeCommand) Handle(ctx console.Context) error {
 
 	// Check if file already exists
 	if file.Exists(filePath) && !ctx.OptionBool("force") {
-		ctx.Error(errors.ConsoleFileAlreadyExists.Args(filePath).Error())
-		return nil
+		return errors.ConsoleFileAlreadyExists.Args(filePath)
 	}
 
 	// Create the view file

--- a/view/console/view_make_command_test.go
+++ b/view/console/view_make_command_test.go
@@ -48,7 +48,7 @@ func (s *ViewMakeCommandTestSuite) TestEmptyName() {
 	viewMakeCommand := &ViewMakeCommand{}
 	mockContext := mocksconsole.NewContext(s.T())
 
-	mockContext.EXPECT().Argument(0).Return("").Once()
+	mockContext.EXPECT().Arguments().Return([]string{""}).Once()
 	mockContext.EXPECT().Error("the view name name cannot be empty").Once()
 	s.Nil(viewMakeCommand.Handle(mockContext))
 }
@@ -57,7 +57,7 @@ func (s *ViewMakeCommandTestSuite) TestCreateSuccess() {
 	viewMakeCommand := &ViewMakeCommand{}
 	mockContext := mocksconsole.NewContext(s.T())
 
-	mockContext.EXPECT().Argument(0).Return("welcome").Once()
+	mockContext.EXPECT().Arguments().Return([]string{"welcome"}).Once()
 
 	expectedPath := filepath.Join("resources", "views", "welcome.tmpl")
 	mockContext.EXPECT().Success("View created successfully").Once()
@@ -112,4 +112,17 @@ func (s *ViewMakeCommandTestSuite) TestPopulateStub() {
 			s.Equal(tt.expectedResult, result)
 		})
 	}
+}
+
+func (s *ViewMakeCommandTestSuite) TestMultipleNames() {
+	viewMakeCommand := &ViewMakeCommand{}
+	mockContext := mocksconsole.NewContext(s.T())
+
+	mockContext.EXPECT().Arguments().Return([]string{"welcome", "dashboard"}).Once()
+	mockContext.EXPECT().Success("View created successfully").Times(2)
+
+	s.Nil(viewMakeCommand.Handle(mockContext))
+	s.True(file.Exists(filepath.Join("resources", "views", "welcome.tmpl")))
+	s.True(file.Exists(filepath.Join("resources", "views", "dashboard.tmpl")))
+	s.Nil(file.Remove("resources"))
 }


### PR DESCRIPTION
## Problem

Follow-up to #1498, which converted only 4 of the 24 `make:*` commands. Maintainer asked to "cover other commands to implement this feature in this PR or another" — this is the other PR. Closes goravel/goravel#880.

## Approach

Applies the exact pattern merged in #1498 to the remaining 20 commands (agent, tool, policy, channel, factory, model, observer, seeder, migration, event, listener, package, provider, test, mail, notification, job, filter, rule, view):

- `Handle` loops over `supportconsole.MakeNames(ctx)` and calls a new `makeOne(ctx, name)`.
- Per-name failures are reported via `ctx.Error` and the loop continues.
- `make:package` / `make:view` keep their internal empty-name prompt/check inside `makeOne`.
- Single-name and no-arg interactive behavior unchanged. No contract changes, no mock regeneration needed.

## Testing

- `go build ./...` clean
- `go test` on all 16 touched packages — 590 passed
- Each command gained a `*_MultipleNames` test asserting multiple files are generated; `make:model` also covers partial failure.